### PR TITLE
test: functional tests for generate_features_catalog.py (#102)

### DIFF
--- a/reports/technical_risk_register.md
+++ b/reports/technical_risk_register.md
@@ -2,8 +2,8 @@
 
 **Last updated:** 2026-06-06  
 **Governing ADR:** [ADR-010](../docs/ADRs/010_technical_risk_register.md)  
-**Total entries:** 69 (65 concerns + 4 disagreements)  
-**Concerns:** Open 27 | Mitigated 12 | Resolved 21 | Accepted 3 | Partially Resolved 1 | New 1  
+**Total entries:** 71 (67 concerns + 4 disagreements)  
+**Concerns:** Open 28 | Mitigated 12 | Resolved 22 | Accepted 3 | Partially Resolved 1 | New 1  
 **Disagreements:** Open 4  
 
 ---
@@ -813,7 +813,33 @@
 | **Source** | falsify: test category completeness (2026-06-07) |
 | **Status** | Open |
 | **Location** | `tools/catalogs/generate_features_catalog.py` (115 lines, 4 regex characterization tests only), `tools/catalogs/update_readme.py` (276 lines, 6 helper characterization tests only) |
-| **Notes** | Both scripts have characterization tests for isolated helper functions (regex patterns, tree formatting) but zero tests for their main functionality: discovering models, loading configs via importlib, generating output, writing files. The helpers are well-tested; the orchestration is untested. See #102 for generate_features_catalog.py. |
+| **Notes** | **Partially resolved 2026-06-07:** Added 11 functional tests for `generate_features_catalog.py`: 5 for `extract_columns_from_querysets()` (single file, dedup, loa extraction, empty dir crash, non-Python ignored) and 6 for `generate_markdown_table()` (valid markdown, headers, placeholders, row count, empty crash, queryset preserved). Found 2 bugs: empty dir crashes groupby (C-66), empty DataFrame crashes tabulate (C-67). `update_readme.py` orchestration remains untestable without views_pipeline_core — accepted. |
+
+---
+
+### C-66 — `extract_columns_from_querysets()` crashes on empty directory
+
+| Field | Value |
+|---|---|
+| **Tier** | 4 |
+| **Trigger** | `extract_columns_from_querysets()` is called on a directory with no `.py` files; pandas `groupby` raises `KeyError` on empty DataFrame |
+| **Source** | test: catalog core tests (2026-06-07) |
+| **Status** | Open |
+| **Location** | `tools/catalogs/generate_features_catalog.py:72` |
+| **Notes** | The function creates an empty `columns_info` list, converts to empty DataFrame (no columns), then tries `df.groupby(['column_name', 'loa'])` which fails because the columns don't exist. Fix: add early return if `columns_info` is empty. Characterized as red test `test_empty_directory_crashes`. |
+
+---
+
+### C-67 — `generate_markdown_table()` crashes on empty DataFrame
+
+| Field | Value |
+|---|---|
+| **Tier** | 4 |
+| **Trigger** | `generate_markdown_table()` is called with an empty DataFrame; `tabulate()` raises `IndexError` because `colalign=("center",)` references a column that doesn't exist |
+| **Source** | test: catalog core tests (2026-06-07) |
+| **Status** | Open |
+| **Location** | `tools/catalogs/generate_features_catalog.py:97` |
+| **Notes** | The `colalign` parameter assumes at least 1 data column. Empty DataFrame has 0 columns → `IndexError`. Fix: skip `colalign` if `table_data` is empty, or return header-only table. Characterized as red test `test_empty_dataframe_crashes_tabulate`. |
 
 ---
 

--- a/tests/test_tooling_scripts.py
+++ b/tests/test_tooling_scripts.py
@@ -538,3 +538,120 @@ class TestFeaturesCatalogAdversarialInputs:
     def test_loa_pattern_missing_from_loa(self):
         match = LOA_PATTERN.search('"col_name"')
         assert match is None
+
+
+# ---------------------------------------------------------------------------
+# Functional tests: generate_features_catalog.py core functions
+# ---------------------------------------------------------------------------
+
+from tools.catalogs.generate_features_catalog import (  # noqa: E402
+    extract_columns_from_querysets,
+    generate_markdown_table,
+)
+import pandas as pd  # noqa: E402
+
+
+@pytest.mark.green
+class TestExtractColumnsFromQuerysets:
+    """Functional tests for extract_columns_from_querysets()."""
+
+    def test_extracts_columns_from_single_file(self, tmp_path):
+        qs_file = tmp_path / "test_queryset.py"
+        qs_file.write_text('''
+qs = (Queryset("test_qs", "priogrid_month")
+    .with_column(Column("ged_sb_dep", from_loa="priogrid_month", from_column="ged_sb_best"))
+    .with_column(Column("acled_count", from_loa="country_month", from_column="acled_count_pr"))
+)
+''')
+        df = extract_columns_from_querysets(tmp_path)
+        assert len(df) == 2
+        assert set(df["column_name"]) == {"ged_sb_dep", "acled_count"}
+        assert "test_queryset" in df["queryset"].values[0]
+
+    def test_deduplicates_across_files(self, tmp_path):
+        for name in ("qs_a", "qs_b"):
+            (tmp_path / f"{name}.py").write_text(
+                'Column("shared_col", from_loa="priogrid_month")'
+            )
+        df = extract_columns_from_querysets(tmp_path)
+        shared = df[df["column_name"] == "shared_col"]
+        assert len(shared) == 1
+        assert "qs_a" in shared.iloc[0]["queryset"]
+        assert "qs_b" in shared.iloc[0]["queryset"]
+
+    def test_columns_with_loa_extracted(self, tmp_path):
+        (tmp_path / "qs.py").write_text(
+            'Column("with_loa", from_loa="pgm")\n'
+        )
+        df = extract_columns_from_querysets(tmp_path)
+        assert len(df) == 1
+        assert df.iloc[0]["column_name"] == "with_loa"
+        assert df.iloc[0]["loa"] == "pgm"
+
+    @pytest.mark.red
+    def test_empty_directory_crashes(self, tmp_path):
+        """Known bug: empty directory causes KeyError in groupby on empty DataFrame."""
+        with pytest.raises(KeyError):
+            extract_columns_from_querysets(tmp_path)
+
+    def test_ignores_non_python_files(self, tmp_path):
+        (tmp_path / "readme.md").write_text('Column("not_python")')
+        (tmp_path / "real.py").write_text('Column("real_col", from_loa="pgm")')
+        df = extract_columns_from_querysets(tmp_path)
+        assert len(df) == 1
+        assert df.iloc[0]["column_name"] == "real_col"
+
+
+@pytest.mark.green
+class TestGenerateMarkdownTable:
+    """Functional tests for generate_markdown_table()."""
+
+    def test_produces_valid_markdown(self, tmp_path):
+        df = pd.DataFrame({
+            "column_name": ["col_a", "col_b"],
+            "queryset": ["qs1", "qs2"],
+            "loa": ["pgm", "cm"],
+        })
+        table = generate_markdown_table(df)
+        assert "Name in viewser" in table
+        assert "col_a" in table
+        assert "col_b" in table
+        assert "|" in table
+
+    def test_has_correct_headers(self):
+        df = pd.DataFrame({"column_name": ["x"], "queryset": ["q"], "loa": ["l"]})
+        table = generate_markdown_table(df)
+        assert "Name in viewser" in table
+        assert "Human-readable name" in table
+        assert "Associated querysets/models" in table
+
+    def test_includes_placeholder_values(self):
+        df = pd.DataFrame({"column_name": ["x"], "queryset": ["q"], "loa": ["l"]})
+        table = generate_markdown_table(df)
+        assert "needs manual update" in table
+
+    def test_row_count_matches_input(self):
+        df = pd.DataFrame({
+            "column_name": ["a", "b", "c"],
+            "queryset": ["q1", "q2", "q3"],
+            "loa": ["pgm", "cm", "pgm"],
+        })
+        table = generate_markdown_table(df)
+        lines = [ln for ln in table.strip().split("\n") if ln.strip()]
+        assert len(lines) == 5  # header + separator + 3 data rows
+
+    @pytest.mark.red
+    def test_empty_dataframe_crashes_tabulate(self):
+        """Known bug: empty DataFrame with colalign causes IndexError in tabulate."""
+        df = pd.DataFrame({"column_name": [], "queryset": [], "loa": []})
+        with pytest.raises(IndexError):
+            generate_markdown_table(df)
+
+    def test_queryset_value_preserved(self):
+        df = pd.DataFrame({
+            "column_name": ["my_col"],
+            "queryset": ["fatalities003_conflict_history"],
+            "loa": ["pgm"],
+        })
+        table = generate_markdown_table(df)
+        assert "fatalities003_conflict_history" in table


### PR DESCRIPTION
## Summary

11 functional tests for the two core functions in generate_features_catalog.py:

- extract_columns_from_querysets: single file, dedup, LOA extraction, non-Python ignored, empty dir crash
- generate_markdown_table: valid markdown, headers, placeholders, row count, queryset preserved, empty crash

Found 2 bugs (characterized as red tests):
- C-66: empty directory crashes groupby on empty DataFrame
- C-67: empty DataFrame crashes tabulate colalign

Partially resolves C-65. Closes #102.

## Test plan
- [x] 52 tests pass in test_tooling_scripts.py
- [x] ruff check clean