### PR TITLE
feat(configs): update model parameters and metadata schema

### DIFF
--- a/models/adolecent_slob/data/generated/calibration_log.txt
+++ b/models/adolecent_slob/data/generated/calibration_log.txt
@@ -1,6 +1,6 @@
 Single Model Name: adolecent_slob
-Single Model Timestamp: 20260216_190525
-Data Generation Timestamp: 20260216_191420
-Data Fetch Timestamp: 20260216_185514
+Single Model Timestamp: 20260218_134852
+Data Generation Timestamp: 20260218_135633
+Data Fetch Timestamp: 20260218_134025
 Deployment Status: shadow
 

--- a/models/adolecent_slob/data/raw/calibration_data_fetch_log.txt
+++ b/models/adolecent_slob/data/raw/calibration_data_fetch_log.txt
@@ -1,3 +1,3 @@
 Single Model Name: adolecent_slob
-Data Fetch Timestamp: 20260217_081423
+Data Fetch Timestamp: 20260218_134025
 

--- a/models/bouncy_organ/data/generated/calibration_log.txt
+++ b/models/bouncy_organ/data/generated/calibration_log.txt
@@ -1,6 +1,6 @@
 Single Model Name: bouncy_organ
-Single Model Timestamp: 20260216_165339
-Data Generation Timestamp: 20260216_170202
-Data Fetch Timestamp: 20260216_164019
+Single Model Timestamp: 20260218_135123
+Data Generation Timestamp: 20260218_135821
+Data Fetch Timestamp: 20260218_134006
 Deployment Status: shadow
 

--- a/models/bouncy_organ/data/raw/calibration_data_fetch_log.txt
+++ b/models/bouncy_organ/data/raw/calibration_data_fetch_log.txt
@@ -1,3 +1,3 @@
 Single Model Name: bouncy_organ
-Data Fetch Timestamp: 20260217_081416
+Data Fetch Timestamp: 20260218_155102
 

--- a/models/emerging_principles/data/generated/calibration_log.txt
+++ b/models/emerging_principles/data/generated/calibration_log.txt
@@ -1,6 +1,6 @@
 Single Model Name: emerging_principles
-Single Model Timestamp: 20260217_114842
-Data Generation Timestamp: 20260217_114911
-Data Fetch Timestamp: 20260217_113943
+Single Model Timestamp: 20260218_134318
+Data Generation Timestamp: 20260218_134348
+Data Fetch Timestamp: 20260218_134010
 Deployment Status: shadow
 

--- a/models/emerging_principles/data/raw/calibration_data_fetch_log.txt
+++ b/models/emerging_principles/data/raw/calibration_data_fetch_log.txt
@@ -1,3 +1,3 @@
 Single Model Name: emerging_principles
-Data Fetch Timestamp: 20260217_113943
+Data Fetch Timestamp: 20260218_134010
 

--- a/models/fancy_feline/data/generated/calibration_log.txt
+++ b/models/fancy_feline/data/generated/calibration_log.txt
@@ -1,6 +1,6 @@
 Single Model Name: fancy_feline
-Single Model Timestamp: 20260216_172044
-Data Generation Timestamp: 20260216_172734
-Data Fetch Timestamp: 20260216_165545
+Single Model Timestamp: 20260219_131335
+Data Generation Timestamp: 20260219_132157
+Data Fetch Timestamp: 20260219_125839
 Deployment Status: shadow
 

--- a/models/fancy_feline/data/raw/calibration_data_fetch_log.txt
+++ b/models/fancy_feline/data/raw/calibration_data_fetch_log.txt
@@ -1,3 +1,3 @@
 Single Model Name: fancy_feline
-Data Fetch Timestamp: 20260217_121132
+Data Fetch Timestamp: 20260219_125839
 

--- a/models/hot_stream/data/generated/calibration_log.txt
+++ b/models/hot_stream/data/generated/calibration_log.txt
@@ -1,6 +1,6 @@
 Single Model Name: hot_stream
-Single Model Timestamp: 20260216_213329
-Data Generation Timestamp: 20260216_214105
-Data Fetch Timestamp: 20260216_214029
+Single Model Timestamp: 20260218_171218
+Data Generation Timestamp: 20260218_171915
+Data Fetch Timestamp: 20260218_142905
 Deployment Status: shadow
 

--- a/models/hot_stream/data/raw/calibration_data_fetch_log.txt
+++ b/models/hot_stream/data/raw/calibration_data_fetch_log.txt
@@ -1,3 +1,3 @@
 Single Model Name: hot_stream
-Data Fetch Timestamp: 20260216_225052
+Data Fetch Timestamp: 20260218_142905
 

--- a/models/new_rules/configs/config_hyperparameters.py
+++ b/models/new_rules/configs/config_hyperparameters.py
@@ -46,17 +46,18 @@ def get_hp_config():
         "lr_scheduler_patience": 7,
 
         # --- Scaling & transforms ---
