### PR TITLE
test: PFE production readiness TDD tests and C-52 risk

### DIFF
--- a/models/black_ranger/configs/config_hyperparameters.py
+++ b/models/black_ranger/configs/config_hyperparameters.py
@@ -14,5 +14,7 @@ def get_hp_config():
         'window_months': 18,
         'lambda_mix': 0.05,
         'n_samples': 256,
+        'n_posterior_samples': 256,
+        'regression_targets': ['lr_os_best'],
     }
     return hyperparameters

--- a/models/blue_ranger/configs/config_hyperparameters.py
+++ b/models/blue_ranger/configs/config_hyperparameters.py
@@ -14,5 +14,7 @@ def get_hp_config():
         'window_months': 18,
         'lambda_mix': 0.05,
         'n_samples': 256,
+        'n_posterior_samples': 256,
+        'regression_targets': ['lr_ged_sb'],
     }
     return hyperparameters

--- a/models/green_ranger/configs/config_hyperparameters.py
+++ b/models/green_ranger/configs/config_hyperparameters.py
@@ -14,5 +14,7 @@ def get_hp_config():
         'window_months': 18,
         'lambda_mix': 0.05,
         'n_samples': 256,
+        'n_posterior_samples': 256,
+        'regression_targets': ['lr_ns_best'],
     }
     return hyperparameters

--- a/models/heavy_strider/configs/config_hyperparameters.py
+++ b/models/heavy_strider/configs/config_hyperparameters.py
@@ -13,6 +13,7 @@ def get_hp_config():
         "time_steps": 36,
         "window_months": 36,
         "n_samples": 64,
+        "n_posterior_samples": 64,
         "seed": 42,
     }
 

--- a/models/light_strider/configs/config_hyperparameters.py
+++ b/models/light_strider/configs/config_hyperparameters.py
@@ -13,6 +13,7 @@ def get_hp_config():
         "time_steps": 36,
         "window_months": 36,
         "n_samples": 64,
+        "n_posterior_samples": 64,
         "seed": 42,
     }
 

--- a/models/lucid_dream/configs/config_hyperparameters.py
+++ b/models/lucid_dream/configs/config_hyperparameters.py
@@ -4,5 +4,7 @@ def get_hp_config():
         'time_steps': 36,
         'window_months': 18,
         'n_samples': 64,
+        'n_posterior_samples': 64,
+        'regression_targets': ['synth_target'],
     }
     return hyperparameters

--- a/models/pink_ranger/configs/config_hyperparameters.py
+++ b/models/pink_ranger/configs/config_hyperparameters.py
@@ -14,5 +14,7 @@ def get_hp_config():
         'window_months': 18,
         'lambda_mix': 0.05,
         'n_samples': 256,
+        'n_posterior_samples': 256,
+        'regression_targets': ['lr_ns_best'],
     }
     return hyperparameters

--- a/models/red_ranger/configs/config_hyperparameters.py
+++ b/models/red_ranger/configs/config_hyperparameters.py
@@ -14,5 +14,7 @@ def get_hp_config():
         'window_months': 18,
         'lambda_mix': 0.05,
         'n_samples': 256,
+        'n_posterior_samples': 256,
+        'regression_targets': ['lr_ged_sb'],
     }
     return hyperparameters

--- a/models/vivid_dream/configs/config_hyperparameters.py
+++ b/models/vivid_dream/configs/config_hyperparameters.py
@@ -5,5 +5,7 @@ def get_hp_config():
         'window_months': 18,
         'lambda_mix': 0.05,
         'n_samples': 64,
+        'n_posterior_samples': 64,
+        'regression_targets': ['synth_target'],
     }
     return hyperparameters

--- a/models/waking_dream/configs/config_hyperparameters.py
+++ b/models/waking_dream/configs/config_hyperparameters.py
@@ -5,5 +5,7 @@ def get_hp_config():
         'window_months': 18,
         'lambda_mix': 0.10,
         'n_samples': 64,
+        'n_posterior_samples': 64,
+        'regression_targets': ['synth_target'],
     }
     return hyperparameters

--- a/models/white_ranger/configs/config_hyperparameters.py
+++ b/models/white_ranger/configs/config_hyperparameters.py
@@ -13,6 +13,7 @@ def get_hp_config():
         "time_steps": 36,
         "window_months": 36,
         "n_samples": 64,
+        "n_posterior_samples": 64,
         "seed": 42,
     }
 

--- a/models/yellow_ranger/configs/config_hyperparameters.py
+++ b/models/yellow_ranger/configs/config_hyperparameters.py
@@ -14,5 +14,7 @@ def get_hp_config():
         'window_months': 18,
         'lambda_mix': 0.05,
         'n_samples': 256,
+        'n_posterior_samples': 256,
+        'regression_targets': ['lr_os_best'],
     }
     return hyperparameters

--- a/reports/technical_risk_register.md
+++ b/reports/technical_risk_register.md
@@ -2,8 +2,8 @@
 
 **Last updated:** 2026-06-01  
 **Governing ADR:** [ADR-010](../docs/ADRs/010_technical_risk_register.md)  
-**Total entries:** 48 (44 concerns + 4 disagreements)  
-**Concerns:** Open 15 | Mitigated 10 | Resolved 16 | Accepted 3  
+**Total entries:** 56 (52 concerns + 4 disagreements)  
+**Concerns:** Open 19 | Mitigated 12 | Resolved 18 | Accepted 3  
 **Disagreements:** Open 4  
 
 ---
@@ -532,8 +532,6 @@
 
 ---
 
-<<<<<<< HEAD
-=======
 ### C-44 — Concat aggregation degrades ensemble CRPS when constituent model quality varies
 
 | Field | Value |
@@ -651,7 +649,6 @@
 
 ---
 
->>>>>>> a58a65c (docs: register C-52 — 12 PF models missing PFE-required config keys)
 ## Disagreements
 
 ### D-01 — Intentional config duplication vs. DRY principle

--- a/reports/technical_risk_register.md
+++ b/reports/technical_risk_register.md
@@ -3,7 +3,7 @@
 **Last updated:** 2026-06-01  
 **Governing ADR:** [ADR-010](../docs/ADRs/010_technical_risk_register.md)  
 **Total entries:** 56 (52 concerns + 4 disagreements)  
-**Concerns:** Open 19 | Mitigated 12 | Resolved 18 | Accepted 3  
+**Concerns:** Open 18 | Mitigated 12 | Resolved 19 | Accepted 3  
 **Disagreements:** Open 4  
 
 ---
@@ -643,9 +643,9 @@
 | **Tier** | 2 |
 | **Trigger** | A developer adds any of the 12 affected models as a constituent of a PredictionFrameEnsembleManager ensemble — the ensemble will crash or produce wrong sample counts because constituent configs lack `n_posterior_samples` and/or `regression_targets` |
 | **Source** | test_pfe_production_readiness.py (TDD green tests, 2026-06-01) |
-| **Status** | Open |
+| **Status** | Resolved |
 | **Location** | `models/{black_ranger,blue_ranger,green_ranger,lucid_dream,pink_ranger,red_ranger,vivid_dream,waking_dream,yellow_ranger}/configs/config_hyperparameters.py` (missing both `n_posterior_samples` and `regression_targets`), `models/{heavy_strider,light_strider,white_ranger}/configs/config_hyperparameters.py` (missing `n_posterior_samples` only) |
