### PR TITLE
test: integration tests for bump.py main() (#101)

### DIFF
--- a/docs/CICs/PartitionBump.md
+++ b/docs/CICs/PartitionBump.md
@@ -153,19 +153,21 @@ cd /tmp && python -m tools.partitions.bump  # ModuleNotFoundError
 
 ## 10. Test Alignment
 
+- `tests/test_bump_partitions.py::TestBumpIntegration` — 9 integration tests exercising `main(repo_root=tmp_path)` end-to-end: dry run, execute, pre-flight reject, missing JSON, temporal block, override skip, sync mode, lockfile content, partitions.json update
 - `tests/test_bump_partitions.py` — 34 unit tests covering domain, fileops, discovery, overrides
-- `tests/test_falsify_bump_robustness.py` — 3 tests verifying resolved findings (double-bump blocked, absurd bump blocked, single-quote resilience)
-- `tests/test_falsify_bump_completeness.py` — 2 tests (ADR-011 references, no override mechanism needed)
+- `tests/test_bump_partitions.py::TestAdversarialInputs` — 9 red tests for adversarial inputs
+- `tests/test_bump_partitions.py::TestStructuralCompliance` — 5 beige tests for structural compliance
+- `tests/test_falsify_bump_robustness.py` — 3 tests verifying resolved findings
+- `tests/test_falsify_bump_completeness.py` — 2 tests (ADR-011, override mechanism)
 - `tests/test_falsify_bump_edge_cases.py` — 3 tests (error handling, comment safety, temp cleanup)
-- `tests/test_config_partitions.py` — 934 tests verifying consistency across all 100 files (uses shared parser)
-- **Gap:** No integration test of `main()` end-to-end with temp directory fixtures (see #101)
+- `tests/test_config_partitions.py` — 934 tests verifying consistency across all 100 files
 
 ---
 
 ## 11. Evolution Notes
 
-- `main()` is a 300-line function. If it grows further, extract phases into named functions (compute_bump, preflight, apply, verify, write_lockfile). The current size is acceptable for a CLI entry point.
-- `REPO_ROOT` is a module-level constant derived from `__file__`. For testability, `main()` could accept a `repo_root` parameter (#101).
+- `main()` accepts an optional `repo_root: Path` parameter for testability. Defaults to the module-level `_DEFAULT_REPO_ROOT`. All internal functions (`_load_canonical`, `_save_canonical`, `_git_state`) accept path parameters.
+- `main()` is a 300-line function. If it grows further, extract phases into named functions.
 - The lockfile format is append-only JSONL. If the tool needs to read previous lockfiles (e.g., to detect the last bump date), a `read_latest_lockfile()` function would be needed.
 
 ---

--- a/tests/test_bump_partitions.py
+++ b/tests/test_bump_partitions.py
@@ -5,9 +5,13 @@ Covers domain invariants, temporal plausibility, file parsing
 double-bump detection.
 """
 import hashlib
+import json as _json
+import sys as _sys
 from pathlib import Path
 
 import pytest
+
+from tools.partitions.bump import main as bump_main
 
 from tools.partitions.domain import (
     PartitionBoundaries,
@@ -464,3 +468,136 @@ class TestStructuralCompliance:
             assert "def generate" in source, (
                 f"{f.relative_to(REPO_ROOT)} missing generate() function"
             )
+
+
+# ---------------------------------------------------------------------------
+# Integration tests: bump.py main() end-to-end
+# ---------------------------------------------------------------------------
+
+_CANONICAL = {
+    "calibration": {"train": [121, 444], "test": [445, 492]},
+    "validation": {"train": [121, 492], "test": [493, 540]},
+    "steps_default": 36,
+}
+
+_PARTITION_SOURCE = '''\
+from datetime import date
+
+def _current_month_id():
+    today = date.today()
+    return (today.year - 1980) * 12 + today.month
+
+def generate(steps=36):
+    return {
+        "calibration": {"train": (121, 444), "test": (445, 492)},
+        "validation": {"train": (121, 492), "test": (493, 540)},
+        "forecasting": {
+            "train": (121, _current_month_id() - 1),
+            "test": (_current_month_id(), _current_month_id() + steps),
+        },
+    }
+'''
+
+
+@pytest.fixture
+def fake_repo(tmp_path):
+    """Minimal repo structure for integration tests."""
+    repo = tmp_path / "repo"
+    meta = repo / "meta"
+    meta.mkdir(parents=True)
+    (meta / "partitions.json").write_text(_json.dumps(_CANONICAL, indent=2))
+    (meta / "fixtures.json").write_text("[]")
+
+    for name in ("alpha", "beta"):
+        model = repo / "models" / name
+        (model / "configs").mkdir(parents=True)
+        (model / "main.py").touch()
+        (model / "configs" / "config_partitions.py").write_text(_PARTITION_SOURCE)
+
+    return repo
+
+
+@pytest.mark.green
+class TestBumpIntegration:
+    """End-to-end integration tests for bump.py main()."""
+
+    def test_dry_run_modifies_nothing(self, fake_repo, monkeypatch, capsys):
+        monkeypatch.setattr(_sys, "argv", ["bump", "--bump", "12"])
+        with pytest.raises(SystemExit) as exc:
+            bump_main(repo_root=fake_repo)
+        assert exc.value.code == 0
+        out = capsys.readouterr().out
+        assert "DRY RUN" in out
+        assert "Would update 2 files" in out
+        for name in ("alpha", "beta"):
+            source = (fake_repo / "models" / name / "configs" / "config_partitions.py").read_text()
+            assert "(121, 444)" in source
+
+    def test_execute_rewrites_files(self, fake_repo, monkeypatch, capsys):
+        monkeypatch.setattr(_sys, "argv", ["bump", "--execute", "--bump", "12"])
+        bump_main(repo_root=fake_repo)
+        for name in ("alpha", "beta"):
+            source = (fake_repo / "models" / name / "configs" / "config_partitions.py").read_text()
+            assert "(121, 456)" in source
+            assert "(457, 504)" in source
+
+    def test_execute_creates_lockfile(self, fake_repo, monkeypatch, capsys):
+        monkeypatch.setattr(_sys, "argv", ["bump", "--execute", "--bump", "12"])
+        bump_main(repo_root=fake_repo)
+        lockfiles = list((fake_repo / "meta").glob("partition_bump_*.jsonl"))
+        assert len(lockfiles) == 1
+        entries = [_json.loads(ln) for ln in lockfiles[0].read_text().strip().split("\n")]
+        events = [e["event"] for e in entries]
+        assert "bump_executed" in events
+        assert "bump_completed" in events
+        assert entries[0].get("git_commit") is not None
+
+    def test_execute_updates_partitions_json(self, fake_repo, monkeypatch, capsys):
+        monkeypatch.setattr(_sys, "argv", ["bump", "--execute", "--bump", "12"])
+        bump_main(repo_root=fake_repo)
+        updated = _json.loads((fake_repo / "meta" / "partitions.json").read_text())
+        assert updated["calibration"]["train"] == [121, 456]
+        assert updated["validation"]["test"] == [505, 552]
+
+    def test_preflight_mismatch_blocks(self, fake_repo, monkeypatch, capsys):
+        bad = (fake_repo / "models" / "alpha" / "configs" / "config_partitions.py")
+        bad.write_text(_PARTITION_SOURCE.replace("(121, 444)", "(121, 400)"))
+        monkeypatch.setattr(_sys, "argv", ["bump", "--execute", "--bump", "12"])
+        with pytest.raises(SystemExit) as exc:
+            bump_main(repo_root=fake_repo)
+        assert exc.value.code == 1
+        assert "MISMATCH" in capsys.readouterr().out
+
+    def test_missing_partitions_json(self, fake_repo, monkeypatch, capsys):
+        (fake_repo / "meta" / "partitions.json").unlink()
+        monkeypatch.setattr(_sys, "argv", ["bump", "--bump", "12"])
+        with pytest.raises(SystemExit) as exc:
+            bump_main(repo_root=fake_repo)
+        assert exc.value.code == 1
+        assert "not found" in capsys.readouterr().out
+
+    def test_temporal_block(self, fake_repo, monkeypatch, capsys):
+        monkeypatch.setattr(_sys, "argv", ["bump", "--bump", "24"])
+        with pytest.raises(SystemExit) as exc:
+            bump_main(repo_root=fake_repo)
+        assert exc.value.code == 1
+        assert "exceeds" in capsys.readouterr().out
+
+    def test_override_file_skipped(self, fake_repo, monkeypatch, capsys):
+        override_src = "PARTITION_OVERRIDE = True\n\n" + _PARTITION_SOURCE
+        (fake_repo / "models" / "alpha" / "configs" / "config_partitions.py").write_text(override_src)
+        monkeypatch.setattr(_sys, "argv", ["bump", "--execute", "--bump", "12"])
+        bump_main(repo_root=fake_repo)
+        alpha_src = (fake_repo / "models" / "alpha" / "configs" / "config_partitions.py").read_text()
+        assert "(121, 444)" in alpha_src
+        beta_src = (fake_repo / "models" / "beta" / "configs" / "config_partitions.py").read_text()
+        assert "(121, 456)" in beta_src
+
+    def test_sync_mode_no_advance(self, fake_repo, monkeypatch, capsys):
+        monkeypatch.setattr(_sys, "argv", ["bump", "--execute", "--bump", "0"])
+        bump_main(repo_root=fake_repo)
+        for name in ("alpha", "beta"):
+            source = (fake_repo / "models" / name / "configs" / "config_partitions.py").read_text()
+            assert "(121, 444)" in source
+        lockfiles = list((fake_repo / "meta").glob("partition_bump_*.jsonl"))
+        assert len(lockfiles) == 1

--- a/tools/partitions/bump.py
+++ b/tools/partitions/bump.py
@@ -47,55 +47,57 @@ from tools.partitions.fileops import (
     write_atomic,
 )
 
-REPO_ROOT = Path(__file__).resolve().parent.parent.parent
-PARTITIONS_FILE = REPO_ROOT / "meta" / "partitions.json"
-LOCK_DIR = REPO_ROOT / "meta"
+_DEFAULT_REPO_ROOT = Path(__file__).resolve().parent.parent.parent
 
 
-def _load_canonical() -> dict:
+def _load_canonical(partitions_file: Path) -> dict:
     try:
-        with open(PARTITIONS_FILE) as f:
+        with open(partitions_file) as f:
             return json.load(f)
     except FileNotFoundError:
-        print(f"ERROR: {PARTITIONS_FILE} not found.")
+        print(f"ERROR: {partitions_file} not found.")
         print("This file is the source of truth for partition boundaries.")
         sys.exit(1)
     except json.JSONDecodeError as e:
-        print(f"ERROR: {PARTITIONS_FILE} contains invalid JSON: {e}")
+        print(f"ERROR: {partitions_file} contains invalid JSON: {e}")
         sys.exit(1)
 
 
-def _save_canonical(canonical: dict, boundaries: PartitionBoundaries) -> None:
+def _save_canonical(
+    canonical: dict, boundaries: PartitionBoundaries, partitions_file: Path
+) -> None:
     merged = {**canonical, **boundaries.to_json_dict()}
-    dir_name = PARTITIONS_FILE.parent
+    dir_name = partitions_file.parent
     with tempfile.NamedTemporaryFile(
         mode="w", dir=dir_name, suffix=".tmp", delete=False
     ) as tmp:
         json.dump(merged, tmp, indent=2)
         tmp.write("\n")
         tmp_path = tmp.name
-    os.replace(tmp_path, str(PARTITIONS_FILE))
+    os.replace(tmp_path, str(partitions_file))
 
 
-def _git_state() -> dict:
+def _git_state(cwd: Path | None = None) -> dict:
     """Capture current git commit, branch, and dirty status."""
+    if cwd is None:
+        cwd = _DEFAULT_REPO_ROOT
     state = {}
     try:
         result = subprocess.run(
             ["git", "rev-parse", "HEAD"],
-            capture_output=True, text=True, timeout=5, cwd=REPO_ROOT,
+            capture_output=True, text=True, timeout=5, cwd=cwd,
         )
         state["git_commit"] = result.stdout.strip() if result.returncode == 0 else "unknown"
 
         result = subprocess.run(
             ["git", "branch", "--show-current"],
-            capture_output=True, text=True, timeout=5, cwd=REPO_ROOT,
+            capture_output=True, text=True, timeout=5, cwd=cwd,
         )
         state["git_branch"] = result.stdout.strip() if result.returncode == 0 else "unknown"
 
         result = subprocess.run(
             ["git", "status", "--porcelain"],
-            capture_output=True, text=True, timeout=5, cwd=REPO_ROOT,
+            capture_output=True, text=True, timeout=5, cwd=cwd,
         )
         state["git_dirty"] = bool(result.stdout.strip()) if result.returncode == 0 else None
     except (subprocess.TimeoutExpired, FileNotFoundError):
@@ -118,7 +120,12 @@ def _print_boundaries(b: PartitionBoundaries) -> None:
         )
 
 
-def main():
+def main(repo_root: Path | None = None):
+    if repo_root is None:
+        repo_root = _DEFAULT_REPO_ROOT
+    partitions_file = repo_root / "meta" / "partitions.json"
+    lock_dir = repo_root / "meta"
+
     parser = argparse.ArgumentParser(
         description="Bump VIEWS partition boundaries forward by N months.",
     )
@@ -146,11 +153,11 @@ def main():
         print(f"WARNING: --bump={bump} is not a multiple of 12 (years).")
 
     # --- Load and validate current canonical ---
-    canonical = _load_canonical()
+    canonical = _load_canonical(partitions_file)
     try:
         current = PartitionBoundaries.from_json(canonical)
     except (KeyError, TypeError) as e:
-        print(f"ERROR: {PARTITIONS_FILE} has invalid structure: {e}")
+        print(f"ERROR: {partitions_file} has invalid structure: {e}")
         print("Expected keys: calibration.train, calibration.test, validation.train, validation.test")
         sys.exit(1)
 
@@ -196,9 +203,9 @@ def main():
     current_flat = current.to_flat_dict()
 
     # --- Coverage check ---
-    entity_dirs = discover_entity_dirs(REPO_ROOT)
+    entity_dirs = discover_entity_dirs(repo_root)
     entity_set = set(entity_dirs)
-    files = discover_partition_files(REPO_ROOT)
+    files = discover_partition_files(repo_root)
     partition_parents = {f.parent.parent for f in files}
     missing = [d for d in entity_dirs if d not in partition_parents]
 
@@ -223,7 +230,7 @@ def main():
         )
         for d in missing:
             print(
-                f"    MISSING: {d.relative_to(REPO_ROOT)} "
+                f"    MISSING: {d.relative_to(repo_root)} "
                 f"— has main.py but no config_partitions.py"
             )
         if not dry_run:
@@ -243,7 +250,7 @@ def main():
             f"(custom partitions, not bumped):"
         )
         for f in override_files:
-            print(f"    {f.parent.parent.relative_to(REPO_ROOT)}")
+            print(f"    {f.parent.parent.relative_to(repo_root)}")
     else:
         print("  0 research overrides")
     print(f"  {len(fixture_files)} test fixtures")
@@ -255,7 +262,7 @@ def main():
     target_files = []
 
     for path in standard_files:
-        rel = path.relative_to(REPO_ROOT)
+        rel = path.relative_to(repo_root)
 
         parsed = extract_values(path.read_text())
         if parsed is None:
@@ -303,7 +310,7 @@ def main():
     write_errors = []
 
     for path in target_files:
-        rel = path.relative_to(REPO_ROOT)
+        rel = path.relative_to(repo_root)
         try:
             source = path.read_text()
             new_source = rewrite_values(source, new_flat)
@@ -324,7 +331,7 @@ def main():
     verify_failures = []
 
     for path in updated:
-        rel = path.relative_to(REPO_ROOT)
+        rel = path.relative_to(repo_root)
         errors = verify_file(path, new_flat)
         if errors:
             verify_failures.extend(errors)
@@ -345,15 +352,15 @@ def main():
 
     # --- Update meta/partitions.json ---
     print("\n--- Updating meta/partitions.json ---")
-    _save_canonical(canonical, new)
+    _save_canonical(canonical, new, partitions_file)
     print("  Written: meta/partitions.json")
 
     # --- Write lockfile ---
     now = datetime.datetime.now(datetime.timezone.utc)
     timestamp = now.strftime("%Y%m%d_%H%M%S")
-    lock_path = LOCK_DIR / f"partition_bump_{timestamp}.jsonl"
+    lock_path = lock_dir / f"partition_bump_{timestamp}.jsonl"
 
-    git = _git_state()
+    git = _git_state(cwd=repo_root)
     lock_entries = []
 
     lock_entries.append({
@@ -377,14 +384,14 @@ def main():
     for path in updated:
         lock_entries.append({
             "event": "file_updated",
-            "file": str(path.relative_to(REPO_ROOT)),
+            "file": str(path.relative_to(repo_root)),
             "verified": True,
         })
 
     for path in override_files:
         lock_entries.append({
             "event": "file_skipped_research_override",
-            "file": str(path.relative_to(REPO_ROOT)),
+            "file": str(path.relative_to(repo_root)),
         })
 
     lock_entries.append({
@@ -398,7 +405,7 @@ def main():
     lock_content = "\n".join(json.dumps(entry) for entry in lock_entries) + "\n"
     write_atomic(lock_path, lock_content)
 
-    print(f"\n--- Lockfile: {lock_path.relative_to(REPO_ROOT)} ---")
+    print(f"\n--- Lockfile: {lock_path.relative_to(repo_root)} ---")
 
     # --- Summary ---
     print("\n=== BUMP COMPLETE ===")
@@ -406,7 +413,7 @@ def main():
     if override_files:
         print(f"  Research overrides:       {len(override_files)} (not bumped)")
     print("  Verification failures:    0")
-    print(f"  Lockfile:                 {lock_path.relative_to(REPO_ROOT)}")
+    print(f"  Lockfile:                 {lock_path.relative_to(repo_root)}")
     print(f"  Git commit:               {git.get('git_commit', 'unknown')[:12]}")
     print(
         f"\n  Before: val test "


### PR DESCRIPTION
## Summary

Parameterizes bump.py main() to accept repo_root (backward compatible) and adds 9 integration tests exercising the full pipeline end-to-end with temp directory fixtures.

### Changes
- main() accepts optional repo_root parameter (defaults to current behavior)
- _load_canonical, _save_canonical, _git_state accept path parameters
- 9 integration tests: dry run, execute, lockfile, pre-flight reject, missing JSON, temporal block, override skip, sync mode, partitions.json update
- CIC PartitionBump.md sections 10+11 updated

### No logic changes — only parameter threading for testability.

Closes #101

## Test plan
- [x] python -m tools.partitions.bump — backward compat, dry run works
- [x] 58 bump tests pass (34 unit + 9 red + 5 beige + 1 fixture + 9 integration)
- [x] Full suite: 5165 passed
- [x] ruff check clean