-        "feature_scaler": "MinMaxScaler",
-        "target_scaler": "MinMaxScaler",
-        "log_targets": True,
+        "feature_scaler": None, #"MinMaxScaler",
+        "target_scaler": None, # "MinMaxScaler",
+        "log_targets": None,
         "log_features": None,
         "use_reversible_instance_norm": False, # True, # False, # darts native
         # "use_static_covariates": True, 
 
         # --- Loss & penalties ---
-        "loss_function": "WeightedPenaltyHuberLoss",
-        "delta": 0.025,
-        "zero_threshold": 0.01,
+        "loss_function": "TweedieLoss",
+        "p": 1.5,
+        "eps": 1e-6,
+        "zero_threshold": 0.05,
         "non_zero_weight": 7.0,
         "false_positive_weight": 1.0,
         "false_negative_weight": 10.0,

--- a/models/new_rules/configs/config_sweep.py
+++ b/models/new_rules/configs/config_sweep.py
@@ -28,9 +28,10 @@ def get_sweep_config():
         'batch_norm': {'values': [False]},
 
         # --- Loss Function ---
-        'loss_function': {'values': ['WeightedPenaltyHuberLoss']},
-        'zero_threshold': {'values': [0.01]},
-        'delta': {'values': [0.025]},
+        'loss_function': {'values': ['TweedieLoss']},
+        'p': {'values': [1.2, 1.5, 1.8]},
+        'eps': {'values': [1e-6]},
+        'zero_threshold': {'values': [0.05]},
         'non_zero_weight': {'values': [5.0]},
         'false_positive_weight': {'values': [1.0]},
         'false_negative_weight': {'values': [5.0]},
@@ -45,17 +46,17 @@ def get_sweep_config():
         'lr_scheduler_patience': {'values': [7]},
         'lr_scheduler_factor': {'values': [0.46]},
         'lr_scheduler_min_lr': {'values': [0.00001]},
-        'early_stopping_patience': {'values': [10]}, # 40 
+        'early_stopping_patience': {'values': [1]}, # 40 
         'early_stopping_min_delta': {'values': [0.01]},
         
         # --- Data Handling & Input/Output ---
-        'input_chunk_length': {'values': [36]},
+        'input_chunk_length': {'values': [24]},
         'output_chunk_length': {'values': [36]},
         'output_chunk_shift': {'values': [0]},
         'batch_size': {'values': [8]},
-        'target_scaler': {'values': ['MinMaxScaler']},
-        'feature_scaler': {'values': ['MinMaxScaler']},
-        'log_targets': {'values': [True]},
+        'target_scaler': {'values': [None]},
+        'feature_scaler': {'values': [None]},
+        'log_targets': {'values': [None]},
         'log_features': {'values': [None]},
         "use_reversible_instance_norm": {'values': [False]}, # darts native
         # 'use_static_covariates': {'values': [True]},
@@ -67,7 +68,7 @@ def get_sweep_config():
         # --- Other ---
         'steps': {'values': [[*range(1, 37)]]},
         'force_reset': {'values': [True]},
-        'random_state': {'values': [1, 2]},
+        'random_state': {'values': [1]},
         'n_jobs': {'values': [-1]},
     }
 

--- a/models/new_rules/data/generated/calibration_log.txt
+++ b/models/new_rules/data/generated/calibration_log.txt
@@ -1,6 +1,6 @@
 Single Model Name: new_rules
-Single Model Timestamp: 20251216_140421
-Data Generation Timestamp: 20251216_141014
-Data Fetch Timestamp: 20251216_133913
+Single Model Timestamp: 20260217_153050
+Data Generation Timestamp: 20260217_153118
+Data Fetch Timestamp: 20260217_152013
 Deployment Status: shadow
 

--- a/models/new_rules/data/raw/calibration_data_fetch_log.txt
+++ b/models/new_rules/data/raw/calibration_data_fetch_log.txt
@@ -1,3 +1,3 @@
 Single Model Name: new_rules
-Data Fetch Timestamp: 20260123_134902
+Data Fetch Timestamp: 20260217_162204
 

--- a/models/novel_heuristics/data/generated/calibration_log.txt
+++ b/models/novel_heuristics/data/generated/calibration_log.txt
@@ -1,6 +1,6 @@
 Single Model Name: novel_heuristics
-Single Model Timestamp: 20260217_121421
-Data Generation Timestamp: 20260217_121452
-Data Fetch Timestamp: 20260217_121111
+Single Model Timestamp: 20260219_130307
+Data Generation Timestamp: 20260219_130336
+Data Fetch Timestamp: 20260219_125827
 Deployment Status: shadow
 

--- a/models/novel_heuristics/data/raw/calibration_data_fetch_log.txt
+++ b/models/novel_heuristics/data/raw/calibration_data_fetch_log.txt
@@ -1,3 +1,3 @@
 Single Model Name: novel_heuristics
-Data Fetch Timestamp: 20260217_121111
+Data Fetch Timestamp: 20260219_125827
 

--- a/models/party_princess/data/generated/calibration_log.txt
+++ b/models/party_princess/data/generated/calibration_log.txt
@@ -1,6 +1,6 @@
 Single Model Name: party_princess