-| **Notes** | All 21 models declare `prediction_format: "prediction_frame"` in `config_meta.py`, meaning they produce PredictionFrame outputs. But 12 of them lack `n_posterior_samples` (needed by PFE to verify aggregated sample counts) and 9 of those also lack `regression_targets` (needed to know which target directories to validate). The 9 models with fully compliant configs (purple_alien, blue_stranger, violet_visitor, bright_starship, bold_comet, blazing_meteor, heavy_freighter, pink_pirate, heavy_strider partially) are the only ones eligible for PFE ensembles today. This blocks the PFE production roadmap: Steps 2-5 require running constituent models through PFE, and any model without these keys cannot participate. The ranger models (7 of 12) use an older config convention with `n_samples` instead of `n_posterior_samples` and no explicit `regression_targets` — they predate the HydraNet multi-target architecture. The dream models (lucid_dream, vivid_dream, waking_dream) are synthetic test models that also predate the convention. Fix: add `n_posterior_samples` and `regression_targets` to all 12 models' `config_hyperparameters.py`. The TDD tests in `test_pfe_production_readiness.py` will turn green as each model is fixed. See also C-42 (PFE not in PyPI release — different: import availability vs. config completeness), C-05 (incomplete HP validation — covers stepshifter/baseline, not PF models). |
+| **Notes** | All 21 models declare `prediction_format: "prediction_frame"` in `config_meta.py`, meaning they produce PredictionFrame outputs. But 12 of them lack `n_posterior_samples` (needed by PFE to verify aggregated sample counts) and 9 of those also lack `regression_targets` (needed to know which target directories to validate). The 9 models with fully compliant configs (purple_alien, blue_stranger, violet_visitor, bright_starship, bold_comet, blazing_meteor, heavy_freighter, pink_pirate, heavy_strider partially) are the only ones eligible for PFE ensembles today. This blocks the PFE production roadmap: Steps 2-5 require running constituent models through PFE, and any model without these keys cannot participate. The ranger models (7 of 12) use an older config convention with `n_samples` instead of `n_posterior_samples` and no explicit `regression_targets` — they predate the HydraNet multi-target architecture. The dream models (lucid_dream, vivid_dream, waking_dream) are synthetic test models that also predate the convention. **Resolved (2026-06-02):** Added `n_posterior_samples` and `regression_targets` to all 12 affected `config_hyperparameters.py` files. Values derived from each model's `config_meta.py` (regression_targets) and existing `n_samples` (n_posterior_samples). xfail markers removed from `test_pfe_production_readiness.py` — all 21 PF models now pass config-level readiness tests unconditionally. See #70. |
 
 ---
 

--- a/reports/technical_risk_register.md
+++ b/reports/technical_risk_register.md
@@ -1,9 +1,9 @@
 # Technical Risk Register — views-models
 
-**Last updated:** 2026-05-24  
+**Last updated:** 2026-06-01  
 **Governing ADR:** [ADR-010](../docs/ADRs/010_technical_risk_register.md)  
-**Total entries:** 47 (43 concerns + 4 disagreements)  
-**Concerns:** Open 14 | Mitigated 10 | Resolved 16 | Accepted 3  
+**Total entries:** 48 (44 concerns + 4 disagreements)  
+**Concerns:** Open 15 | Mitigated 10 | Resolved 16 | Accepted 3  
 **Disagreements:** Open 4  
 
 ---
@@ -532,6 +532,126 @@
 
 ---
 
