### PR TITLE
fix(C-59): remove Phase 1 workarounds, fix cm N-BEATS covariates

### DIFF
--- a/models/bright_starship/configs/config_queryset.py
+++ b/models/bright_starship/configs/config_queryset.py
@@ -4,25 +4,6 @@ This replaces the viewser Queryset pattern used in other models.
 Instead of connecting to PRIO's PostgreSQL via viewser, bright_starship
 fetches from the VIEWS data factory via load_dataset().
 
-load_dataset() is a unified API that auto-detects the storage backend
-(local npy directory vs zarr store) from the path. The URL below
-points to a zarr store served over HTTP, but the function returns a
-pandas DataFrame — zarr is the storage format, DataFrame is the
-consumer interface.
-
-Data flow:
-  zarr store (HTTP) → numpy grid [T,H,W,C] → flatten + region filter
-  → DataFrame with MultiIndex (month_id, priogrid_gid)
-
-On first run, main.py calls fetch_data() which:
-  1. Calls load_dataset() — opens zarr, subsets by time + region
-  2. Renames factory column names to VIEWSER convention
-  3. Derives row/col grid coordinates from priogrid_gid
-  4. Fills NaN with 0.0 (defensive — see note below)
-  5. Saves as {run_type}_viewser_df.parquet in data/raw/
-
-Subsequent runs use the cached parquet directly — delete it to re-fetch.
-
 Prerequisites:
     pip install views-datafactory
     ~/.netrc entry for 204.168.219.108 (see README.md for setup)
@@ -30,17 +11,10 @@ Prerequisites:
 
 from __future__ import annotations
 
-import logging
-from pathlib import Path
-
-import numpy as np
-import pandas as pd
-
 from datafactory_query.defaults import DEFAULT_REMOTE
 from views_pipeline_core.managers.model import ModelPathManager
 
 model_name = ModelPathManager.get_model_name_from_path(__file__)
-logger = logging.getLogger(__name__)
 
 # Data source URL — load_dataset() detects zarr vs npy from the path.
 # Zarr over HTTP requires ~/.netrc credentials (see README.md).
@@ -60,17 +34,8 @@ FEATURE_RENAME = {
     "gaul0_code": "c_id",          # FAO GAUL country code → identity column
 }
 
-# PRIO-GRID is 720 columns wide (0.5° global grid). Used to derive row/col.
-NCOL = 720
-
-
 def generate():
-    """Data source descriptor (satisfies ModelPathManager.get_queryset() interface).
-
-    NOTE: Not used at runtime. main.py's _ensure_data() calls fetch_data()
-    directly, so the parquet exists before HydranetManager ever loads this.
-    Kept for interface compatibility with views-pipeline-core.
-    """
+    """Data source descriptor (satisfies ModelPathManager.get_queryset() interface)."""
     return {
         "name": model_name,
         "source": "views-datafactory",  # "views-datafactory" or "viewser"
@@ -79,78 +44,3 @@ def generate():
         "loa": "priogrid_month",        # "priogrid_month" or "country_month"
         "features": FEATURE_RENAME,
     }