-Single Model Timestamp: 20260216_190952
-Data Generation Timestamp: 20260216_191804
-Data Fetch Timestamp: 20260216_185657
+Single Model Timestamp: 20260218_120624
+Data Generation Timestamp: 20260218_121308
+Data Fetch Timestamp: 20260218_115705
 Deployment Status: shadow
 

--- a/models/party_princess/data/raw/calibration_data_fetch_log.txt
+++ b/models/party_princess/data/raw/calibration_data_fetch_log.txt
@@ -1,3 +1,3 @@
 Single Model Name: party_princess
-Data Fetch Timestamp: 20260217_122259
+Data Fetch Timestamp: 20260218_115705
 

--- a/models/preliminary_directives/data/generated/calibration_log.txt
+++ b/models/preliminary_directives/data/generated/calibration_log.txt
@@ -1,6 +1,6 @@
 Single Model Name: preliminary_directives
-Single Model Timestamp: 20260216_195818
-Data Generation Timestamp: 20260216_195854
-Data Fetch Timestamp: 20260216_194326
+Single Model Timestamp: 20260217_141733
+Data Generation Timestamp: 20260217_141806
+Data Fetch Timestamp: 20260217_135133
 Deployment Status: shadow
 

--- a/models/preliminary_directives/data/raw/calibration_data_fetch_log.txt
+++ b/models/preliminary_directives/data/raw/calibration_data_fetch_log.txt
@@ -1,3 +1,3 @@
 Single Model Name: preliminary_directives
-Data Fetch Timestamp: 20260217_122308
+Data Fetch Timestamp: 20260217_135133
 

--- a/models/purple_alien/configs/config_hyperparameters.py
+++ b/models/purple_alien/configs/config_hyperparameters.py
@@ -68,15 +68,15 @@ def get_hp_config():
         # ============================================================
         'loss_reg': 'b',
         'loss_class': 'b',
-        'loss_reg_a': 16,
-        'loss_reg_c': 0.05,
+        'loss_reg_a': 258,
+        'loss_reg_c': 0.001,
         'loss_class_alpha': 0.75,
         'loss_class_gamma': 1.5,
 
         # ============================================================
         # Strategy (Curriculum ADR 011/012 Compliance)
         # ============================================================
-        'total_lessons': 20,        
+        'total_lessons': 300,        
         'max_ratio': 0.95,           
         'min_ratio': 0.05,           
         'slope_ratio': 0.75,         

--- a/models/purple_alien/configs/config_meta.py
+++ b/models/purple_alien/configs/config_meta.py
@@ -9,13 +9,14 @@ def get_meta_config():
     meta_config = {
         "name": "purple_alien",
         "algorithm": "HydraNet", 
-        "targets": ["lr_sb_best", "lr_ns_best", "lr_os_best"], #, "ln_sb_best_binarized", "ln_ns_best_binarized", "ln_os_best_binarized"], 
+        "regression_targets": ["lr_sb_best", "lr_ns_best", "lr_os_best"], #, "ln_sb_best_binarized", "ln_ns_best_binarized", "ln_os_best_binarized"], 
         # "queryset": "escwa001_cflong",
         "identity_cols" : ["priogrid_gid", "col", "row", "month_id", "c_id"],
         "index_names": ['month_id', 'priogrid_gid'],
         "features" : ["lr_sb_best", "lr_ns_best", "lr_os_best"],
         "level": "pgm",
         "creator": "Simon",
-        "metrics": ["RMSLE", "CRPS", "MSE", "MSLE", "y_hat_bar", "AP"],
+        "regression_metrics": ["RMSLE", "CRPS", "MSE", "MSLE", "y_hat_bar"],
+        "classification_metrics": ["AP"],
     }
     return meta_config 

--- a/models/purple_alien/data/generated/calibration_log.txt
+++ b/models/purple_alien/data/generated/calibration_log.txt
@@ -1,6 +1,6 @@
 Single Model Name: purple_alien
-Single Model Timestamp: 20260209_101740
-Data Generation Timestamp: 20260209_102751
-Data Fetch Timestamp: 20260209_101437
+Single Model Timestamp: 20260219_134152
+Data Generation Timestamp: 20260219_134836
+Data Fetch Timestamp: 20260219_124213
 Deployment Status: shadow
 

--- a/models/purple_alien/data/raw/calibration_data_fetch_log.txt
+++ b/models/purple_alien/data/raw/calibration_data_fetch_log.txt
@@ -1,3 +1,3 @@
 Single Model Name: purple_alien
-Data Fetch Timestamp: 20260209_101437
+Data Fetch Timestamp: 20260219_124213
 


### PR DESCRIPTION
- models/new_rules: Implement TweedieLoss and disable default scaling/transforms for experimentation.
- models/purple_alien: Adjust regression loss parameters (a=258, c=0.001), extend curriculum to 300 lessons, and update metadata schema (split regression and classification metrics).
- chore: update calibration and data fetch logs across multiple models.