+<<<<<<< HEAD
+=======
+### C-44 — Concat aggregation degrades ensemble CRPS when constituent model quality varies
+
+| Field | Value |
+|---|---|
+| **Tier** | 3 |
+| **Trigger** | Building a concat ensemble where constituent models have heterogeneous performance on a specific target (e.g., one model's CRPS is 50%+ worse than others on that target) |
+| **Source** | golden_hour calibration run (2026-05-25) |
+| **Status** | Open |
+| **Location** | `ensembles/golden_hour/configs/config_meta.py` (`aggregation: "concat"`), `views-pipeline-core` PredictionFrameEnsembleManager concat path |
+| **Notes** | Observed 53% CRPS degradation on `lr_sb_best` vs best individual model (golden_hour: 0.233 vs purple_alien: 0.152). blue_stranger (0.223) contributed 64 poor-quality samples that diluted the 128 better samples from purple_alien and violet_visitor. Concat treats all posterior samples equally — no mechanism to down-weight poor contributors. For future ensembles, consider weighted aggregation or model selection for targets where constituent quality varies significantly. Models were uncalibrated so this finding may not hold after hyperparameter optimization. See also C-13 (no prediction quality validation before aggregation). |
+
+---
+
+### C-45 — Ensemble `-t` flag causes full retraining cascade when models are pre-trained
+
+| Field | Value |
+|---|---|
+| **Tier** | 2 |
+| **Trigger** | Running any PredictionFrameEnsembleManager or DataFrameEnsembleManager with `-t` when constituent models already have trained artifacts in their `artifacts/` directories |
+| **Source** | golden_hour calibration run (2026-05-25) |
+| **Status** | Open |
+| **Location** | `views-pipeline-core` EnsembleManager train path (invokes constituent `run.sh` subprocesses) |
+| **Notes** | Running `python main.py -r calibration -t -e` on a pre-trained ensemble causes: (1) retrain all constituent models via run.sh subprocess (~2h), (2) create new model artifacts with new timestamps, (3) discover no predictions exist for those new timestamps, (4) re-evaluate all constituent models via run.sh subprocess (~3h), (5) finally perform the actual aggregation (~30 min). This wasted ~6 hours on golden_hour. The correct command when models are already trained: `python main.py -r calibration -e --saved`. The `-t` flag on ensembles should either warn when artifacts already exist, or detect and reuse existing timestamps rather than creating new ones. See also C-22 (no idempotency guarantee in training artifacts). |
+
+---
+
+### C-46 — Classification targets not evaluable at PredictionFrame ensemble level
+
+| Field | Value |
+|---|---|
+| **Tier** | 3 |
+| **Trigger** | Adding `classification_targets` to any PredictionFrame ensemble's `config_meta.py` |
+| **Source** | golden_hour design review (2026-05-24) |
+| **Status** | Open |
+| **Location** | `views-pipeline-core` `PredictionFrameEnsembleManager.prepare_actuals_df` (identity lambda), `ensembles/golden_hour/configs/config_meta.py` (regression-only by design) |
+| **Notes** | `PredictionFrameEnsembleManager.prepare_actuals_df` is a no-op identity lambda. Classification targets (`by_sb_best`, `by_ns_best`, `by_os_best`) are derived signals not present in raw viewser data. Individual HydraNet models derive them via `DataFetcher.apply_blueprint()`, but the ensemble doesn't inherit that derivation logic. Including `classification_targets` in ensemble `config_meta` causes `KeyError` when `EvaluationStage._load_actuals()` looks for the derived columns in raw actuals. Workaround: exclude `classification_targets` from ensemble config; evaluate classification at individual model level only. golden_hour correctly implements this workaround. Fix would require `PredictionFrameEnsembleManager` to implement target derivation or delegate to constituent model blueprints. See also C-15 (CIC failure mode coverage — ensemble aggregation failure modes listed as remaining gap). |
+
+---
+
+### C-47 — Track A/B dual output produces redundant predictions with contradictory documentation
+
+| Field | Value |
+|---|---|
+| **Tier** | 3 |
+| **Trigger** | A developer sets `skip_predictions_delivery` back to `False` to re-enable Track B parquets without verifying the PyArrow memory fix is in place |
+| **Source** | golden_hour investigation (2026-05-25) |
+| **Status** | Mitigated |
+| **Location** | `views-pipeline-core` config (`skip_predictions_delivery` flag), `models/*/data/generated/` (both `.npy` and `.parquet` outputs coexist) |
+| **Notes** | HydraNet models produce both Track A (`.npy` PredictionFrame, 64 posterior samples) and Track B (`.parquet` DataFrame delivery, point predictions) simultaneously. **Mitigated (2026-05-26):** All 19 PredictionFrame models now have `skip_predictions_delivery: True`, suppressing Track B parquet generation. The contradictory `False, #True,` comment pattern has been removed. `test_track_parity.py` (40 tests) verified Track A and Track B produce identical values before Track B was disabled. `CoreConfigSniffer` (views-pipeline-core PR #87) now enforces the key as mandatory — models without it crash at config validation. Residual risk: if Track B is re-enabled without the PyArrow memory fix, the 5.5M Python float object allocation (~4.8–6.4 GB peak) will recur. See also C-40 (generate() return type contract mismatch). |
+
+---
+
+### C-48 — Viewser vs datafactory variable variant mismatch confounds parity comparison
+
+| Field | Value |
+|---|---|
+| **Tier** | 2 |
+| **Trigger** | CRPS or forecast parity comparison between golden_hour (viewser) and stellar_horizon (datafactory) shows divergence; root cause is data input differences, not pipeline differences |
+| **Source** | config diff investigation (2026-05-26) |
+| **Status** | Resolved |
+| **Location** | `models/purple_alien/configs/config_queryset.py` (`ged_sb_best_sum_nokgi`), `models/bright_starship/configs/config_queryset.py` (`ged_sb_best`), same pattern for `ged_ns_best` and `ged_os_best` |
+| **Notes** | The viewser trio (purple_alien, blue_stranger, violet_visitor) trains on `ged_*_best_sum_nokgi` — the summed, no-known-geographical-imprecision variant of UCDP fatality counts. The datafactory trio (bright_starship, bold_comet, blazing_meteor) trains on `ged_*_best` — the base variant. Despite different variable names, both deliver functionally identical values. **Resolved (2026-05-26):** Direct cell-by-cell comparison of cached training parquets (4,876,920 rows × 6 columns) showed 99.99% exact match for all three target variables: lr_sb_best (614 differing rows of 4.9M), lr_ns_best (138), lr_os_best (182). Correlations all >0.999. The `_sum_nokgi` suffix does not indicate a different aggregation — both sources deliver the same fatality sums per PRIO-GRID cell-month. The ~600 differing rows have small absolute differences reflecting timing differences in UCDP data ingestion. This concern is fully disproven as a source of prediction divergence. See `reports/parity_investigation_20260526.md` for full analysis. See also C-02 (queryset validation), C-40 (generate() contract mismatch). |
+
+---
+
+### C-49 — Feature set divergence between viewser and datafactory model configs
+
+| Field | Value |
+|---|---|
+| **Tier** | 4 |
+| **Trigger** | Parity comparison between golden_hour and stellar_horizon produces unexplained spatial or regional bias differences |
+| **Source** | config diff investigation (2026-05-26) |
+| **Status** | Partially Resolved |
+| **Location** | `models/purple_alien/configs/config_queryset.py` (lines 22-23: `col`, `row` columns), `models/bright_starship/configs/config_queryset.py` (no spatial features) |
+| **Notes** | Originally three concerns. **Partially resolved (2026-05-26):** **(1) Spatial features: DISPROVEN.** Raw data comparison confirmed `col` and `row` are 100% identical between viewser and datafactory parquets. Both data loading paths provide them. **(2) Country encoding: CONFIRMED but metadata-only.** viewser uses VIEWS-internal `country_id` (e.g., 192); datafactory uses FAO `gaul0_code` (e.g., 159, or -1 for unassigned). 0% cell-level match. However, `c_id` is in `identity_cols`, NOT in `features` — HydraNet uses only 3 input channels (lr_sb_best, lr_ns_best, lr_os_best). Unless curriculum sampling or stratified evaluation uses `c_id` values downstream, this is a metadata-only divergence with no model impact. Downgraded from Tier 2 to Tier 4. **(3) NA handling:** Not yet investigated. See `reports/parity_investigation_20260526.md` for full analysis. See also C-48 (resolved — variable variant not a divergence source), C-02 (queryset correctness). |
+
+---
+
+### C-50 — `views-baseline` not published to PyPI; `requirements.txt` version spec unresolvable on fresh clone
+
+| Field | Value |
+|---|---|
+| **Tier** | 2 |
+| **Trigger** | A developer clones the repo on a new machine and runs any baseline model's `run.sh`, which creates `envs/views-baseline` and fails at `pip install -r requirements.txt` because `views-baseline>=1.0.0,<2.0.0` has no matching distribution on PyPI |
+| **Source** | synthetic ensemble run (2026-05-26) |
+| **Status** | Open |
+| **Location** | `models/lucid_dream/requirements.txt`, `models/vivid_dream/requirements.txt`, `models/waking_dream/requirements.txt`, `models/vertical_dream/requirements.txt`, `models/horizontal_dream/requirements.txt`, `models/diagonal_dream/requirements.txt`, `models/red_ranger/requirements.txt`, `models/green_ranger/requirements.txt`, `models/blue_ranger/requirements.txt`, `models/black_ranger/requirements.txt`, `models/pink_ranger/requirements.txt`, `models/yellow_ranger/requirements.txt`, `models/white_ranger/requirements.txt`, `models/light_strider/requirements.txt`, `models/heavy_strider/requirements.txt`, `models/average_cmbaseline/requirements.txt`, `models/average_pgmbaseline/requirements.txt`, `models/zero_cmbaseline/requirements.txt`, `models/zero_pgmbaseline/requirements.txt`, `models/locf_cmbaseline/requirements.txt`, `models/locf_pgmbaseline/requirements.txt` (21 models total) |
+| **Notes** | All 21 baseline models declare `views-baseline>=1.0.0,<2.0.0` in `requirements.txt`. The `views-baseline` package is not published to PyPI at all — it is only available as a local editable install from `~/Documents/scripts/views_platform/views-baseline` at version `0.1.0`. On existing developer machines with the pre-existing `envs/views-baseline` env, the pip dry-run check succeeds because the package is already installed, and `run.sh` proceeds normally. On a fresh clone (new machine, CI, new contributor), `run.sh` creates the conda env, `pip install` fails with `No matching distribution found for views-baseline`, and the model crashes with `ModuleNotFoundError: No module named 'views_baseline'`. **Observed (2026-05-26):** All 6 synthetic model runs showed `ERROR: No matching distribution found for views-baseline<2.0.0,>=1.0.0` but succeeded because the env already had the local install. **Fix options:** (1) publish `views-baseline` to PyPI at version `>=1.0.0`, (2) change `requirements.txt` to use a git+https URL (matching the `views-datafactory` pattern in HydraNet models), (3) update `run.sh` to install from local path if available (but run.sh must not be modified — see feedback constraint). See also C-38 (same class: `datafactory_query` not installed), C-42 (same class: `views-pipeline-core` from PyPI lacks features), C-08 (requirements coherence). |
+
+---
+
+### C-51 — Datafactory trio missing `sampling_strategy` — ADR-049 required field, runtime crash
+
+| Field | Value |
+|---|---|
+| **Tier** | 2 |
+| **Trigger** | A developer runs `bash models/bold_comet/run.sh -r calibration` (or bright_starship, blazing_meteor) and views-hydranet rejects the config with `'sampling_strategy' is required (ADR-049)` |
+| **Source** | review (PR #59, 2026-05-31) |
+| **Status** | Resolved |
+| **Location** | `models/bright_starship/configs/config_hyperparameters.py`, `models/bold_comet/configs/config_hyperparameters.py`, `models/blazing_meteor/configs/config_hyperparameters.py`, `models/heavy_freighter/configs/config_hyperparameters.py` |
+| **Notes** | The viewser trio (purple_alien, blue_stranger, violet_visitor) received `sampling_strategy` in this PR cycle (threshold/boltzmann/sigmoid respectively). The datafactory trio and heavy_freighter were not updated — bold_comet and blazing_meteor were cloned from bright_starship, which also lacked the field. views-hydranet's curriculum learner validates the key at config load time and raises `KeyError` on absence. All four models would fail immediately on any training run. The parity test (`test_datafactory_parity.py::TestDatafactoryTrioConfigParity::test_identical_shared_hyperparameters`) does not catch this because it strips loss keys and compares models pairwise — since all three are equally missing the field, they match each other. **Resolved (2026-06-01):** Added `'sampling_strategy': 'threshold'` to all four affected models (3 datafactory + heavy_freighter). Added `test_hydranet_has_sampling_strategy` to `test_config_completeness.py` to catch this class of omission for all HydraNet models (scoped via `meta_config["algorithm"] == "HydraNet"`) — this test is what caught heavy_freighter. See also C-05 (incomplete HP validation — covers stepshifter/baseline, not HydraNet), C-38 (datafactory_query not installed — same models, different dependency class), C-42 (unreleased pipeline-core branch — different: import availability, not config completeness). |
+
+---
+
+### C-52 — 12 PF models missing config keys required for PFE ensemble participation
+
+| Field | Value |
+|---|---|
+| **Tier** | 2 |
+| **Trigger** | A developer adds any of the 12 affected models as a constituent of a PredictionFrameEnsembleManager ensemble — the ensemble will crash or produce wrong sample counts because constituent configs lack `n_posterior_samples` and/or `regression_targets` |
+| **Source** | test_pfe_production_readiness.py (TDD green tests, 2026-06-01) |
+| **Status** | Open |
+| **Location** | `models/{black_ranger,blue_ranger,green_ranger,lucid_dream,pink_ranger,red_ranger,vivid_dream,waking_dream,yellow_ranger}/configs/config_hyperparameters.py` (missing both `n_posterior_samples` and `regression_targets`), `models/{heavy_strider,light_strider,white_ranger}/configs/config_hyperparameters.py` (missing `n_posterior_samples` only) |
+| **Notes** | All 21 models declare `prediction_format: "prediction_frame"` in `config_meta.py`, meaning they produce PredictionFrame outputs. But 12 of them lack `n_posterior_samples` (needed by PFE to verify aggregated sample counts) and 9 of those also lack `regression_targets` (needed to know which target directories to validate). The 9 models with fully compliant configs (purple_alien, blue_stranger, violet_visitor, bright_starship, bold_comet, blazing_meteor, heavy_freighter, pink_pirate, heavy_strider partially) are the only ones eligible for PFE ensembles today. This blocks the PFE production roadmap: Steps 2-5 require running constituent models through PFE, and any model without these keys cannot participate. The ranger models (7 of 12) use an older config convention with `n_samples` instead of `n_posterior_samples` and no explicit `regression_targets` — they predate the HydraNet multi-target architecture. The dream models (lucid_dream, vivid_dream, waking_dream) are synthetic test models that also predate the convention. Fix: add `n_posterior_samples` and `regression_targets` to all 12 models' `config_hyperparameters.py`. The TDD tests in `test_pfe_production_readiness.py` will turn green as each model is fixed. See also C-42 (PFE not in PyPI release — different: import availability vs. config completeness), C-05 (incomplete HP validation — covers stepshifter/baseline, not PF models). |
+
+---
+
+>>>>>>> a58a65c (docs: register C-52 — 12 PF models missing PFE-required config keys)
 ## Disagreements
 
 ### D-01 — Intentional config duplication vs. DRY principle

--- a/tests/test_pfe_production_readiness.py
+++ b/tests/test_pfe_production_readiness.py
@@ -109,18 +109,6 @@ def _latest_pf_run(base_dir, name):
 PF_MODELS = _discover_pf_models()
 PFE_ENSEMBLES = _discover_pfe_ensembles()
 
-# C-52: PF models not yet PFE-ready. Remove models as they gain the keys.
-_C52_MISSING_N_POSTERIOR = {
-    "black_ranger", "blue_ranger", "green_ranger", "heavy_strider",
-    "light_strider", "lucid_dream", "pink_ranger", "red_ranger",
-    "vivid_dream", "waking_dream", "white_ranger", "yellow_ranger",
-}
-_C52_MISSING_REGRESSION_TARGETS = {
-    "black_ranger", "blue_ranger", "green_ranger", "lucid_dream",
-    "pink_ranger", "red_ranger", "vivid_dream", "waking_dream",
-    "yellow_ranger",
-}
-
 
 # ══════════════════════════════════════════════════════════════════════
 # Issue #64 — Config-level readiness (green, always-run)
@@ -135,11 +123,7 @@ class TestPFModelConfigReadiness:
     def pf_model(self, request):
         return request.param
 
-    def test_has_n_posterior_samples(self, pf_model, request):
-        if pf_model in _C52_MISSING_N_POSTERIOR:
-            request.applymarker(pytest.mark.xfail(
-                reason=f"C-52: {pf_model} missing n_posterior_samples"
-            ))
+    def test_has_n_posterior_samples(self, pf_model):
         hp = _load_hp(pf_model)
         n = hp.get("n_posterior_samples")
         assert isinstance(n, int) and n > 0, (
@@ -150,11 +134,7 @@ class TestPFModelConfigReadiness:
         meta = _load_meta(pf_model)
         assert meta.get("prediction_format") == "prediction_frame"
 
-    def test_has_regression_targets(self, pf_model, request):
-        if pf_model in _C52_MISSING_REGRESSION_TARGETS:
-            request.applymarker(pytest.mark.xfail(
-                reason=f"C-52: {pf_model} missing regression_targets"
-            ))
+    def test_has_regression_targets(self, pf_model):
         hp = _load_hp(pf_model)
         targets = hp.get("regression_targets")
         assert isinstance(targets, list) and len(targets) > 0, (
@@ -380,6 +360,8 @@ class TestTransformUndoScale:
     def test_values_not_log_compressed(self, pf_case):
         name = pf_case[0]
         target, origin = self._first_target_origin(pf_case)
+        if target.startswith("synth_"):
+            pytest.skip(f"{name}/{target}: synthetic target, log-compression check N/A")
         y = np.load(origin / target / "y_pred.npy", mmap_mode="r")
         assert y.max() > 10, (
             f"{name}/{target}: max value {y.max():.4f} suggests log-scale — "

--- a/tests/test_pfe_production_readiness.py
+++ b/tests/test_pfe_production_readiness.py
@@ -8,12 +8,13 @@ Green tests (config-level) always run.
 Red tests (output-level) skip when prediction outputs don't exist.
 """
 
-import importlib.util
 import re
 from pathlib import Path
 
 import numpy as np
 import pytest
+
+from tests.conftest import load_config_module
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 MODELS_DIR = REPO_ROOT / "models"
@@ -27,11 +28,7 @@ _GETTER_ALIASES = {"config_hyperparameters": "get_hp_config"}
 
 def _load_config(base_dir, name, config_name):
     path = base_dir / name / "configs" / f"{config_name}.py"
-    spec = importlib.util.spec_from_file_location(
-        f"_pfe_{name}_{config_name}", path
-    )
-    mod = importlib.util.module_from_spec(spec)
-    spec.loader.exec_module(mod)
+    mod = load_config_module(path)
     getter = _GETTER_ALIASES.get(
         config_name, f"get_{config_name.removeprefix('config_')}_config"
     )
@@ -72,7 +69,7 @@ def _discover_pf_models():
             meta = _load_meta(d.name)
             if meta.get("prediction_format") == "prediction_frame":
                 pf_models.append(d.name)
-        except Exception:
+        except (FileNotFoundError, AttributeError):
             continue
     return pf_models
 
@@ -200,7 +197,7 @@ class TestPFEEnsembleConfigReadiness:
         samples = []
         for model_name in meta["models"]:
             hp = _load_hp(model_name)
-            samples.append(hp["n_posterior_samples"])
+            samples.append(_require_n_posterior_samples(hp, model_name))
         assert len(set(samples)) == 1, (
             f"{pfe_ensemble} uses arithmetic_mean but constituents have "
             f"different n_posterior_samples: {samples}"
@@ -438,15 +435,18 @@ class TestPFEEnsembleAggregation:
         name, run_type, timestamp = pfe_case
         return ENSEMBLES_DIR / name / "data" / "generated" / f"predictions_{run_type}_{timestamp}"
 
+    def _first_origin(self, pfe_case):
+        pred_dir = self._pred_dir(pfe_case)
+        return sorted(
+            d for d in pred_dir.iterdir()
+            if d.is_dir() and d.name.startswith("origin_")
+        )[0]
+
     def test_all_targets_have_directories(self, pfe_case):
         name = pfe_case[0]
         meta = _load_meta(name, ENSEMBLES_DIR)
         expected_targets = set(meta["regression_targets"])
-        pred_dir = self._pred_dir(pfe_case)
-        first_origin = sorted(
-            d for d in pred_dir.iterdir()
-            if d.is_dir() and d.name.startswith("origin_")
-        )[0]
+        first_origin = self._first_origin(pfe_case)
         actual_targets = {d.name for d in first_origin.iterdir() if d.is_dir()}
         missing = expected_targets - actual_targets
         assert not missing, (
@@ -458,12 +458,7 @@ class TestPFEEnsembleAggregation:
         meta = _load_meta(name, ENSEMBLES_DIR)
         expected = _expected_ensemble_samples(name)
         first_target = meta["regression_targets"][0]
-        pred_dir = self._pred_dir(pfe_case)
-        first_origin = sorted(
-            d for d in pred_dir.iterdir()
-            if d.is_dir() and d.name.startswith("origin_")
-        )[0]
-        y = np.load(first_origin / first_target / "y_pred.npy", mmap_mode="r")
+        y = np.load(self._first_origin(pfe_case) / first_target / "y_pred.npy", mmap_mode="r")
         assert y.shape[1] == expected, (
             f"{name}: aggregated samples={y.shape[1]} but expected "
             f"{expected} (from constituent configs, aggregation='{meta['aggregation']}')"
@@ -473,12 +468,7 @@ class TestPFEEnsembleAggregation:
         name = pfe_case[0]
         meta = _load_meta(name, ENSEMBLES_DIR)
         first_target = meta["regression_targets"][0]
-        pred_dir = self._pred_dir(pfe_case)
-        first_origin = sorted(
-            d for d in pred_dir.iterdir()
-            if d.is_dir() and d.name.startswith("origin_")
-        )[0]
-        y = np.load(first_origin / first_target / "y_pred.npy", mmap_mode="r")
+        y = np.load(self._first_origin(pfe_case) / first_target / "y_pred.npy", mmap_mode="r")
         assert y.min() >= 0, (
             f"{name}/{first_target}: min={y.min():.4f} is negative"
         )
@@ -487,12 +477,7 @@ class TestPFEEnsembleAggregation:
         name = pfe_case[0]
         meta = _load_meta(name, ENSEMBLES_DIR)
         first_target = meta["regression_targets"][0]
-        pred_dir = self._pred_dir(pfe_case)
-        first_origin = sorted(
-            d for d in pred_dir.iterdir()
-            if d.is_dir() and d.name.startswith("origin_")
-        )[0]
-        y = np.load(first_origin / first_target / "y_pred.npy", mmap_mode="r")
+        y = np.load(self._first_origin(pfe_case) / first_target / "y_pred.npy", mmap_mode="r")
         assert y.max() > 10, (
             f"{name}/{first_target}: max={y.max():.4f} suggests log-scale"
         )
@@ -501,12 +486,7 @@ class TestPFEEnsembleAggregation:
         name = pfe_case[0]
         meta = _load_meta(name, ENSEMBLES_DIR)
         first_target = meta["regression_targets"][0]
-        pred_dir = self._pred_dir(pfe_case)
-        first_origin = sorted(
-            d for d in pred_dir.iterdir()
-            if d.is_dir() and d.name.startswith("origin_")
-        )[0]
-        y = np.load(first_origin / first_target / "y_pred.npy", mmap_mode="r")
+        y = np.load(self._first_origin(pfe_case) / first_target / "y_pred.npy", mmap_mode="r")
         assert np.isnan(y).sum() == 0, f"{name}: NaN in aggregated output"
         assert np.isinf(y).sum() == 0, f"{name}: Inf in aggregated output"
 
@@ -514,12 +494,7 @@ class TestPFEEnsembleAggregation:
         name = pfe_case[0]
         meta = _load_meta(name, ENSEMBLES_DIR)
         first_target = meta["regression_targets"][0]
-        pred_dir = self._pred_dir(pfe_case)
-        first_origin = sorted(
-            d for d in pred_dir.iterdir()
-            if d.is_dir() and d.name.startswith("origin_")
-        )[0]
-        ids = np.load(first_origin / first_target / "identifiers.npz")
+        ids = np.load(self._first_origin(pfe_case) / first_target / "identifiers.npz")
         assert "time" in ids and "unit" in ids, (
             f"{name}: identifiers.npz missing keys, got {list(ids.keys())}"
         )

--- a/tests/test_pfe_production_readiness.py
+++ b/tests/test_pfe_production_readiness.py
@@ -109,6 +109,18 @@ def _latest_pf_run(base_dir, name):
 PF_MODELS = _discover_pf_models()
 PFE_ENSEMBLES = _discover_pfe_ensembles()
 
+# C-52: PF models not yet PFE-ready. Remove models as they gain the keys.
+_C52_MISSING_N_POSTERIOR = {
+    "black_ranger", "blue_ranger", "green_ranger", "heavy_strider",
+    "light_strider", "lucid_dream", "pink_ranger", "red_ranger",
+    "vivid_dream", "waking_dream", "white_ranger", "yellow_ranger",
+}
+_C52_MISSING_REGRESSION_TARGETS = {
+    "black_ranger", "blue_ranger", "green_ranger", "lucid_dream",
+    "pink_ranger", "red_ranger", "vivid_dream", "waking_dream",
+    "yellow_ranger",
+}
+
 
 # ══════════════════════════════════════════════════════════════════════
 # Issue #64 — Config-level readiness (green, always-run)
@@ -123,7 +135,11 @@ class TestPFModelConfigReadiness:
     def pf_model(self, request):
         return request.param
 
-    def test_has_n_posterior_samples(self, pf_model):
+    def test_has_n_posterior_samples(self, pf_model, request):
+        if pf_model in _C52_MISSING_N_POSTERIOR:
+            request.applymarker(pytest.mark.xfail(
+                reason=f"C-52: {pf_model} missing n_posterior_samples"
+            ))
         hp = _load_hp(pf_model)
         n = hp.get("n_posterior_samples")
         assert isinstance(n, int) and n > 0, (
@@ -134,7 +150,11 @@ class TestPFModelConfigReadiness:
         meta = _load_meta(pf_model)
         assert meta.get("prediction_format") == "prediction_frame"
 
-    def test_has_regression_targets(self, pf_model):
+    def test_has_regression_targets(self, pf_model, request):
+        if pf_model in _C52_MISSING_REGRESSION_TARGETS:
+            request.applymarker(pytest.mark.xfail(
+                reason=f"C-52: {pf_model} missing regression_targets"
+            ))
         hp = _load_hp(pf_model)
         targets = hp.get("regression_targets")
         assert isinstance(targets, list) and len(targets) > 0, (

--- a/tests/test_pfe_production_readiness.py
+++ b/tests/test_pfe_production_readiness.py
@@ -1,0 +1,525 @@
+"""PredictionFrame ensemble production readiness tests.
+
+TDD tests for the PFE production roadmap (views-pipeline-core
+2026-06-01_pfe_production_roadmap.md). All expectations are derived
+from model and ensemble configs — nothing is hardcoded.
+
+Green tests (config-level) always run.
+Red tests (output-level) skip when prediction outputs don't exist.
+"""
+
+import importlib.util
+import re
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+MODELS_DIR = REPO_ROOT / "models"
+ENSEMBLES_DIR = REPO_ROOT / "ensembles"
+
+
+# ── Helpers ──────────────────────────────────────────────────────────
+
+_GETTER_ALIASES = {"config_hyperparameters": "get_hp_config"}
+
+
+def _load_config(base_dir, name, config_name):
+    path = base_dir / name / "configs" / f"{config_name}.py"
+    spec = importlib.util.spec_from_file_location(
+        f"_pfe_{name}_{config_name}", path
+    )
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    getter = _GETTER_ALIASES.get(
+        config_name, f"get_{config_name.removeprefix('config_')}_config"
+    )
+    return getattr(mod, getter)()
+
+
+def _load_meta(name, base_dir=MODELS_DIR):
+    return _load_config(base_dir, name, "config_meta")
+
+
+def _load_hp(name, base_dir=MODELS_DIR):
+    return _load_config(base_dir, name, "config_hyperparameters")
+
+
+def _require_regression_targets(hp, name):
+    targets = hp.get("regression_targets")
+    if not targets:
+        pytest.skip(f"{name}: no regression_targets in config (green test catches this)")
+    return targets
+
+
+def _require_n_posterior_samples(hp, name):
+    n = hp.get("n_posterior_samples")
+    if n is None:
+        pytest.skip(f"{name}: no n_posterior_samples in config (green test catches this)")
+    return n
+
+
+def _discover_pf_models():
+    """Return names of all models with prediction_format == 'prediction_frame'."""
+    pf_models = []
+    for d in sorted(MODELS_DIR.iterdir()):
+        if not d.is_dir() or not (d / "configs" / "config_meta.py").exists():
+            continue
+        if d.name == "fake_model":
+            continue
+        try:
+            meta = _load_meta(d.name)
+            if meta.get("prediction_format") == "prediction_frame":
+                pf_models.append(d.name)
+        except Exception:
+            continue
+    return pf_models
+
+
+def _discover_pfe_ensembles():
+    """Return names of ensembles that use PredictionFrameEnsembleManager."""
+    pfe = []
+    for d in sorted(ENSEMBLES_DIR.iterdir()):
+        main_py = d / "main.py"
+        if not main_py.exists():
+            continue
+        text = main_py.read_text()
+        if "PredictionFrameEnsembleManager" in text:
+            pfe.append(d.name)
+    return pfe
+
+
+def _find_pf_prediction_runs(base_dir, name):
+    """Find (run_type, timestamp) pairs with PF directory structure."""
+    gen = base_dir / name / "data" / "generated"
+    if not gen.exists():
+        return []
+    runs = []
+    for d in sorted(gen.iterdir()):
+        match = re.match(r"predictions_(\w+?)_(\d{8}_\d{6})$", d.name)
+        if match and (d / "origin_0").is_dir():
+            runs.append(match.groups())
+    return runs
+
+
+def _latest_pf_run(base_dir, name):
+    """Return (run_type, timestamp) for the most recent PF run, or None."""
+    runs = _find_pf_prediction_runs(base_dir, name)
+    return runs[-1] if runs else None
+
+
+PF_MODELS = _discover_pf_models()
+PFE_ENSEMBLES = _discover_pfe_ensembles()
+
+
+# ══════════════════════════════════════════════════════════════════════
+# Issue #64 — Config-level readiness (green, always-run)
+# ══════════════════════════════════════════════════════════════════════
+
+class TestPFModelConfigReadiness:
+    """Every PF model must have the config keys that PFE depends on."""
+
+    pytestmark = [pytest.mark.green]
+
+    @pytest.fixture(params=PF_MODELS)
+    def pf_model(self, request):
+        return request.param
+
+    def test_has_n_posterior_samples(self, pf_model):
+        hp = _load_hp(pf_model)
+        n = hp.get("n_posterior_samples")
+        assert isinstance(n, int) and n > 0, (
+            f"{pf_model}: n_posterior_samples must be a positive int, got {n}"
+        )
+
+    def test_has_prediction_format(self, pf_model):
+        meta = _load_meta(pf_model)
+        assert meta.get("prediction_format") == "prediction_frame"
+
+    def test_has_regression_targets(self, pf_model):
+        hp = _load_hp(pf_model)
+        targets = hp.get("regression_targets")
+        assert isinstance(targets, list) and len(targets) > 0, (
+            f"{pf_model}: regression_targets must be a non-empty list"
+        )
+
+    def test_has_steps(self, pf_model):
+        hp = _load_hp(pf_model)
+        steps = hp.get("steps")
+        assert isinstance(steps, list) and len(steps) > 0, (
+            f"{pf_model}: steps must be a non-empty list"
+        )
+
+
+class TestPFEEnsembleConfigReadiness:
+    """Every PFE ensemble must reference valid PF constituent models."""
+
+    pytestmark = [pytest.mark.green]
+
+    @pytest.fixture(params=PFE_ENSEMBLES)
+    def pfe_ensemble(self, request):
+        return request.param
+
+    def test_models_list_non_empty(self, pfe_ensemble):
+        meta = _load_meta(pfe_ensemble, ENSEMBLES_DIR)
+        models = meta.get("models")
+        assert isinstance(models, list) and len(models) > 0
+
+    def test_all_constituents_exist(self, pfe_ensemble):
+        meta = _load_meta(pfe_ensemble, ENSEMBLES_DIR)
+        for model_name in meta["models"]:
+            assert (MODELS_DIR / model_name).is_dir(), (
+                f"{pfe_ensemble} references {model_name} but it doesn't exist"
+            )
+
+    def test_all_constituents_are_pf_models(self, pfe_ensemble):
+        meta = _load_meta(pfe_ensemble, ENSEMBLES_DIR)
+        for model_name in meta["models"]:
+            model_meta = _load_meta(model_name)
+            assert model_meta.get("prediction_format") == "prediction_frame", (
+                f"{pfe_ensemble} constituent {model_name} is not a PF model"
+            )
+
+    def test_aggregation_valid_for_pfe(self, pfe_ensemble):
+        meta = _load_meta(pfe_ensemble, ENSEMBLES_DIR)
+        assert meta.get("aggregation") in ("concat", "arithmetic_mean"), (
+            f"{pfe_ensemble}: aggregation must be 'concat' or 'arithmetic_mean', "
+            f"got '{meta.get('aggregation')}'"
+        )
+
+    def test_has_regression_targets(self, pfe_ensemble):
+        meta = _load_meta(pfe_ensemble, ENSEMBLES_DIR)
+        targets = meta.get("regression_targets")
+        assert isinstance(targets, list) and len(targets) > 0
+
+    def test_constituent_samples_consistent_for_mean(self, pfe_ensemble):
+        meta = _load_meta(pfe_ensemble, ENSEMBLES_DIR)
+        if meta.get("aggregation") != "arithmetic_mean":
+            pytest.skip("only applies to arithmetic_mean aggregation")
+        samples = []
+        for model_name in meta["models"]:
+            hp = _load_hp(model_name)
+            samples.append(hp["n_posterior_samples"])
+        assert len(set(samples)) == 1, (
+            f"{pfe_ensemble} uses arithmetic_mean but constituents have "
+            f"different n_posterior_samples: {samples}"
+        )
+
+
+# ══════════════════════════════════════════════════════════════════════
+# Issue #65 — PredictionFrame output validation (red, skip-when-absent)
+# ══════════════════════════════════════════════════════════════════════
+
+def _pf_output_cases():
+    """Yield (model_name, run_type, timestamp) for PF models with outputs."""
+    cases = []
+    for name in PF_MODELS:
+        run = _latest_pf_run(MODELS_DIR, name)
+        if run:
+            cases.append((name, *run))
+    return cases
+
+
+PF_OUTPUT_CASES = _pf_output_cases()
+PF_OUTPUT_IDS = [f"{c[0]}_{c[1]}" for c in PF_OUTPUT_CASES]
+
+
+class TestPredictionFrameOutput:
+    """Validate PF output structure against config-derived expectations."""
+
+    pytestmark = [pytest.mark.red]
+
+    @pytest.fixture(params=PF_OUTPUT_CASES, ids=PF_OUTPUT_IDS)
+    def pf_case(self, request):
+        return request.param
+
+    def _pred_dir(self, pf_case):
+        name, run_type, timestamp = pf_case
+        return MODELS_DIR / name / "data" / "generated" / f"predictions_{run_type}_{timestamp}"
+
+    def _origins(self, pf_case):
+        pred_dir = self._pred_dir(pf_case)
+        return sorted(
+            d for d in pred_dir.iterdir()
+            if d.is_dir() and d.name.startswith("origin_")
+        )
+
+    def test_all_regression_targets_have_directories(self, pf_case):
+        name = pf_case[0]
+        hp = _load_hp(name)
+        targets = _require_regression_targets(hp, name)
+        expected_targets = set(targets)
+        origins = self._origins(pf_case)
+        assert len(origins) > 0, f"{name}: no origin directories found"
+        first_origin = origins[0]
+        actual_targets = {d.name for d in first_origin.iterdir() if d.is_dir()}
+        missing = expected_targets - actual_targets
+        assert not missing, (
+            f"{name}: origin_0 missing regression target dirs: {missing}"
+        )
+
+    def test_y_pred_shape(self, pf_case):
+        name = pf_case[0]
+        hp = _load_hp(name)
+        targets = _require_regression_targets(hp, name)
+        expected_samples = _require_n_posterior_samples(hp, name)
+        first_origin = self._origins(pf_case)[0]
+        y = np.load(first_origin / targets[0] / "y_pred.npy", mmap_mode="r")
+        assert y.ndim == 2, f"{name}: y_pred must be 2D, got {y.ndim}D"
+        assert y.shape[0] > 0, f"{name}: y_pred has 0 rows"
+        assert y.shape[1] == expected_samples, (
+            f"{name}: y_pred.shape[1]={y.shape[1]} but "
+            f"n_posterior_samples={expected_samples}"
+        )
+
+    def test_y_pred_dtype(self, pf_case):
+        name = pf_case[0]
+        hp = _load_hp(name)
+        targets = _require_regression_targets(hp, name)
+        first_origin = self._origins(pf_case)[0]
+        y = np.load(first_origin / targets[0] / "y_pred.npy", mmap_mode="r")
+        assert y.dtype in (np.float32, np.float64), (
+            f"{name}: y_pred dtype must be float32/64, got {y.dtype}"
+        )
+
+    def test_identifiers_keys(self, pf_case):
+        name = pf_case[0]
+        hp = _load_hp(name)
+        targets = _require_regression_targets(hp, name)
+        first_origin = self._origins(pf_case)[0]
+        ids = np.load(first_origin / targets[0] / "identifiers.npz")
+        assert "time" in ids and "unit" in ids, (
+            f"{name}: identifiers.npz must have 'time' and 'unit' keys, "
+            f"got {list(ids.keys())}"
+        )
+
+    def test_identifiers_length_matches_predictions(self, pf_case):
+        name = pf_case[0]
+        hp = _load_hp(name)
+        targets = _require_regression_targets(hp, name)
+        first_origin = self._origins(pf_case)[0]
+        y = np.load(first_origin / targets[0] / "y_pred.npy", mmap_mode="r")
+        ids = np.load(first_origin / targets[0] / "identifiers.npz")
+        assert len(ids["time"]) == y.shape[0], (
+            f"{name}: time ids length {len(ids['time'])} != y_pred rows {y.shape[0]}"
+        )
+        assert len(ids["unit"]) == y.shape[0], (
+            f"{name}: unit ids length {len(ids['unit'])} != y_pred rows {y.shape[0]}"
+        )
+
+    def test_origins_consistent_across_targets(self, pf_case):
+        name = pf_case[0]
+        hp = _load_hp(name)
+        targets = _require_regression_targets(hp, name)
+        pred_dir = self._pred_dir(pf_case)
+        origin_sets = {}
+        for target in targets:
+            origins = {
+                d.name for d in pred_dir.iterdir()
+                if d.is_dir() and d.name.startswith("origin_")
+                and (d / target).is_dir()
+            }
+            origin_sets[target] = origins
+        target_names = list(origin_sets.keys())
+        for t in target_names[1:]:
+            assert origin_sets[target_names[0]] == origin_sets[t], (
+                f"{name}: origin sets differ between {target_names[0]} and {t}"
+            )
+
+
+class TestTransformUndoScale:
+    """Verify predictions are on measurement scale, not log-compressed."""
+
+    pytestmark = [pytest.mark.red]
+
+    @pytest.fixture(params=PF_OUTPUT_CASES, ids=PF_OUTPUT_IDS)
+    def pf_case(self, request):
+        return request.param
+
+    def _first_target_origin(self, pf_case):
+        name = pf_case[0]
+        hp = _load_hp(name)
+        targets = _require_regression_targets(hp, name)
+        pred_dir = (
+            MODELS_DIR / name / "data" / "generated"
+            / f"predictions_{pf_case[1]}_{pf_case[2]}"
+        )
+        first_origin = sorted(
+            d for d in pred_dir.iterdir()
+            if d.is_dir() and d.name.startswith("origin_")
+        )[0]
+        return targets[0], first_origin
+
+    def test_values_non_negative(self, pf_case):
+        name = pf_case[0]
+        target, origin = self._first_target_origin(pf_case)
+        y = np.load(origin / target / "y_pred.npy", mmap_mode="r")
+        assert y.min() >= 0, (
+            f"{name}/{target}: min value {y.min():.4f} is negative — "
+            f"fatality counts must be non-negative"
+        )
+
+    def test_values_not_log_compressed(self, pf_case):
+        name = pf_case[0]
+        target, origin = self._first_target_origin(pf_case)
+        y = np.load(origin / target / "y_pred.npy", mmap_mode="r")
+        assert y.max() > 10, (
+            f"{name}/{target}: max value {y.max():.4f} suggests log-scale — "
+            f"measurement-scale fatality counts should exceed 10 in high-conflict cells"
+        )
+
+    def test_no_nan(self, pf_case):
+        name = pf_case[0]
+        target, origin = self._first_target_origin(pf_case)
+        y = np.load(origin / target / "y_pred.npy", mmap_mode="r")
+        nan_count = np.isnan(y).sum()
+        assert nan_count == 0, f"{name}/{target}: {nan_count} NaN values"
+
+    def test_no_inf(self, pf_case):
+        name = pf_case[0]
+        target, origin = self._first_target_origin(pf_case)
+        y = np.load(origin / target / "y_pred.npy", mmap_mode="r")
+        inf_count = np.isinf(y).sum()
+        assert inf_count == 0, f"{name}/{target}: {inf_count} Inf values"
+
+
+# ══════════════════════════════════════════════════════════════════════
+# Issue #66 — PFE ensemble aggregation validation (red, skip-when-absent)
+# ══════════════════════════════════════════════════════════════════════
+
+def _pfe_output_cases():
+    """Yield (ensemble_name, run_type, timestamp) for PFE ensembles with outputs."""
+    cases = []
+    for name in PFE_ENSEMBLES:
+        run = _latest_pf_run(ENSEMBLES_DIR, name)
+        if run:
+            cases.append((name, *run))
+    return cases
+
+
+PFE_OUTPUT_CASES = _pfe_output_cases()
+PFE_OUTPUT_IDS = [f"{c[0]}_{c[1]}" for c in PFE_OUTPUT_CASES]
+
+
+def _expected_ensemble_samples(ensemble_name):
+    meta = _load_meta(ensemble_name, ENSEMBLES_DIR)
+    aggregation = meta["aggregation"]
+    samples = []
+    for model_name in meta["models"]:
+        hp = _load_hp(model_name)
+        n = hp.get("n_posterior_samples")
+        if n is None:
+            pytest.skip(
+                f"{ensemble_name}: constituent {model_name} missing "
+                f"n_posterior_samples (green test catches this)"
+            )
+        samples.append(n)
+    if aggregation == "concat":
+        return sum(samples)
+    elif aggregation == "arithmetic_mean":
+        return samples[0]
+    return None
+
+
+class TestPFEEnsembleAggregation:
+    """Validate ensemble PF output: sample count, scale, integrity."""
+
+    pytestmark = [pytest.mark.red]
+
+    @pytest.fixture(params=PFE_OUTPUT_CASES if PFE_OUTPUT_CASES else [None],
+                    ids=PFE_OUTPUT_IDS if PFE_OUTPUT_IDS else ["no_ensemble_output"])
+    def pfe_case(self, request):
+        if request.param is None:
+            pytest.skip("no PFE ensemble predictions found")
+        return request.param
+
+    def _pred_dir(self, pfe_case):
+        name, run_type, timestamp = pfe_case
+        return ENSEMBLES_DIR / name / "data" / "generated" / f"predictions_{run_type}_{timestamp}"
+
+    def test_all_targets_have_directories(self, pfe_case):
+        name = pfe_case[0]
+        meta = _load_meta(name, ENSEMBLES_DIR)
+        expected_targets = set(meta["regression_targets"])
+        pred_dir = self._pred_dir(pfe_case)
+        first_origin = sorted(
+            d for d in pred_dir.iterdir()
+            if d.is_dir() and d.name.startswith("origin_")
+        )[0]
+        actual_targets = {d.name for d in first_origin.iterdir() if d.is_dir()}
+        missing = expected_targets - actual_targets
+        assert not missing, (
+            f"{name}: origin_0 missing regression target dirs: {missing}"
+        )
+
+    def test_aggregated_sample_count(self, pfe_case):
+        name = pfe_case[0]
+        meta = _load_meta(name, ENSEMBLES_DIR)
+        expected = _expected_ensemble_samples(name)
+        first_target = meta["regression_targets"][0]
+        pred_dir = self._pred_dir(pfe_case)
+        first_origin = sorted(
+            d for d in pred_dir.iterdir()
+            if d.is_dir() and d.name.startswith("origin_")
+        )[0]
+        y = np.load(first_origin / first_target / "y_pred.npy", mmap_mode="r")
+        assert y.shape[1] == expected, (
+            f"{name}: aggregated samples={y.shape[1]} but expected "
+            f"{expected} (from constituent configs, aggregation='{meta['aggregation']}')"
+        )
+
+    def test_aggregated_values_non_negative(self, pfe_case):
+        name = pfe_case[0]
+        meta = _load_meta(name, ENSEMBLES_DIR)
+        first_target = meta["regression_targets"][0]
+        pred_dir = self._pred_dir(pfe_case)
+        first_origin = sorted(
+            d for d in pred_dir.iterdir()
+            if d.is_dir() and d.name.startswith("origin_")
+        )[0]
+        y = np.load(first_origin / first_target / "y_pred.npy", mmap_mode="r")
+        assert y.min() >= 0, (
+            f"{name}/{first_target}: min={y.min():.4f} is negative"
+        )
+
+    def test_aggregated_values_not_log_compressed(self, pfe_case):
+        name = pfe_case[0]
+        meta = _load_meta(name, ENSEMBLES_DIR)
+        first_target = meta["regression_targets"][0]
+        pred_dir = self._pred_dir(pfe_case)
+        first_origin = sorted(
+            d for d in pred_dir.iterdir()
+            if d.is_dir() and d.name.startswith("origin_")
+        )[0]
+        y = np.load(first_origin / first_target / "y_pred.npy", mmap_mode="r")
+        assert y.max() > 10, (
+            f"{name}/{first_target}: max={y.max():.4f} suggests log-scale"
+        )
+
+    def test_aggregated_no_nan_inf(self, pfe_case):
+        name = pfe_case[0]
+        meta = _load_meta(name, ENSEMBLES_DIR)
+        first_target = meta["regression_targets"][0]
+        pred_dir = self._pred_dir(pfe_case)
+        first_origin = sorted(
+            d for d in pred_dir.iterdir()
+            if d.is_dir() and d.name.startswith("origin_")
+        )[0]
+        y = np.load(first_origin / first_target / "y_pred.npy", mmap_mode="r")
+        assert np.isnan(y).sum() == 0, f"{name}: NaN in aggregated output"
+        assert np.isinf(y).sum() == 0, f"{name}: Inf in aggregated output"
+
+    def test_identifiers_present(self, pfe_case):
+        name = pfe_case[0]
+        meta = _load_meta(name, ENSEMBLES_DIR)
+        first_target = meta["regression_targets"][0]
+        pred_dir = self._pred_dir(pfe_case)
+        first_origin = sorted(
+            d for d in pred_dir.iterdir()
+            if d.is_dir() and d.name.startswith("origin_")
+        )[0]
+        ids = np.load(first_origin / first_target / "identifiers.npz")
+        assert "time" in ids and "unit" in ids, (
+            f"{name}: identifiers.npz missing keys, got {list(ids.keys())}"
+        )

--- a/tests/test_pfe_production_readiness.py
+++ b/tests/test_pfe_production_readiness.py
@@ -148,6 +148,18 @@ class TestPFModelConfigReadiness:
             f"{pf_model}: steps must be a non-empty list"
         )
 
+    def test_regression_targets_consistent_meta_hp(self, pf_model):
+        meta = _load_meta(pf_model)
+        hp = _load_hp(pf_model)
+        meta_targets = meta.get("regression_targets")
+        hp_targets = hp.get("regression_targets")
+        if not meta_targets or not hp_targets:
+            pytest.skip(f"{pf_model}: one or both configs missing regression_targets")
+        assert sorted(meta_targets) == sorted(hp_targets), (
+            f"{pf_model}: config_meta regression_targets {meta_targets} != "
+            f"config_hyperparameters regression_targets {hp_targets}"
+        )
+
 
 class TestPFEEnsembleConfigReadiness:
     """Every PFE ensemble must reference valid PF constituent models."""
@@ -479,6 +491,8 @@ class TestPFEEnsembleAggregation:
         name = pfe_case[0]
         meta = _load_meta(name, ENSEMBLES_DIR)
         first_target = meta["regression_targets"][0]
+        if first_target.startswith("synth_"):
+            pytest.skip(f"{name}/{first_target}: synthetic target, log-compression check N/A")
         y = np.load(self._first_origin(pfe_case) / first_target / "y_pred.npy", mmap_mode="r")
         assert y.max() > 10, (
             f"{name}/{first_target}: max={y.max():.4f} suggests log-scale"


### PR DESCRIPTION
## Summary
- Add `tests/test_pfe_production_readiness.py` — 27 TDD tests across 5 classes covering issues #64, #65, #66
- Fix C-52: add `n_posterior_samples` and/or `regression_targets` to 12 PF models' `config_hyperparameters.py`
- Register C-52 (Tier 2) in risk register, then mark Resolved after all configs fixed
- Fix merge conflict markers and stale header counts in risk register

### Test classes
| Class | Category | Issue | Tests |
|---|---|---|---|
| `TestPFModelConfigReadiness` | green | #64 | 5 — every PF model has the config keys PFE depends on |
| `TestPFEEnsembleConfigReadiness` | green | #64 | 6 — every PFE ensemble references valid PF constituents |
| `TestPredictionFrameOutput` | red | #65 | 7 — y_pred shape/dtype, identifiers, cross-target consistency |
| `TestTransformUndoScale` | red | #65 | 4 — non-negative, not log-compressed, no NaN/Inf |
| `TestPFEEnsembleAggregation` | red | #66 | 6 — aggregated sample count, scale, integrity |

### TDD cycle (Red > Green > Refactor)
1. **Red:** Tests defined with xfail markers for 12 non-compliant models
2. **Green:** Config fixes applied — rangers (6), dreams (3), striders + white_ranger (3)
3. **Refactor:** xfail sets removed, all 21 PF models hard-pass config readiness

### Config changes (12 models)
- **Rangers** (black, blue, green, pink, red, yellow): `n_posterior_samples: 256` + model-specific `regression_targets`
- **Dreams** (lucid, vivid, waking): `n_posterior_samples: 64` + `regression_targets: ['synth_target']`
- **Striders + white_ranger**: `n_posterior_samples: 64` (already had `regression_targets`)

### Design
- All expectations derived dynamically from model/ensemble configs — nothing hardcoded
- Green tests always run; red tests skip when prediction outputs don't exist
- Red tests skip when config prerequisites are missing (green tests catch those)
- Reuses `conftest.load_config_module` — no duplicated importlib logic

### Final state
- **184 passed**, **13 skipped**, 0 xfail, 0 failures (`test_pfe_production_readiness.py`)
- Full test suite: **4305 passed**, 340 skipped, 0 regressions

## Test plan
- [x] `ruff check tests/test_pfe_production_readiness.py` — passes
- [x] `pytest tests/test_pfe_production_readiness.py -v` — 184 passed, 13 skipped
- [x] `pytest tests/` — 4305 passed, no regressions
- [x] `review-diff` verdict: CLEAN (0 critical, 0 warnings)
- [x] All 12 config changes verified against each model's `config_meta.py`
- [x] Merge conflict markers removed from risk register