-
-
-def fetch_data(
-    run_type: str,
-    output_dir: Path,
-    partitions: dict,
-) -> Path:
-    """Fetch data from the factory and save as VIEWSER-compatible parquet.
-
-    Called by main.py's _ensure_data() when the cached parquet is missing.
-
-    Data flow:
-        1. load_dataset() opens the zarr store over HTTP
-        2. Subsets by time range (lazy — only requested months are downloaded)
-        3. Subsets by region (africa_me_legacy = 13,110 PRIO-GRID cells)
-        4. Returns DataFrame with MultiIndex (month_id, priogrid_gid)
-        5. This function renames columns, derives row/col, fills NaN, saves
-
-    Args:
-        run_type: "calibration", "validation", or "forecasting".
-        output_dir: Directory for the parquet file (typically data/raw/).
-        partitions: Dict from config_partitions.generate() with structure
-            {run_type: {"train": (start, end), "test": (start, end)}}.
-
-    Returns:
-        Path to the saved parquet file.
-
-    Output contract:
-        - MultiIndex: (month_id, priogrid_gid)
-        - Columns: lr_sb_best, lr_ns_best, lr_os_best, c_id, row, col
-        - No NaN values (filled with 0.0)
-        - dtypes: float32 for event columns (from zarr), float64 for row/col/c_id
-    """
-    from datafactory_query import load_dataset
-
-    bounds = partitions[run_type]
-    start = bounds["train"][0]
-    end = bounds["test"][1]
-
-    logger.info(
-        "Fetching %s data from %s (months %d-%d, region=%s)",
-        run_type, ZARR_URL, start, end, REGION,
-    )
-
-    df = load_dataset(
-        region=REGION,
-        start=start,
-        end=end,
-        features=FACTORY_FEATURES,
-        output_format="dataframe",  # also: "feature_frame" (numpy + identifiers)
-        data_dir=ZARR_URL,          # auto-detects zarr vs npy from path
-    )
-
-    df = df.rename(columns=FEATURE_RENAME)
-
-    # HydraNet expects row/col but the zarr store only has priogrid_gid.
-    # PRIO-GRID definition: row = (pgid-1)//720 + 1, col = (pgid-1)%720 + 1.
-    pgids = df.index.get_level_values("priogrid_gid")
-    df["row"] = ((pgids - 1) // NCOL + 1).astype(np.float64)
-    df["col"] = ((pgids - 1) % NCOL + 1).astype(np.float64)
-
-    # Defensive: assembled grid has no NaN (events=0.0, admin=-1.0),
-    # but the VIEWSER parquet contract requires no NaN. Cheap insurance.
-    df = df.fillna(0.0)
-    df = df.sort_index()
-
-    output_dir.mkdir(parents=True, exist_ok=True)
-    out_path = output_dir / f"{run_type}_viewser_df.parquet"
-    df.to_parquet(out_path)
-
-    logger.info(
-        "Saved %s: %d rows, %.1f MB",
-        out_path, len(df), out_path.stat().st_size / 1e6,
-    )
-    return out_path

--- a/models/bright_starship/main.py
+++ b/models/bright_starship/main.py
@@ -21,34 +21,8 @@ except Exception as e:
     raise RuntimeError(f"Unexpected error: {e}. Check the logs for details.")
 
 
-def _ensure_data(run_type: str) -> None:
-    """Fetch data from Hetzner zarr store if the parquet cache is missing."""
-    raw_dir = model_path.data_raw
-    parquet = raw_dir / f"{run_type}_viewser_df.parquet"
-    if parquet.exists():
-        logger.info("Using cached %s", parquet)
-        return
-
-    logger.info("Cache miss for %s — fetching from Hetzner", run_type)
-    from configs.config_queryset import fetch_data
-    from configs.config_partitions import generate as generate_partitions
-
-    partitions = generate_partitions()
-    fetch_data(run_type, raw_dir, partitions)
-
-
 if __name__ == "__main__":
     args = ForecastingModelArgs.parse_args()
-
-    _ensure_data(args.run_type)
-
-    # Phase 1 workaround for views-pipeline-core C-51: get_data() hardcodes
-    # viewser as sole data source. bright_starship fetches from views-datafactory
-    # via _ensure_data(), so the parquet cache is already populated. Setting
-    # saved=True routes get_data() through the cache-read path (dataloaders.py:
-    # 1253-1257), bypassing _fetch_data_from_viewser() which would crash on our
-    # dict descriptor. Remove once Phase 2 lands (DataFetchStrategy dispatch).
-    args.saved = True
 
     manager = HydranetManager(model_path=model_path)
 

--- a/models/bright_starship/scripts/audit_data_parity.py
+++ b/models/bright_starship/scripts/audit_data_parity.py
@@ -173,7 +173,7 @@ def audit(factory: pd.DataFrame, viewser: pd.DataFrame) -> bool:
         # c_id is an identity column, not a training feature.
         f_consistency = f_sorted.groupby(level=1)["c_id"].nunique().max()
         v_consistency = v_sorted.groupby(level=1)["c_id"].nunique().max()
-        print(f"  Values differ (expected: different coding systems)")
+        print("  Values differ (expected: different coding systems)")
         print(f"  Factory: {f_consistency} c_id per pgid (GAUL, time-invariant)")
         print(f"  Viewser: {v_consistency} c_id per pgid (time-varying lookup)")
         print("  ACCEPTABLE — c_id is identity metadata, not a training feature")
@@ -205,10 +205,10 @@ def audit(factory: pd.DataFrame, viewser: pd.DataFrame) -> bool:
         print(f"    sum: factory={f_sum:,.1f}, viewser={v_sum:,.1f}")
 
         if pct_diff < 0.5:
-            print(f"    ACCEPTABLE — within expected UCDP annual version residual")
+            print("    ACCEPTABLE — within expected UCDP annual version residual")
             warnings.append(f"{col}: {pct_diff:.3f}% cells differ (annual version)")
         else:
-            print(f"    FAIL — exceeds 0.5% threshold")
+            print("    FAIL — exceeds 0.5% threshold")
             failures.append(f"{col}: {pct_diff:.3f}% cells differ")
 
     # ── 5. Dtype check ────────────────────────────────────────

--- a/models/emerging_principles/configs/config_meta.py
+++ b/models/emerging_principles/configs/config_meta.py
@@ -10,7 +10,7 @@ def get_meta_config():
     meta_config = {
         "name": "emerging_principles", 
         "algorithm": "NBEATSModel",
-        "regression_targets": ["lr_ged_sb_dep"],
+        "regression_targets": ["lr_ged_sb"],
         # "queryset": "escwa001_cflong",
         "level": "cm",
         "creator": "Simon",

--- a/models/emerging_principles/configs/config_queryset.py
+++ b/models/emerging_principles/configs/config_queryset.py
@@ -21,18 +21,12 @@ def generate():
         return (
             queryset.with_column(
                 Column(
-                    "lr_ged_sb_dep",
-                    from_loa="country_month",
-                    from_column="ged_sb_best_sum_nokgi",
-                ).transform.missing.fill()
-            )
-            .with_column(
-                Column(
                     "lr_ged_sb",
                     from_loa="country_month",
                     from_column="ged_sb_best_sum_nokgi",
                 ).transform.missing.fill()
             )
+           # Future covariates (uncomment to add non-state and one-sided violence):
            # .with_column(
            #     Column(
            #         "lr_ged_ns",

--- a/models/emerging_principles/configs/config_queryset.py
+++ b/models/emerging_principles/configs/config_queryset.py
@@ -26,21 +26,20 @@ def generate():
                     from_column="ged_sb_best_sum_nokgi",
                 ).transform.missing.fill()
             )
-           # Future covariates (uncomment to add non-state and one-sided violence):
-           # .with_column(
-           #     Column(
-           #         "lr_ged_ns",
-           #         from_loa="country_month",
-           #         from_column="ged_ns_best_sum_nokgi",
-           #     ).transform.missing.fill()
-           # )
-           # .with_column(
-           #     Column(
-           #         "lr_ged_os",
-           #         from_loa="country_month",
-           #         from_column="ged_os_best_sum_nokgi",
-           #     ).transform.missing.fill()
-           # )
+            .with_column(
+                Column(
+                    "lr_ged_ns",
+                    from_loa="country_month",
+                    from_column="ged_ns_best_sum_nokgi",
+                ).transform.missing.fill()
+            )
+            .with_column(
+                Column(
+                    "lr_ged_os",
+                    from_loa="country_month",
+                    from_column="ged_os_best_sum_nokgi",
+                ).transform.missing.fill()
+            )
            # .with_column(
            #     Column(
            #         "lr_acled_sb", from_loa="country_month", from_column="acled_sb_fat"

--- a/models/emerging_principles/configs/config_queryset.py
+++ b/models/emerging_principles/configs/config_queryset.py
@@ -17,7 +17,6 @@ def generate():
     # VIEWSER 6, Example configuration. Modify as needed.
 
     def _add_conflict_history(queryset: Queryset) -> Queryset:
-        print("Adding conflict history features...")
         return (
             queryset.with_column(
                 Column(

--- a/models/new_rules/configs/config_meta.py
+++ b/models/new_rules/configs/config_meta.py
@@ -10,7 +10,7 @@ def get_meta_config():
     meta_config = {
         "name": "new_rules", 
         "algorithm": "NBEATSModel",
-        "regression_targets": ["lr_ged_sb_dep"],
+        "regression_targets": ["lr_ged_sb"],
         # "queryset": "escwa001_cflong",
         "level": "cm",
         "creator": "Simon",

--- a/models/new_rules/configs/config_queryset.py
+++ b/models/new_rules/configs/config_queryset.py
@@ -21,18 +21,12 @@ def generate():
         return (
             queryset.with_column(
                 Column(
-                    "lr_ged_sb_dep",
-                    from_loa="country_month",
-                    from_column="ged_sb_best_sum_nokgi",
-                ).transform.missing.fill()
-            )
-            .with_column(
-                Column(
                     "lr_ged_sb",
                     from_loa="country_month",
                     from_column="ged_sb_best_sum_nokgi",
                 ).transform.missing.fill()
             )
+           # Future covariates (uncomment to add non-state and one-sided violence):
            # .with_column(
            #     Column(
            #         "lr_ged_ns",

--- a/models/new_rules/configs/config_queryset.py
+++ b/models/new_rules/configs/config_queryset.py
@@ -26,21 +26,20 @@ def generate():
                     from_column="ged_sb_best_sum_nokgi",
                 ).transform.missing.fill()
             )
-           # Future covariates (uncomment to add non-state and one-sided violence):
-           # .with_column(
-           #     Column(
-           #         "lr_ged_ns",
-           #         from_loa="country_month",
-           #         from_column="ged_ns_best_sum_nokgi",
-           #     ).transform.missing.fill()
-           # )
-           # .with_column(
-           #     Column(
-           #         "lr_ged_os",
-           #         from_loa="country_month",
-           #         from_column="ged_os_best_sum_nokgi",
-           #     ).transform.missing.fill()
-           # )
+            .with_column(
+                Column(
+                    "lr_ged_ns",
+                    from_loa="country_month",
+                    from_column="ged_ns_best_sum_nokgi",
+                ).transform.missing.fill()
+            )
+            .with_column(
+                Column(
+                    "lr_ged_os",
+                    from_loa="country_month",
+                    from_column="ged_os_best_sum_nokgi",
+                ).transform.missing.fill()
+            )
            # .with_column(
            #     Column(
            #         "lr_acled_sb", from_loa="country_month", from_column="acled_sb_fat"

--- a/models/new_rules/configs/config_queryset.py
+++ b/models/new_rules/configs/config_queryset.py
@@ -17,7 +17,6 @@ def generate():
     # VIEWSER 6, Example configuration. Modify as needed.
 
     def _add_conflict_history(queryset: Queryset) -> Queryset:
-        print("Adding conflict history features...")
         return (
             queryset.with_column(
                 Column(

--- a/models/novel_heuristics/configs/config_queryset.py
+++ b/models/novel_heuristics/configs/config_queryset.py
@@ -21,18 +21,12 @@ def generate():
         return (
             queryset.with_column(
                 Column(
-                    "lr_ged_sb_dep",
-                    from_loa="country_month",
-                    from_column="ged_sb_best_sum_nokgi",
-                ).transform.missing.fill()
-            )
-            .with_column(
-                Column(
                     "lr_ged_sb",
                     from_loa="country_month",
                     from_column="ged_sb_best_sum_nokgi",
                 ).transform.missing.fill()
             )
+           # Future covariates (uncomment to add non-state and one-sided violence):
            # .with_column(
            #     Column(
            #         "lr_ged_ns",

--- a/models/novel_heuristics/configs/config_queryset.py
+++ b/models/novel_heuristics/configs/config_queryset.py
@@ -26,21 +26,20 @@ def generate():
                     from_column="ged_sb_best_sum_nokgi",
                 ).transform.missing.fill()
             )
-           # Future covariates (uncomment to add non-state and one-sided violence):
-           # .with_column(
-           #     Column(
-           #         "lr_ged_ns",
-           #         from_loa="country_month",
-           #         from_column="ged_ns_best_sum_nokgi",
-           #     ).transform.missing.fill()
-           # )
-           # .with_column(
-           #     Column(
-           #         "lr_ged_os",
-           #         from_loa="country_month",
-           #         from_column="ged_os_best_sum_nokgi",
-           #     ).transform.missing.fill()
-           # )
+            .with_column(
+                Column(
+                    "lr_ged_ns",
+                    from_loa="country_month",
+                    from_column="ged_ns_best_sum_nokgi",
+                ).transform.missing.fill()
+            )
+            .with_column(
+                Column(
+                    "lr_ged_os",
+                    from_loa="country_month",
+                    from_column="ged_os_best_sum_nokgi",
+                ).transform.missing.fill()
+            )
            # .with_column(
            #     Column(
            #         "lr_acled_sb", from_loa="country_month", from_column="acled_sb_fat"

--- a/models/novel_heuristics/configs/config_queryset.py
+++ b/models/novel_heuristics/configs/config_queryset.py
@@ -17,7 +17,6 @@ def generate():
     # VIEWSER 6, Example configuration. Modify as needed.
 
     def _add_conflict_history(queryset: Queryset) -> Queryset:
-        print("Adding conflict history features...")
         return (
             queryset.with_column(
                 Column(

--- a/models/preliminary_directives/configs/config_meta.py
+++ b/models/preliminary_directives/configs/config_meta.py
@@ -10,7 +10,7 @@ def get_meta_config():
     meta_config = {
         "name": "preliminary_directives", 
         "algorithm": "NBEATSModel",
-        "regression_targets": ["lr_ged_sb_dep"],
+        "regression_targets": ["lr_ged_sb"],
         # "queryset": "escwa001_cflong",
         "level": "cm",
         "creator": "Simon",

--- a/models/preliminary_directives/configs/config_queryset.py
+++ b/models/preliminary_directives/configs/config_queryset.py
@@ -21,18 +21,12 @@ def generate():
         return (
             queryset.with_column(
                 Column(
-                    "lr_ged_sb_dep",
-                    from_loa="country_month",
-                    from_column="ged_sb_best_sum_nokgi",
-                ).transform.missing.fill()
-            )
-            .with_column(
-                Column(
                     "lr_ged_sb",
                     from_loa="country_month",
                     from_column="ged_sb_best_sum_nokgi",
                 ).transform.missing.fill()
             )
+           # Future covariates (uncomment to add non-state and one-sided violence):
            # .with_column(
            #     Column(
            #         "lr_ged_ns",

--- a/models/preliminary_directives/configs/config_queryset.py
+++ b/models/preliminary_directives/configs/config_queryset.py
@@ -26,21 +26,20 @@ def generate():
                     from_column="ged_sb_best_sum_nokgi",
                 ).transform.missing.fill()
             )
-           # Future covariates (uncomment to add non-state and one-sided violence):
-           # .with_column(
-           #     Column(
-           #         "lr_ged_ns",
-           #         from_loa="country_month",
-           #         from_column="ged_ns_best_sum_nokgi",
-           #     ).transform.missing.fill()
-           # )
-           # .with_column(
-           #     Column(
-           #         "lr_ged_os",
-           #         from_loa="country_month",
-           #         from_column="ged_os_best_sum_nokgi",
-           #     ).transform.missing.fill()
-           # )
+            .with_column(
+                Column(
+                    "lr_ged_ns",
+                    from_loa="country_month",
+                    from_column="ged_ns_best_sum_nokgi",
+                ).transform.missing.fill()
+            )
+            .with_column(
+                Column(
+                    "lr_ged_os",
+                    from_loa="country_month",
+                    from_column="ged_os_best_sum_nokgi",
+                ).transform.missing.fill()
+            )
            # .with_column(
            #     Column(
            #         "lr_acled_sb", from_loa="country_month", from_column="acled_sb_fat"

--- a/models/preliminary_directives/configs/config_queryset.py
+++ b/models/preliminary_directives/configs/config_queryset.py
@@ -17,7 +17,6 @@ def generate():
     # VIEWSER 6, Example configuration. Modify as needed.
 
     def _add_conflict_history(queryset: Queryset) -> Queryset:
-        print("Adding conflict history features...")
         return (
             queryset.with_column(
                 Column(

--- a/models/shining_codex/configs/config_queryset.py
+++ b/models/shining_codex/configs/config_queryset.py
@@ -18,12 +18,16 @@ model_name = ModelPathManager.get_model_name_from_path(__file__)
 
 ZARR_URL = DEFAULT_REMOTE.zarr_url
 
-REGION = "africa_me_legacy"
+REGION = "global"
 
 FACTORY_FEATURES = ["ged_sb_best"]
+# Future covariates (uncomment to add non-state and one-sided violence):
+# FACTORY_FEATURES = ["ged_sb_best", "ged_ns_best", "ged_os_best"]
 
 FEATURE_RENAME = {
     "ged_sb_best": "lr_ged_sb",
+    # "ged_ns_best": "lr_ged_ns",
+    # "ged_os_best": "lr_ged_os",
 }
 
 

--- a/models/shining_codex/configs/config_queryset.py
+++ b/models/shining_codex/configs/config_queryset.py
@@ -20,14 +20,12 @@ ZARR_URL = DEFAULT_REMOTE.zarr_url
 
 REGION = "global"
 
-FACTORY_FEATURES = ["ged_sb_best"]
-# Future covariates (uncomment to add non-state and one-sided violence):
-# FACTORY_FEATURES = ["ged_sb_best", "ged_ns_best", "ged_os_best"]
+FACTORY_FEATURES = ["ged_sb_best", "ged_ns_best", "ged_os_best"]
 
 FEATURE_RENAME = {
     "ged_sb_best": "lr_ged_sb",
-    # "ged_ns_best": "lr_ged_ns",
-    # "ged_os_best": "lr_ged_os",
+    "ged_ns_best": "lr_ged_ns",
+    "ged_os_best": "lr_ged_os",
 }
 
 

--- a/models/shining_codex/configs/config_queryset.py
+++ b/models/shining_codex/configs/config_queryset.py
@@ -2,22 +2,7 @@
 
 This replaces the viewser Queryset pattern used in novel_heuristics.
 Instead of connecting to PRIO's PostgreSQL via viewser, shining_codex
-fetches from the VIEWS data factory via load_dataset() with
-output_format="country_month", which sums grid-cell features per
-(month_id, country_id) using gaul0_code as the grouping key.
-
-Data flow:
-  zarr store (HTTP) → numpy grid [T,H,W,C] → flatten + region filter
-  → groupby(month_id, gaul0_code).sum()
-  → DataFrame with MultiIndex (month_id, country_id)
-
-On first run, main.py calls fetch_data() which:
-  1. Calls load_dataset(output_format="country_month")
-  2. Renames factory column names to novel_heuristics convention
-  3. Fills NaN with 0.0
-  4. Saves as {run_type}_viewser_df.parquet in data/raw/
-
-Subsequent runs use the cached parquet directly — delete it to re-fetch.
+fetches from the VIEWS data factory via load_dataset().
 
 Prerequisites:
     pip install views-datafactory
@@ -26,14 +11,10 @@ Prerequisites:
 
 from __future__ import annotations
 
-import logging
-from pathlib import Path
-
 from datafactory_query.defaults import DEFAULT_REMOTE
 from views_pipeline_core.managers.model import ModelPathManager
 
 model_name = ModelPathManager.get_model_name_from_path(__file__)
-logger = logging.getLogger(__name__)
 
 ZARR_URL = DEFAULT_REMOTE.zarr_url
 
@@ -47,12 +28,7 @@ FEATURE_RENAME = {
 
 
 def generate():
-    """Data source descriptor (satisfies ModelPathManager.get_queryset() interface).
-
-    NOTE: Not used at runtime. main.py's _ensure_data() calls fetch_data()
-    directly, so the parquet exists before DartsForecastingModelManager ever
-    loads this. Kept for interface compatibility with views-pipeline-core.
-    """
+    """Data source descriptor (satisfies ModelPathManager.get_queryset() interface)."""
     return {
         "name": model_name,
         "source": "views-datafactory",
@@ -61,63 +37,3 @@ def generate():
         "loa": "country_month",
         "features": FEATURE_RENAME,
     }
-
-
-def fetch_data(
-    run_type: str,
-    output_dir: Path,
-    partitions: dict,
-) -> Path:
-    """Fetch country-month data from the factory and save as parquet.
-
-    Called by main.py's _ensure_data() when the cached parquet is missing.
-
-    Args:
-        run_type: "calibration", "validation", or "forecasting".
-        output_dir: Directory for the parquet file (typically data/raw/).
-        partitions: Dict from config_partitions.generate().
-
-    Returns:
-        Path to the saved parquet file.
-
-    Output contract (parity with novel_heuristics):
-        - MultiIndex: (month_id, country_id)
-        - Columns: lr_ged_sb_dep (feature), lr_ged_sb (target)
-        - Both columns contain identical data (country-sum of ged_sb_best)
-        - lr_ged_sb_dep is legacy naming for "dependent variable as feature"
-        - No NaN values (filled with 0.0)
-    """
-    from datafactory_query import load_dataset
-
-    bounds = partitions[run_type]
-    start = bounds["train"][0]
-    end = bounds["test"][1]
-
-    logger.info(
-        "Fetching %s cm data from %s (months %d-%d, region=%s)",
-        run_type, ZARR_URL, start, end, REGION,
-    )
-
-    df = load_dataset(
-        region=REGION,
-        start=start,
-        end=end,
-        features=FACTORY_FEATURES,
-        output_format="country_month",
-        data_dir=ZARR_URL,
-    )
-
-    df = df.rename(columns=FEATURE_RENAME)
-    df["lr_ged_sb_dep"] = df["lr_ged_sb"]
-    df = df.fillna(0.0)
-    df = df.sort_index()
-
-    output_dir.mkdir(parents=True, exist_ok=True)
-    out_path = output_dir / f"{run_type}_viewser_df.parquet"
-    df.to_parquet(out_path)
-
-    logger.info(
-        "Saved %s: %d rows, %.1f MB",
-        out_path, len(df), out_path.stat().st_size / 1e6,
-    )
-    return out_path

--- a/models/shining_codex/main.py
+++ b/models/shining_codex/main.py
@@ -23,32 +23,8 @@ except Exception as e:
     raise RuntimeError(f"Unexpected error: {e}. Check the logs for details.")
 
 
-def _ensure_data(run_type: str) -> None:
-    """Fetch data from Hetzner zarr store if the parquet cache is missing."""
-    raw_dir = model_path.data_raw
-    parquet = raw_dir / f"{run_type}_viewser_df.parquet"
-    if parquet.exists():
-        logger.info("Using cached %s", parquet)
-        return
-
-    logger.info("Cache miss for %s — fetching from Hetzner", run_type)
-    from configs.config_queryset import fetch_data
-    from configs.config_partitions import generate as generate_partitions
-
-    partitions = generate_partitions()
-    fetch_data(run_type, raw_dir, partitions)
-
-
 if __name__ == "__main__":
     args = ForecastingModelArgs.parse_args()
-
-    _ensure_data(args.run_type)
-
-    # Phase 1 workaround for views-pipeline-core C-51: get_data() hardcodes
-    # viewser as sole data source. _ensure_data() populates the parquet cache
-    # from views-datafactory, so saved=True routes around the viewser fetch.
-    # Remove once Phase 2 lands (DataFetchStrategy dispatch).
-    args.saved = True
 
     manager = DartsForecastingModelManager(
         model_path=model_path,


### PR DESCRIPTION
## Summary

- **Remove Phase 1 datafactory workarounds** from `bright_starship` and `shining_codex`: delete `fetch_data()`, `_ensure_data()`, `args.saved=True` hack, verbose docstrings, and unused imports. Both models now use the standard pipeline path (descriptor dict from `generate()` → core dispatch via `get_data()`).
- **Replace fake autoregressive feature** in all 4 viewser cm N-BEATS models (`novel_heuristics`, `new_rules`, `emerging_principles`, `preliminary_directives`): remove `lr_ged_sb_dep` (a duplicate of the target used as its own covariate) and replace with real covariates `lr_ged_ns` and `lr_ged_os`. Fix `regression_targets` from `["lr_ged_sb_dep"]` to `["lr_ged_sb"]` in 3 models.
- **Fix `shining_codex` region** from `"africa_me_legacy"` → `"global"` (cm models need global country coverage) and add `ged_ns_best`/`ged_os_best` features for parity with viewser models.

Net change: −320 / +50 lines across 11 files (almost entirely dead code removal).

## Dependencies

- `views-pipeline-core` ≥2.3.0 (`fix/C-59-cached-data-path-coupling`, PR #70)
- `views-r2darts2` C-66 fix (commit `679746c`): `DartsForecaster` auto-disables `feature_scaler` when `features=[]`

## What to verify

- [ ] `bright_starship` — no behavioral change, only dead code removal. `generate()` descriptor dict unchanged.
- [ ] `shining_codex` region `"global"` — cached parquets in `data/raw/` must be deleted before re-running (data shape changed).
- [ ] All 5 cm N-BEATS models have `regression_targets: ["lr_ged_sb"]` and covariates `lr_ged_ns` + `lr_ged_os`.
- [ ] 4 viewser `config_queryset.py` files are identical.
- [ ] No stale references to `fetch_data`, `_ensure_data`, `args.saved`, or `lr_ged_sb_dep` in source files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)