### PR TITLE
fix: set explicit num_layers for adolecent_slob TCN model

### DIFF
--- a/models/adolecent_slob/configs/config_hyperparameters.py
+++ b/models/adolecent_slob/configs/config_hyperparameters.py
@@ -23,7 +23,7 @@ def get_hp_config():
         'num_filters': 64,
         'dilation_base': 3,
         'weight_norm': False,
-        'num_layers': None,
+        'num_layers': 3,
 
         # --- Regularization ---
         'dropout': 0.3,


### PR DESCRIPTION
## Summary
- `adolecent_slob` had `num_layers: None`, letting Darts auto-compute the value — a reproducibility risk
- The ReproducibilityGate (added to TCN genome in views-r2darts2 `71e6961`, Mar 13) correctly rejects this as an implicit default
- Set `num_layers: 3`, the value Darts derives from `input_chunk_length=48`, `kernel_size=5`, `dilation_base=3` — identical behavior, explicitly declared

## Test plan
- [x] Full test suite passes (3942 passed, 327 skipped)
- [ ] Re-run integration test on GPU machine: `bash run_integration_tests.sh --library r2darts2`

🤖 Generated with [Claude Code](https://claude.com/claude-code)