### PR TITLE
docs: annotate heavy_freighter grid offset

### DIFF
--- a/models/heavy_freighter/configs/config_hyperparameters.py
+++ b/models/heavy_freighter/configs/config_hyperparameters.py
@@ -24,7 +24,7 @@ def get_hp_config():
         'features': ['lr_sb_best', 'lr_ns_best', 'lr_os_best'],
         'input_channels': 3, # Checksum: Must match len(features)
         'row_offset': 1,
-        'col_offset': 1,
+        'col_offset': 1, # Global grid: 1-indexed priogrid → 0-based array
         'height': 360,
         'width': 720,
 


### PR DESCRIPTION
## Summary
- Adds inline comment explaining why `row_offset`/`col_offset` are 1 (global grid uses 1-indexed priogrid coordinates, offset maps to 0-based array indices)
- Addresses review suggestion from PR #51 — the offset values differ from other models (87/310) because heavy_freighter covers the full 360x720 grid

## Test plan
- [x] All 3514 tests pass
- [x] Ruff clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)