### PR TITLE
fix: correct heavy_freighter row/col offset for datafactory grid

### DIFF
--- a/models/heavy_freighter/configs/config_hyperparameters.py
+++ b/models/heavy_freighter/configs/config_hyperparameters.py
@@ -23,8 +23,8 @@ def get_hp_config():
         "index_names": ['month_id', 'priogrid_gid'],
         'features': ['lr_sb_best', 'lr_ns_best', 'lr_os_best'],
         'input_channels': 3, # Checksum: Must match len(features)
-        'row_offset': 0,
-        'col_offset': 0,
+        'row_offset': 1,
+        'col_offset': 1,
         'height': 360,
         'width': 720,
 


### PR DESCRIPTION
## Summary

- `row_offset` and `col_offset` changed from `0` → `1` in heavy_freighter's hyperparameter config
- Pipeline-core computes 1-indexed row/col from pgids (`(pgid-1)//720 + 1`), so the offset must be 1 for `r_idx = row - offset` to yield 0-based array indices

## Context

heavy_freighter is the first model using views-datafactory directly (via `region=land`). The offset was incorrectly set to 0, causing `IndexError` in VisualDiagnostics and `ValueError` in DataSniffer's anchor alignment check.

Companion PR in views-hydranet relaxes the sniffer to accept sparse regions where `df['row'].min() > row_offset`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)