### PR TITLE
Restore stepshifter target compression (log1p) + Shurf fix + metrics + chunky_bunny

### DIFF
--- a/ensembles/chunky_bunny/README.md
+++ b/ensembles/chunky_bunny/README.md
@@ -1,0 +1,56 @@
+# Chunky Bunny
+## Overview
+
+This folder contains code for the Chunky Bunny model, an ensemble machine learning model designed for predicting fatalities.
+
+`chunky_bunny` is a **clone of the original `big_chungus` ensemble** (the 2026-06-04 calibration run), recreated with its **full 23 constituents** — 13 plain stepshifters + 6 Hurdle stepshifters + 4 deep-learning models. It mirrors `big_chungus` exactly, but its stepshifter constituents now carry the restored `target_transform` fix (plain models → `log1p`), so its results should be sane rather than divergent. (It differs from `pink_ponyclub`, which carries only the 19 stepshifter constituents and omits the 4 deep-learning models.)
+
+
+| Information         | Details                        |
+|---------------------|--------------------------------|
+| **Models** | bittersweet_symphony, brown_cheese, car_radio, counting_stars, demon_days, elastic_heart, fast_car, fluorescent_adolescent, good_riddance, green_squirrel, heavy_rotation, high_hopes, little_lies, national_anthem, new_rules, ominous_ox, plastic_beach, popular_monster, revolving_door, smol_cat, teen_spirit, twin_flame, yellow_submarine                  |
+| **Level of Analysis** | cm            |
+| **Targets**         | lr_ged_sb |
+| **Aggregation**       |  mean   |
+| **Metrics**       |  MSLE, MSE, MCR_point, y_hat_bar    |
+| **Deployment Status**       |  shadow    |
+
+## Repository Structure
+
+```
+Chunky Bunny
+├── README.md
+├── main.py
+├── requirements.txt
+├── run.sh
+├── logs
+├── artifacts
+├── configs
+│   ├── config_deployment.py
+│   ├── config_hyperparameters.py
+│   ├── config_meta.py
+│   ├── config_modelset.py
+│   ├── config_partitions.py
+├── data
+│   ├── generated
+│   ├── processed
+├── reports
+```
+
+## Setup Instructions
+
+Clone the [views-pipeline-core](https://github.com/views-platform/views-pipeline-core) and the [views-models](https://github.com/views-platform/views-models) repository.
+
+
+## Usage
+Modify configurations in configs/.
+
+If you already have an existing environment, run the `main.py` file. If you don't have an existing environment, run the `run.sh` file.
+
+```
+python main.py -r calibration -t -e -re
+
+or
+
+./run.sh -r calibration -t -e -re
+```

--- a/ensembles/chunky_bunny/configs/config_deployment.py
+++ b/ensembles/chunky_bunny/configs/config_deployment.py
@@ -1,0 +1,20 @@
+"""
+Deployment Configuration Script
+
+This script defines the deployment configuration settings for the application. 
+It includes the deployment status and any additional settings specified.
+
+Deployment Status:
+- shadow: The deployment is shadowed and not yet active.
+- deployed: The deployment is active and in use.
+- baseline: The deployment is in a baseline state, for reference or comparison.
+- deprecated: The deployment is deprecated and no longer supported.
+
+Additional settings can be included in the configuration dictionary as needed.
+
+"""
+
+def get_deployment_config():
+    # Deployment settings
+    deployment_config = {'deployment_status': 'shadow'}
+    return deployment_config

--- a/ensembles/chunky_bunny/configs/config_hyperparameters.py
+++ b/ensembles/chunky_bunny/configs/config_hyperparameters.py
@@ -1,0 +1,5 @@
+def get_hp_config(): 
+    hp_config = {
+        "steps": [*range(1, 36 + 1, 1)]
+    }
+    return hp_config

--- a/ensembles/chunky_bunny/configs/config_meta.py
+++ b/ensembles/chunky_bunny/configs/config_meta.py
@@ -1,0 +1,19 @@
+def get_meta_config():
+    """
+    Contains the metadata for the model (model architecture, name, target variable, and level of analysis).
+    This config is for documentation purposes only, and modifying it will not affect the model, the training, or the evaluation.
+
+    Returns:
+    - meta_config (dict): A dictionary containing model meta configuration.
+    """
+    meta_config = {
+        "name": "chunky_bunny",
+        "regression_targets": ["lr_ged_sb"],
+        "level": "cm",
+        "aggregation": "mean",
+        "regression_point_baselines": ["average_cmbaseline", "zero_cmbaseline", "locf_cmbaseline"],
+        "regression_point_metrics": ["MSLE", "MSE", "MCR_point", "y_hat_bar"],
+        "creator": "Simon",
+        "reconciliation": None,
+    }
+    return meta_config

--- a/ensembles/chunky_bunny/configs/config_modelset.py
+++ b/ensembles/chunky_bunny/configs/config_modelset.py
@@ -1,0 +1,41 @@
+def get_modelset_config():
+    """
+    Contains the list of constituent models for the ensemble.
+
+    Returns:
+    - modelset_config (dict): A dictionary with the key 'models' listing constituent model names.
+
+    Note:
+        chunky_bunny is a clone of the original ``big_chungus`` ensemble (the
+        2026-06-04 calibration run): the full 23 constituents — 13 plain
+        stepshifters + 6 Hurdle stepshifters + 4 deep-learning models — as opposed
+        to ``pink_ponyclub`` which carries only the 19 stepshifter constituents.
+    """
+    modelset_config = {
+        "models": [
+            "bittersweet_symphony",
+            "brown_cheese",
+            "car_radio",
+            "counting_stars",
+            "demon_days",
+            "elastic_heart",
+            "fast_car",
+            "fluorescent_adolescent",
+            "good_riddance",
+            "green_squirrel",
+            "heavy_rotation",
+            "high_hopes",
+            "little_lies",
+            "national_anthem",
+            "new_rules",
+            "ominous_ox",
+            "plastic_beach",
+            "popular_monster",
+            "revolving_door",
+            "smol_cat",
+            "teen_spirit",
+            "twin_flame",
+            "yellow_submarine",
+        ],
+    }
+    return modelset_config

--- a/ensembles/chunky_bunny/configs/config_partitions.py
+++ b/ensembles/chunky_bunny/configs/config_partitions.py
@@ -1,0 +1,50 @@
+from datetime import date
+
+
+def _current_month_id() -> int:
+    """VIEWS month_id for the current calendar month. Epoch: January 1980."""
+    today = date.today()
+    return (today.year - 1980) * 12 + today.month
+
+
+
+def generate(steps: int = 36) -> dict:
+    """
+    Generates partition configurations for different phases of model evaluation.
+
+    Returns:
+        dict: A dictionary with keys 'calibration', 'validation', and 'forecasting', each containing
+            'train' and 'test' tuples or callables specifying the index ranges for training and testing data.
+
+    Partition details:
+        - 'calibration': Uses fixed index ranges for training and testing.
+        - 'validation': Uses fixed index ranges for training and testing.
+        - 'forecasting': Uses the current month to dynamically determine training and testing index ranges.
+
+    Note:
+        - The 'forecasting' partition's 'train' and 'test' ranges are computed from the current month.
+    """
+
+    def forecasting_train_range():
+        month_last = _current_month_id() - 1
+        return (121, month_last)
+
+    def forecasting_test_range(steps):
+        month_last = _current_month_id() - 1
+        return (month_last + 1, month_last + 1 + steps)
+
+    return {
+        "calibration": {
+            "train": (121, 444),
+            "test": (445, 492),
+        },
+        "validation": {
+            "train": (121, 492),
+            "test": (493, 540),
+        },
+        "forecasting": {
+            "train": forecasting_train_range(),
+            "test": forecasting_test_range(steps=steps),
+        },
+    }
+

--- a/ensembles/chunky_bunny/main.py
+++ b/ensembles/chunky_bunny/main.py
@@ -1,0 +1,20 @@
+from pathlib import Path
+from views_pipeline_core.cli import ForecastingModelArgs
+from views_pipeline_core.managers.ensemble import EnsemblePathManager, EnsembleManager
+
+try:
+    ensemble_path = EnsemblePathManager(Path(__file__))
+except Exception as e:
+    raise RuntimeError(f"Unexpected error: {e}. Check the logs for details.")
+
+if __name__ == "__main__":
+    args = ForecastingModelArgs.parse_args()
+
+    manager = EnsembleManager(
+        ensemble_path=ensemble_path,
+        wandb_notifications=args.wandb_notifications,
+        use_prediction_store=args.prediction_store,
+    )
+
+    manager.execute_single_run(args)
+

--- a/ensembles/chunky_bunny/requirements.txt
+++ b/ensembles/chunky_bunny/requirements.txt
@@ -1,0 +1,1 @@
+views-pipeline-core>=2.0.0,<3.0.0

--- a/ensembles/chunky_bunny/run.sh
+++ b/ensembles/chunky_bunny/run.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+
+if [[ "$OSTYPE" == "darwin"* ]]; then
+  if ! grep -q 'export LDFLAGS="-L/opt/homebrew/opt/libomp/lib"' ~/.zshrc; then
+    echo 'export LDFLAGS="-L/opt/homebrew/opt/libomp/lib"' >> ~/.zshrc
+  fi
+  if ! grep -q 'export CPPFLAGS="-I/opt/homebrew/opt/libomp/include"' ~/.zshrc; then
+    echo 'export CPPFLAGS="-I/opt/homebrew/opt/libomp/include"' >> ~/.zshrc
+  fi
+  if ! grep -q 'export DYLD_LIBRARY_PATH="/opt/homebrew/opt/libomp/lib:$DYLD_LIBRARY_PATH"' ~/.zshrc; then
+    echo 'export DYLD_LIBRARY_PATH="/opt/homebrew/opt/libomp/lib:$DYLD_LIBRARY_PATH"' >> ~/.zshrc
+  fi
+  source ~/.zshrc
+fi
+
+script_path=$(dirname "$(realpath $0)")
+project_path="$( cd "$script_path/../../" >/dev/null 2>&1 && pwd )"
+env_path="$project_path/envs/views_ensemble"
+
+eval "$(conda shell.bash hook)"
+
+if [ -d "$env_path" ]; then
+  echo "Conda environment already exists at $env_path. Checking dependencies..."
+  conda activate "$env_path"
+  echo "$env_path is activated"
+
+  missing_packages=$(pip install --dry-run -r $script_path/requirements.txt 2>&1 | grep -v "Requirement already satisfied" | wc -l)
+  if [ "$missing_packages" -gt 0 ]; then
+    echo "Installing missing or outdated packages..."
+    pip install -r $script_path/requirements.txt
+  else
+    echo "All packages are up-to-date."
+  fi
+else
+  echo "Creating new Conda environment at $env_path..."
+  conda create --prefix "$env_path" python=3.11 -y
+  conda activate "$env_path"
+  pip install -r $script_path/requirements.txt
+fi
+
+echo "Running $script_path/main.py "
+python $script_path/main.py "$@"

--- a/models/bad_blood/configs/config_hyperparameters.py
+++ b/models/bad_blood/configs/config_hyperparameters.py
@@ -9,6 +9,7 @@ def get_hp_config():
     """
     
     hyperparameters = {
+        "target_transform": "identity",
         'steps': [*range(1, 36 + 1, 1)],
         "time_steps": 36,
         'parameters': {

--- a/models/bittersweet_symphony/configs/config_hyperparameters.py
+++ b/models/bittersweet_symphony/configs/config_hyperparameters.py
@@ -9,6 +9,7 @@ def get_hp_config():
     """
     
     hyperparameters = {
+        "target_transform": "identity",
         "steps": [*range(1, 36 + 1, 1)],
         "time_steps": 36,
         "parameters": {

--- a/models/bittersweet_symphony/configs/config_hyperparameters.py
+++ b/models/bittersweet_symphony/configs/config_hyperparameters.py
@@ -9,7 +9,7 @@ def get_hp_config():
     """
     
     hyperparameters = {
-        "target_transform": "identity",
+        "target_transform": "log1p",
         "steps": [*range(1, 36 + 1, 1)],
         "time_steps": 36,
         "parameters": {

--- a/models/bittersweet_symphony/configs/config_meta.py
+++ b/models/bittersweet_symphony/configs/config_meta.py
@@ -11,7 +11,7 @@ def get_meta_config():
         "name": "bittersweet_symphony", 
         "algorithm": "XGBRegressor",
         "regression_point_baselines": ["average_cmbaseline", "zero_cmbaseline", "locf_cmbaseline"],
-        "regression_point_metrics": ["RMSLE", "MSE", "MSLE", "y_hat_bar"],
+        "regression_point_metrics": ["MSLE", "MSE", "MCR_point", "y_hat_bar"],
         "regression_targets": ["lr_ged_sb"],
         "queryset": "fatalities003_all_features",
         "level": "cm",

--- a/models/blank_space/configs/config_hyperparameters.py
+++ b/models/blank_space/configs/config_hyperparameters.py
@@ -1,5 +1,6 @@
 def get_hp_config(): 
     hp_config = {
+        "target_transform": "identity",
         "steps": [*range(1, 36 + 1, 1)],
         "time_steps": 36,
         "parameters": {

--- a/models/brown_cheese/configs/config_hyperparameters.py
+++ b/models/brown_cheese/configs/config_hyperparameters.py
@@ -9,6 +9,7 @@ def get_hp_config():
     """
     
     hyperparameters = {
+        "target_transform": "identity",
         "steps": [*range(1, 36 + 1, 1)],
         "time_steps": 36,
         "parameters": {

--- a/models/brown_cheese/configs/config_hyperparameters.py
+++ b/models/brown_cheese/configs/config_hyperparameters.py
@@ -9,7 +9,7 @@ def get_hp_config():
     """
     
     hyperparameters = {
-        "target_transform": "identity",
+        "target_transform": "log1p",
         "steps": [*range(1, 36 + 1, 1)],
         "time_steps": 36,
         "parameters": {

--- a/models/brown_cheese/configs/config_meta.py
+++ b/models/brown_cheese/configs/config_meta.py
@@ -11,7 +11,7 @@ def get_meta_config():
         "name": "brown_cheese", 
         "algorithm": "XGBRFRegressor",
         "regression_point_baselines": ["average_cmbaseline", "zero_cmbaseline", "locf_cmbaseline"],
-        "regression_point_metrics": ["RMSLE", "MSE", "MSLE", "y_hat_bar"],
+        "regression_point_metrics": ["MSLE", "MSE", "MCR_point", "y_hat_bar"],
         "regression_targets": ["lr_ged_sb"],
         "queryset": "fatalities003_baseline",
         "level": "cm",

--- a/models/car_radio/configs/config_hyperparameters.py
+++ b/models/car_radio/configs/config_hyperparameters.py
@@ -9,6 +9,7 @@ def get_hp_config():
     """
     
     hyperparameters = {
+        "target_transform": "identity",
         "steps": [*range(1, 36 + 1, 1)],
         "time_steps": 36,
         "parameters": {

--- a/models/car_radio/configs/config_hyperparameters.py
+++ b/models/car_radio/configs/config_hyperparameters.py
@@ -9,7 +9,7 @@ def get_hp_config():
     """
     
     hyperparameters = {
-        "target_transform": "identity",
+        "target_transform": "log1p",
         "steps": [*range(1, 36 + 1, 1)],
         "time_steps": 36,
         "parameters": {

--- a/models/car_radio/configs/config_meta.py
+++ b/models/car_radio/configs/config_meta.py
@@ -11,7 +11,7 @@ def get_meta_config():
         "name": "car_radio", 
         "algorithm": "XGBRegressor",
         "regression_point_baselines": ["average_cmbaseline", "zero_cmbaseline", "locf_cmbaseline"],
-        "regression_point_metrics": ["RMSLE", "MSE", "MSLE", "y_hat_bar"],
+        "regression_point_metrics": ["MSLE", "MSE", "MCR_point", "y_hat_bar"],
         "regression_targets": ["lr_ged_sb"],
         "queryset": "fatalities003_topics",
         "level": "cm",

--- a/models/caring_fish/configs/config_hyperparameters.py
+++ b/models/caring_fish/configs/config_hyperparameters.py
@@ -9,6 +9,7 @@ def get_hp_config():
     """
     
     hyperparameters = {
+        "target_transform": "identity",
         'steps': [*range(1, 36 + 1, 1)],
         "time_steps": 36,
         'parameters': {

--- a/models/cheap_thrills/configs/config_hyperparameters.py
+++ b/models/cheap_thrills/configs/config_hyperparameters.py
@@ -9,6 +9,7 @@ def get_hp_config():
     """
     
     hyperparameters = {
+        "target_transform": "identity",
         'steps': [*range(1, 36 + 1, 1)],
         "time_steps": 36,
         'submodels_to_train': 50,

--- a/models/cheap_thrills/configs/config_meta.py
+++ b/models/cheap_thrills/configs/config_meta.py
@@ -17,7 +17,7 @@ def get_meta_config():
         "model_reg": "XGBRegressor",
         "model_clf": "XGBClassifier",
         "regression_point_baselines": ["average_cmbaseline", "zero_cmbaseline", "locf_cmbaseline"],
-        "regression_point_metrics": ["RMSLE", "MSE", "MSLE", "y_hat_bar"],
+        "regression_point_metrics": ["MSLE", "MSE", "MCR_point", "y_hat_bar"],
         "queryset": "structural_brief_nolog",
         "rolling_origin_stride": 1,
     }

--- a/models/chunky_cat/configs/config_hyperparameters.py
+++ b/models/chunky_cat/configs/config_hyperparameters.py
@@ -9,6 +9,7 @@ def get_hp_config():
     """
     
     hyperparameters = {
+        "target_transform": "identity",
         'steps': [*range(1, 36 + 1, 1)],
         "time_steps": 36,
         'parameters': {

--- a/models/counting_stars/configs/config_hyperparameters.py
+++ b/models/counting_stars/configs/config_hyperparameters.py
@@ -9,6 +9,7 @@ def get_hp_config():
     """
     
     hyperparameters = {
+        "target_transform": "identity",
         "steps": [*range(1, 36 + 1, 1)],
         "time_steps": 36,
         "parameters": {

--- a/models/counting_stars/configs/config_hyperparameters.py
+++ b/models/counting_stars/configs/config_hyperparameters.py
@@ -9,7 +9,7 @@ def get_hp_config():
     """
     
     hyperparameters = {
-        "target_transform": "identity",
+        "target_transform": "log1p",
         "steps": [*range(1, 36 + 1, 1)],
         "time_steps": 36,
         "parameters": {

--- a/models/counting_stars/configs/config_meta.py
+++ b/models/counting_stars/configs/config_meta.py
@@ -11,7 +11,7 @@ def get_meta_config():
         "name": "counting_stars", 
         "algorithm": "XGBRegressor",
         "regression_point_baselines": ["average_cmbaseline", "zero_cmbaseline", "locf_cmbaseline"],
-        "regression_point_metrics": ["RMSLE", "MSE", "MSLE", "y_hat_bar"],
+        "regression_point_metrics": ["MSLE", "MSE", "MCR_point", "y_hat_bar"],
         "regression_targets": ["lr_ged_sb"],
         "queryset": "fatalities003_conflict_history_long",
         "level": "cm",

--- a/models/dark_paradise/configs/config_hyperparameters.py
+++ b/models/dark_paradise/configs/config_hyperparameters.py
@@ -9,6 +9,7 @@ def get_hp_config():
     """
     
     hyperparameters = {
+        "target_transform": "identity",
         "steps": [*range(1, 36 + 1, 1)],
         "time_steps": 36,
         "parameters": {

--- a/models/demon_days/configs/config_hyperparameters.py
+++ b/models/demon_days/configs/config_hyperparameters.py
@@ -9,6 +9,7 @@ def get_hp_config():
     """
     
     hyperparameters = {
+        "target_transform": "identity",
         "steps": [*range(1, 36 + 1, 1)],
         "time_steps": 36,
         "parameters": {

--- a/models/demon_days/configs/config_hyperparameters.py
+++ b/models/demon_days/configs/config_hyperparameters.py
@@ -9,7 +9,7 @@ def get_hp_config():
     """
     
     hyperparameters = {
-        "target_transform": "identity",
+        "target_transform": "log1p",
         "steps": [*range(1, 36 + 1, 1)],
         "time_steps": 36,
         "parameters": {

--- a/models/demon_days/configs/config_meta.py
+++ b/models/demon_days/configs/config_meta.py
@@ -11,7 +11,7 @@ def get_meta_config():
         "name": "demon_days", 
         "algorithm": "XGBRFRegressor",
         "regression_point_baselines": ["average_cmbaseline", "zero_cmbaseline", "locf_cmbaseline"],
-        "regression_point_metrics": ["RMSLE", "MSE", "MSLE", "y_hat_bar"],
+        "regression_point_metrics": ["MSLE", "MSE", "MCR_point", "y_hat_bar"],
         "regression_targets": ["lr_ged_sb"],
         "queryset": "fatalities003_faostat",
         "level": "cm",

--- a/models/fast_car/configs/config_hyperparameters.py
+++ b/models/fast_car/configs/config_hyperparameters.py
@@ -9,6 +9,7 @@ def get_hp_config():
     """
     
     hyperparameters = {
+        "target_transform": "identity",
         "steps": [*range(1, 36 + 1, 1)],
         "time_steps": 36,
         "parameters": {

--- a/models/fast_car/configs/config_meta.py
+++ b/models/fast_car/configs/config_meta.py
@@ -13,7 +13,7 @@ def get_meta_config():
         "model_clf": "XGBClassifier",
         "model_reg": "XGBRegressor",
         "regression_point_baselines": ["average_cmbaseline", "zero_cmbaseline", "locf_cmbaseline"],
-        "regression_point_metrics": ["RMSLE", "MSE", "MSLE", "y_hat_bar"],
+        "regression_point_metrics": ["MSLE", "MSE", "MCR_point", "y_hat_bar"],
         "regression_targets": ["lr_ged_sb"],
         "queryset": "fatalities003_vdem_short",
         "level": "cm",

--- a/models/fluorescent_adolescent/configs/config_hyperparameters.py
+++ b/models/fluorescent_adolescent/configs/config_hyperparameters.py
@@ -9,6 +9,7 @@ def get_hp_config():
     """
     
     hyperparameters = {
+        "target_transform": "identity",
         "steps": [*range(1, 36 + 1, 1)],
         "time_steps": 36,
         "parameters": {

--- a/models/fluorescent_adolescent/configs/config_meta.py
+++ b/models/fluorescent_adolescent/configs/config_meta.py
@@ -13,7 +13,7 @@ def get_meta_config():
         "model_clf": "XGBClassifier", 
         "model_reg": "XGBRegressor",
         "regression_point_baselines": ["average_cmbaseline", "zero_cmbaseline", "locf_cmbaseline"],
-        "regression_point_metrics": ["RMSLE", "MSE", "MSLE", "y_hat_bar"],
+        "regression_point_metrics": ["MSLE", "MSE", "MCR_point", "y_hat_bar"],
         "regression_targets": ["lr_ged_sb"],
         "queryset": "fatalities003_joint_narrow",
         "level": "cm",

--- a/models/fourtieth_symphony/configs/config_hyperparameters.py
+++ b/models/fourtieth_symphony/configs/config_hyperparameters.py
@@ -9,6 +9,7 @@ def get_hp_config():
     """
     
     hyperparameters = {
+        "target_transform": "identity",
         'steps': [*range(1, 36 + 1, 1)],
         "time_steps": 36,
         'submodels_to_train': 20,

--- a/models/fourtieth_symphony/configs/config_hyperparameters.py
+++ b/models/fourtieth_symphony/configs/config_hyperparameters.py
@@ -14,7 +14,7 @@ def get_hp_config():
         "time_steps": 36,
         'submodels_to_train': 20,
         'pred_samples': 10,
-        'log_target': True,
+        'log_target': False,
         'draw_dist': 'Lognormal',
         'draw_sigma': 0.5,
         'geo_unit_samples': 1.0,

--- a/models/fourtieth_symphony/configs/config_meta.py
+++ b/models/fourtieth_symphony/configs/config_meta.py
@@ -17,7 +17,7 @@ def get_meta_config():
         "model_reg": "XGBRegressor",
         "model_clf": "XGBClassifier",
         "regression_point_baselines": ["average_cmbaseline", "zero_cmbaseline", "locf_cmbaseline"],
-        "regression_point_metrics": ["RMSLE", "MSE", "MSLE", "y_hat_bar"],
+        "regression_point_metrics": ["MSLE", "MSE", "MCR_point", "y_hat_bar"],
         "queryset": "uncertainty_broad_nolog",
         "rolling_origin_stride": 1,
     }

--- a/models/good_riddance/configs/config_hyperparameters.py
+++ b/models/good_riddance/configs/config_hyperparameters.py
@@ -9,6 +9,7 @@ def get_hp_config():
     """
     
     hyperparameters = {
+        "target_transform": "identity",
         "steps": [*range(1, 36 + 1, 1)],
         "time_steps": 36,
         "parameters": {

--- a/models/good_riddance/configs/config_hyperparameters.py
+++ b/models/good_riddance/configs/config_hyperparameters.py
@@ -9,7 +9,7 @@ def get_hp_config():
     """
     
     hyperparameters = {
-        "target_transform": "identity",
+        "target_transform": "log1p",
         "steps": [*range(1, 36 + 1, 1)],
         "time_steps": 36,
         "parameters": {

--- a/models/good_riddance/configs/config_meta.py
+++ b/models/good_riddance/configs/config_meta.py
@@ -11,7 +11,7 @@ def get_meta_config():
         "name": "good_riddance", 
         "algorithm": "XGBRFRegressor",
         "regression_point_baselines": ["average_cmbaseline", "zero_cmbaseline", "locf_cmbaseline"],
-        "regression_point_metrics": ["RMSLE", "MSE", "MSLE", "y_hat_bar"],
+        "regression_point_metrics": ["MSLE", "MSE", "MCR_point", "y_hat_bar"],
         "regression_targets": ["lr_ged_sb"],
         "queryset": "fatalities003_joint_narrow",
         "level": "cm",

--- a/models/green_squirrel/configs/config_hyperparameters.py
+++ b/models/green_squirrel/configs/config_hyperparameters.py
@@ -9,6 +9,7 @@ def get_hp_config():
     """
     
     hyperparameters = {
+        "target_transform": "identity",
         "steps": [*range(1, 36 + 1, 1)],
         "time_steps": 36,
         "parameters": {

--- a/models/green_squirrel/configs/config_meta.py
+++ b/models/green_squirrel/configs/config_meta.py
@@ -13,7 +13,7 @@ def get_meta_config():
         "model_clf": "XGBRFClassifier",
         "model_reg": "XGBRFRegressor",
         "regression_point_baselines": ["average_cmbaseline", "zero_cmbaseline", "locf_cmbaseline"],
-        "regression_point_metrics": ["RMSLE", "MSE", "MSLE", "y_hat_bar"],
+        "regression_point_metrics": ["MSLE", "MSE", "MCR_point", "y_hat_bar"],
         "regression_targets": ["lr_ged_sb"],
         "queryset": "fatalities003_joint_broad",
         "level": "cm",

--- a/models/heavy_rotation/configs/config_hyperparameters.py
+++ b/models/heavy_rotation/configs/config_hyperparameters.py
@@ -9,6 +9,7 @@ def get_hp_config():
     """
     
     hyperparameters = {
+        "target_transform": "identity",
         "steps": [*range(1, 36 + 1, 1)],
         "time_steps": 36,
         "parameters": {

--- a/models/heavy_rotation/configs/config_hyperparameters.py
+++ b/models/heavy_rotation/configs/config_hyperparameters.py
@@ -9,7 +9,7 @@ def get_hp_config():
     """
     
     hyperparameters = {
-        "target_transform": "identity",
+        "target_transform": "log1p",
         "steps": [*range(1, 36 + 1, 1)],
         "time_steps": 36,
         "parameters": {

--- a/models/heavy_rotation/configs/config_meta.py
+++ b/models/heavy_rotation/configs/config_meta.py
@@ -11,7 +11,7 @@ def get_meta_config():
         "name": "heavy_rotation", 
         "algorithm": "XGBRFRegressor",
         "regression_point_baselines": ["average_cmbaseline", "zero_cmbaseline", "locf_cmbaseline"],
-        "regression_point_metrics": ["RMSLE", "MSE", "MSLE", "y_hat_bar"],
+        "regression_point_metrics": ["MSLE", "MSE", "MCR_point", "y_hat_bar"],
         "regression_targets": ["lr_ged_sb"],
         "queryset": "fatalities003_joint_broad",
         "level": "cm",

--- a/models/high_hopes/configs/config_hyperparameters.py
+++ b/models/high_hopes/configs/config_hyperparameters.py
@@ -9,6 +9,7 @@ def get_hp_config():
     """
     
     hyperparameters = {
+        "target_transform": "identity",
         'steps': [*range(1, 36 + 1, 1)],
         "time_steps": 36,
         "parameters": {

--- a/models/high_hopes/configs/config_meta.py
+++ b/models/high_hopes/configs/config_meta.py
@@ -13,7 +13,7 @@ def get_meta_config():
         "model_clf": "LGBMClassifier",
         "model_reg": "LGBMRegressor",
         "regression_point_baselines": ["average_cmbaseline", "zero_cmbaseline", "locf_cmbaseline"],
-        "regression_point_metrics": ["RMSLE", "MSE", "MSLE", "y_hat_bar"],
+        "regression_point_metrics": ["MSLE", "MSE", "MCR_point", "y_hat_bar"],
         "regression_targets": ["lr_ged_sb"],
         "queryset": "fatalities003_conflict_history",
         "level": "cm",

--- a/models/invisible_string/configs/config_hyperparameters.py
+++ b/models/invisible_string/configs/config_hyperparameters.py
@@ -9,6 +9,7 @@ def get_hp_config():
     """
     
     hyperparameters = {
+        "target_transform": "identity",
         'steps': [*range(1, 36 + 1, 1)],
         "time_steps": 36,
         'parameters': {

--- a/models/lavender_haze/configs/config_hyperparameters.py
+++ b/models/lavender_haze/configs/config_hyperparameters.py
@@ -1,5 +1,6 @@
 def get_hp_config(): 
     hp_config = {
+        "target_transform": "identity",
         "steps": [*range(1, 36 + 1, 1)],
         "time_steps": 36,
         "parameters": {

--- a/models/little_lies/configs/config_hyperparameters.py
+++ b/models/little_lies/configs/config_hyperparameters.py
@@ -9,6 +9,7 @@ def get_hp_config():
     """
     
     hyperparameters = {
+        "target_transform": "identity",
         "steps": [*range(1, 36 + 1, 1)],
         "time_steps": 36,
         "parameters": {

--- a/models/little_lies/configs/config_meta.py
+++ b/models/little_lies/configs/config_meta.py
@@ -13,7 +13,7 @@ def get_meta_config():
         "model_clf": "LGBMClassifier", 
         "model_reg": "LGBMRegressor",
         "regression_point_baselines": ["average_cmbaseline", "zero_cmbaseline", "locf_cmbaseline"],
-        "regression_point_metrics": ["RMSLE", "MSE", "MSLE", "y_hat_bar"],
+        "regression_point_metrics": ["MSLE", "MSE", "MCR_point", "y_hat_bar"],
         "regression_targets": ["lr_ged_sb"],
         "queryset": "fatalities003_joint_narrow",
         "level": "cm",

--- a/models/lovely_creature/configs/config_hyperparameters.py
+++ b/models/lovely_creature/configs/config_hyperparameters.py
@@ -9,6 +9,7 @@ def get_hp_config():
     """
     
     hyperparameters = {
+        "target_transform": "identity",
         'steps': [*range(1, 36 + 1, 1)],
         "time_steps": 36,
         'submodels_to_train': 50,

--- a/models/lovely_creature/configs/config_meta.py
+++ b/models/lovely_creature/configs/config_meta.py
@@ -17,7 +17,7 @@ def get_meta_config():
         "model_reg": "XGBRegressor",
         "model_clf": "XGBClassifier",
         "regression_point_baselines": ["average_cmbaseline", "zero_cmbaseline", "locf_cmbaseline"],
-        "regression_point_metrics": ["RMSLE", "MSE", "MSLE", "y_hat_bar"],
+        "regression_point_metrics": ["MSLE", "MSE", "MCR_point", "y_hat_bar"],
         "queryset": "uncertainty_broad_nolog",
         "rolling_origin_stride": 1,
     }

--- a/models/midnight_rain/configs/config_hyperparameters.py
+++ b/models/midnight_rain/configs/config_hyperparameters.py
@@ -9,6 +9,7 @@ def get_hp_config():
     """
     
     hyperparameters = {
+        "target_transform": "identity",
         'steps': [*range(1, 36 + 1, 1)],
         "time_steps": 36,
          'parameters': {

--- a/models/national_anthem/configs/config_hyperparameters.py
+++ b/models/national_anthem/configs/config_hyperparameters.py
@@ -9,6 +9,7 @@ def get_hp_config():
     """
     
     hyperparameters = {
+        "target_transform": "identity",
         "steps": [*range(1, 36 + 1, 1)],
         "time_steps": 36,
         "parameters": {

--- a/models/national_anthem/configs/config_hyperparameters.py
+++ b/models/national_anthem/configs/config_hyperparameters.py
@@ -9,7 +9,7 @@ def get_hp_config():
     """
     
     hyperparameters = {
-        "target_transform": "identity",
+        "target_transform": "log1p",
         "steps": [*range(1, 36 + 1, 1)],
         "time_steps": 36,
         "parameters": {

--- a/models/national_anthem/configs/config_meta.py
+++ b/models/national_anthem/configs/config_meta.py
@@ -11,7 +11,7 @@ def get_meta_config():
         "name": "national_anthem", 
         "algorithm": "XGBRFRegressor",
         "regression_point_baselines": ["average_cmbaseline", "zero_cmbaseline", "locf_cmbaseline"],
-        "regression_point_metrics": ["RMSLE", "MSE", "MSLE", "y_hat_bar"],
+        "regression_point_metrics": ["MSLE", "MSE", "MCR_point", "y_hat_bar"],
         "regression_targets": ["lr_ged_sb"],
         "queryset": "fatalities003_wdi_short",
         "level": "cm",

--- a/models/old_money/configs/config_hyperparameters.py
+++ b/models/old_money/configs/config_hyperparameters.py
@@ -1,5 +1,6 @@
 def get_hp_config(): 
     hp_config = {
+        "target_transform": "identity",
         "steps": [*range(1, 36 + 1, 1)],
         "time_steps": 36,
         "parameters": {

--- a/models/ominous_ox/configs/config_hyperparameters.py
+++ b/models/ominous_ox/configs/config_hyperparameters.py
@@ -9,7 +9,7 @@ def get_hp_config():
     """
     
     hyperparameters = {
-        "target_transform": "identity",
+        "target_transform": "log1p",
         'steps': [*range(1, 36 + 1, 1)],
         "time_steps": 36,
         "parameters": {

--- a/models/ominous_ox/configs/config_hyperparameters.py
+++ b/models/ominous_ox/configs/config_hyperparameters.py
@@ -9,6 +9,7 @@ def get_hp_config():
     """
     
     hyperparameters = {
+        "target_transform": "identity",
         'steps': [*range(1, 36 + 1, 1)],
         "time_steps": 36,
         "parameters": {

--- a/models/ominous_ox/configs/config_meta.py
+++ b/models/ominous_ox/configs/config_meta.py
@@ -11,7 +11,7 @@ def get_meta_config():
         "name": "ominous_ox", 
         "algorithm": "XGBRFRegressor",
         "regression_point_baselines": ["average_cmbaseline", "zero_cmbaseline", "locf_cmbaseline"],
-        "regression_point_metrics": ["RMSLE", "MSE", "MSLE", "y_hat_bar"],
+        "regression_point_metrics": ["MSLE", "MSE", "MCR_point", "y_hat_bar"],
         "regression_targets": ["lr_ged_sb"],
         "queryset": "fatalities003_conflict_history",
         "level": "cm",

--- a/models/orange_pasta/configs/config_hyperparameters.py
+++ b/models/orange_pasta/configs/config_hyperparameters.py
@@ -1,5 +1,6 @@
 def get_hp_config(): 
     hp_config = {
+        "target_transform": "identity",
         "steps": [*range(1, 36 + 1, 1)],
         "time_steps": 36,
         "parameters": {

--- a/models/plastic_beach/configs/config_hyperparameters.py
+++ b/models/plastic_beach/configs/config_hyperparameters.py
@@ -9,6 +9,7 @@ def get_hp_config():
     """
     
     hyperparameters = {
+        "target_transform": "identity",
         "steps": [*range(1, 36 + 1, 1)],
         "time_steps": 36,
         "parameters": {

--- a/models/plastic_beach/configs/config_hyperparameters.py
+++ b/models/plastic_beach/configs/config_hyperparameters.py
@@ -9,7 +9,7 @@ def get_hp_config():
     """
     
     hyperparameters = {
-        "target_transform": "identity",
+        "target_transform": "log1p",
         "steps": [*range(1, 36 + 1, 1)],
         "time_steps": 36,
         "parameters": {

--- a/models/plastic_beach/configs/config_meta.py
+++ b/models/plastic_beach/configs/config_meta.py
@@ -11,7 +11,7 @@ def get_meta_config():
         "name": "plastic_beach", 
         "algorithm": "XGBRFRegressor",
         "regression_point_baselines": ["average_cmbaseline", "zero_cmbaseline", "locf_cmbaseline"],
-        "regression_point_metrics": ["RMSLE", "MSE", "MSLE", "y_hat_bar"],
+        "regression_point_metrics": ["MSLE", "MSE", "MCR_point", "y_hat_bar"],
         "regression_targets": ["lr_ged_sb"],
         "queryset": "fatalities003_aquastat",
         "level": "cm",

--- a/models/popular_monster/configs/config_hyperparameters.py
+++ b/models/popular_monster/configs/config_hyperparameters.py
@@ -9,6 +9,7 @@ def get_hp_config():
     """
     
     hyperparameters = {
+        "target_transform": "identity",
         "steps": [*range(1, 36 + 1, 1)],
         "time_steps": 36,
         "parameters": {

--- a/models/popular_monster/configs/config_hyperparameters.py
+++ b/models/popular_monster/configs/config_hyperparameters.py
@@ -9,7 +9,7 @@ def get_hp_config():
     """
     
     hyperparameters = {
-        "target_transform": "identity",
+        "target_transform": "log1p",
         "steps": [*range(1, 36 + 1, 1)],
         "time_steps": 36,
         "parameters": {

--- a/models/popular_monster/configs/config_meta.py
+++ b/models/popular_monster/configs/config_meta.py
@@ -11,7 +11,7 @@ def get_meta_config():
         "name": "popular_monster", 
         "algorithm": "XGBRFRegressor",
         "regression_point_baselines": ["average_cmbaseline", "zero_cmbaseline", "locf_cmbaseline"],
-        "regression_point_metrics": ["RMSLE", "MSE", "MSLE", "y_hat_bar"],
+        "regression_point_metrics": ["MSLE", "MSE", "MCR_point", "y_hat_bar"],
         "regression_targets": ["lr_ged_sb"],
         "queryset": "fatalities003_topics",
         "level": "cm",

--- a/models/purple_haze/configs/config_hyperparameters.py
+++ b/models/purple_haze/configs/config_hyperparameters.py
@@ -9,6 +9,7 @@ def get_hp_config():
     """
     
     hyperparameters = {
+        "target_transform": "identity",
         'steps': [*range(1, 36 + 1, 1)],
         "time_steps": 36,
         'submodels_to_train': 50,

--- a/models/purple_haze/configs/config_meta.py
+++ b/models/purple_haze/configs/config_meta.py
@@ -17,7 +17,7 @@ def get_meta_config():
         "model_reg": "XGBRegressor",
         "model_clf": "XGBClassifier",
         "regression_point_baselines": ["average_cmbaseline", "zero_cmbaseline", "locf_cmbaseline"],
-        "regression_point_metrics": ["RMSLE", "MSE", "MSLE", "y_hat_bar"],
+        "regression_point_metrics": ["MSLE", "MSE", "MCR_point", "y_hat_bar"],
         "queryset": "uncertainty_broad_nolog",
         "rolling_origin_stride": 1,
     }

--- a/models/teen_spirit/configs/config_hyperparameters.py
+++ b/models/teen_spirit/configs/config_hyperparameters.py
@@ -9,6 +9,7 @@ def get_hp_config():
     """
     
     hyperparameters = {
+        "target_transform": "identity",
         "steps": [*range(1, 36 + 1, 1)],
         "time_steps": 36,
         "parameters": {

--- a/models/teen_spirit/configs/config_hyperparameters.py
+++ b/models/teen_spirit/configs/config_hyperparameters.py
@@ -9,7 +9,7 @@ def get_hp_config():
     """
     
     hyperparameters = {
-        "target_transform": "identity",
+        "target_transform": "log1p",
         "steps": [*range(1, 36 + 1, 1)],
         "time_steps": 36,
         "parameters": {

--- a/models/teen_spirit/configs/config_meta.py
+++ b/models/teen_spirit/configs/config_meta.py
@@ -11,7 +11,7 @@ def get_meta_config():
         "name": "teen_spirit", 
         "algorithm": "XGBRFRegressor",
         "regression_point_baselines": ["average_cmbaseline", "zero_cmbaseline", "locf_cmbaseline"],
-        "regression_point_metrics": ["RMSLE", "MSE", "MSLE", "y_hat_bar"],
+        "regression_point_metrics": ["MSLE", "MSE", "MCR_point", "y_hat_bar"],
         "regression_targets": ["lr_ged_sb"],
         "queryset": "fatalities003_faoprices",
         "level": "cm",

--- a/models/twin_flame/configs/config_hyperparameters.py
+++ b/models/twin_flame/configs/config_hyperparameters.py
@@ -9,6 +9,7 @@ def get_hp_config():
     """
     
     hyperparameters = {
+        "target_transform": "identity",
         "steps": [*range(1, 36 + 1, 1)],
         "time_steps": 36,
         "parameters": {

--- a/models/twin_flame/configs/config_meta.py
+++ b/models/twin_flame/configs/config_meta.py
@@ -13,7 +13,7 @@ def get_meta_config():
         "model_clf": "LGBMClassifier",
         "model_reg": "LGBMRegressor",
         "regression_point_baselines": ["average_cmbaseline", "zero_cmbaseline", "locf_cmbaseline"],
-        "regression_point_metrics": ["RMSLE", "MSE", "MSLE", "y_hat_bar"],
+        "regression_point_metrics": ["MSLE", "MSE", "MCR_point", "y_hat_bar"],
         "regression_targets": ["lr_ged_sb"],
         "queryset": "fatalities003_topics",
         "level": "cm",

--- a/models/violet_visitor/configs/config_hyperparameters.py
+++ b/models/violet_visitor/configs/config_hyperparameters.py
@@ -1,18 +1,29 @@
 
 def get_hp_config():
     """
-    Ensemble member B: "Calibration-focused" — conservative SS for MCR near 1.0.
+    C-113 SS-BASELINE + Arm-1 LOSS EXPERIMENT (2026-06-07).
 
-    Orthogonal design for golden_hour ensemble (3 HydraNet models × 16 samples = 48).
-    Based on sweep finding: epsilon_max=0.25 delivers sb MCR=1.01 (nearest to ideal).
+    Two independent things are set here — do NOT read this as an untouched baseline:
+      - Scheduled sampling: OFF (ss_epsilon_max=0.0, pure teacher forcing). This is
+        the honest zero-point for the autoregressive-runaway investigation — the
+        unfixed model, with NO exposure-bias fix mixed in.
+      - Regression loss: the Arm-1 HURDLE experiment (lognormal_nll on positive
+        cells only), NOT the tobit baseline. See the Loss Functions section below.
 
-    Diversity axes vs other members:
-    - Seeds: 42/42 (vs 4/4 and 99/99)
-    - Sigma: per-target {1.0, 0.75, 0.5} (same as member A, different from C)
-    - SS epsilon: 0.25 (vs 0.5 and 0.5) — less self-prediction, better calibration
-    - SS warmup: 15 (vs 10 and 5) — longer pure teacher forcing
-    - Dropout: 0.15 (vs 0.125 and 0.1) — more regularization, wider posteriors
-    - Sampling: sigmoid (vs threshold) — different spatial anchor selection
+    So: SS is the clean baseline, but the loss is an active experiment arm. The
+    config_sweep.py "C-113 baseline" sweep is a different setup — it keeps the
+    tobit baseline and searches dropout/learning-rate instead.
+
+    Was previously "ensemble member B" (calibration-focused) for the golden_hour
+    ensemble (3 HydraNet models × 16 samples = 48), with SS epsilon=0.25 (sweep
+    finding: epsilon_max=0.25 → sb MCR=1.01). SS was turned off for the baseline run.
+
+    Settings retained from that config:
+    - Seeds: 42/42
+    - Sigma: per-target {1.0, 0.75, 0.5}
+    - SS warmup: 15 lessons (inert while SS is off)
+    - Dropout: 0.15
+    - Sampling: sigmoid
     """
 
     hyperparameters = {
@@ -79,30 +90,34 @@ def get_hp_config():
         'time_steps': 36,
 
         # ============================================================
-        # Loss Functions — Tobit + per-target sigma (ADR-054/055)
+        # Loss Functions — Arm-1 hurdle: lognormal_nll on positive cells only
+        # (the BOUNDED last loss-level experiment — magnitude_calibration dossier
+        #  2026-06-08, issue #85). Baseline was Tobit + per-target sigma
+        #  (ADR-054/055); Tobit is censored ⇒ mutually exclusive with the hurdle
+        #  mask, so the positive-regime loss switches to lognormal_nll with a
+        #  SCALAR sigma (a per-target dict is validator-rejected for non-tobit
+        #  losses). hurdle_threshold=0 activates the C-45 positive-only mask
+        #  (training_engine.py:234-259). ONE mechanism vs the saved baseline.
         # ============================================================
-        'loss_reg': 'tobit',
-        'loss_reg_sigma': {
-            'lr_sb_best': 1.0,
-            'lr_ns_best': 0.75,
-            'lr_os_best': 0.5,
-        },
+        'loss_reg': 'lognormal_nll',
+        'loss_reg_sigma': 0.9,
+        'hurdle_threshold': 0,
         'loss_class': 'focal',
         'loss_class_alpha': 0.75,
         'loss_class_gamma': 1.5,
         'onset_bias_init': -7.0,
 
         # ============================================================
-        # Scheduled Sampling (ADR-056) — conservative for calibration
+        # Scheduled Sampling (ADR-056) — OFF (clean C-113 baseline, pure teacher forcing)
         # ============================================================
         'ss_schedule': 'linear',
         'ss_warmup_lessons': 15,
-        'ss_epsilon_max': 0.25,
+        'ss_epsilon_max': 0.0,  # 0 = scheduled sampling OFF — clean baseline (pure teacher forcing)
 
         # ============================================================
         # Strategy (Curriculum ADR 011/012 Compliance)
         # ============================================================
-        'total_lessons': 200,
+        'total_lessons': 40,
         'max_ratio': 0.95,
         'min_ratio': 0.05,
         'slope_ratio': 0.75,

--- a/models/violet_visitor/configs/config_sweep.py
+++ b/models/violet_visitor/configs/config_sweep.py
@@ -3,11 +3,11 @@ def get_sweep_config():
     """
     Contains the configuration for hyperparameter sweeps using WandB.
     This configuration is "operational" so modifying it will change the search strategy, parameter ranges, and other settings for hyperparameter tuning aimed at optimizing model performance.
-    
+
     Returns:
     - sweep_config (dict): A dictionary containing the configuration for hyperparameter sweeps, defining the methods and parameter ranges used to search for optimal hyperparameters.
     """
- 
+
     sweep_config = {
     'name': 'violet_visitor_sweep',
     'method': 'grid'
@@ -15,45 +15,110 @@ def get_sweep_config():
 
     metric = {
         'name': '36month_mean_squared_error',
-        'goal': 'minimize'   
+        'goal': 'minimize'
         }
 
     sweep_config['metric'] = metric
 
     parameters_dict = {
-        'model' : {'value' :'HydraBNUNet06_LSTM4'},
-        'weight_init' : {'value' : 'xavier_norm'}, # ['xavier_uni', 'xavier_norm', 'kaiming_uni', 'kaiming_normal']
-        'clip_grad_norm' : {'value': True},
-        'scheduler' : {'value': 'WarmupDecay'}, #CosineAnnealingLR004  'CosineAnnealingLR' 'OneCycleLR'
-        'total_hidden_channels': {'value': 32}, # you like need 32, it seems from qualitative results
-        'min_events': {'value': 5},
+
+        # ============================================================
+        # Ledger / Topology
+        # ============================================================
+        'time_col': {'value': 'month_id'},
+        'id_col': {'value': 'priogrid_gid'},
+        'spatial_cols': {'value': ['row', 'col']},
+        'identity_cols': {'value': ['month_id', 'priogrid_gid', 'c_id', 'row', 'col']},
+        'index_names': {'value': ['month_id', 'priogrid_gid']},
+        'features': {'value': ['lr_sb_best', 'lr_ns_best', 'lr_os_best']},
+        'input_channels': {'value': 3},
+        'row_offset': {'value': 87},
+        'col_offset': {'value': 310},
+        'height': {'value': 180},
+        'width': {'value': 180},
+
+        # ============================================================
+        # Model Architecture
+        # ============================================================
+        'model': {'value': 'HydraBNUNet06_LSTM4'},
+        'total_hidden_channels': {'value': 32},
+        'dropout_rate': {'values': [0.10, 0.15, 0.20]},        # SWEPT around baseline 0.15
+        'window_dim': {'value': 32},
+        'output_channels': {'value': 1},
+        'weight_init': {'value': 'xavier_norm'},
+        'h_init': {'value': 'abs_rand_exp-100'},
+
+        # ============================================================
+        # Optimization
+        # ============================================================
         'windows_per_lesson': {'value': 3},
-        'total_lessons': {'value': 150},
-        'batch_size': {'value':  3}, # just speed running here..
-        "dropout_rate" : {'value' : 0.125},
-        'learning_rate': {'value' :  0.001}, #0.001 default, but 0.005 might be better
-        "weight_decay" : {'value' : 0.1},
-        "slope_ratio" : {'value' : 0.75},
-        "roof_ratio" : {'value' :  0.7},
-        "max_ratio" : {'value' :  0.95},
-        "min_ratio" : {'value' :  0.05},
-        'input_channels' : {'value' : 3},
-        'output_channels': {'value' : 1},
+        'learning_rate': {'values': [0.0005, 0.001, 0.002]},   # SWEPT around baseline 0.001
+        'weight_decay': {'value': 0.1},
+        'scheduler': {'value': 'WarmupDecay'},
+        'warmup_steps': {'value': 100},
+        'clip_grad_norm': {'value': True},
+        'torch_seed': {'value': 42},
+        'np_seed': {'value': 42},
+
+        # ============================================================
+        # Multi-Task Signals
+        # ============================================================
         'classification_targets': {'value': ['by_sb_best', 'by_ns_best', 'by_os_best']},
         'regression_targets': {'value': ['lr_sb_best', 'lr_ns_best', 'lr_os_best']},
-        'loss_class' : { 'value' : 'b'}, # det nytter jo ikke noget at du køre over gamma og alpha for loss-class a...
-        'loss_class_gamma' : {'value' : 1.5},
-        'loss_class_alpha' : {'value' : 0.75}, # should be between 0.5 and 0.95...
-        'loss_reg' : { 'value' :  'b'},
-        'loss_reg_a' : { 'value' : 258},
-        'loss_reg_c' : { 'value' : 0.001},
-        # was: 'd' (lognormal_nll, sigma=0.9)
-        'np_seed' : {'values' : [4, 8]},
-        'torch_seed' : {'values' : [4, 8]},
-        'window_dim' : {'value' : 32},
-        'h_init' : {'value' : 'abs_rand_exp-100'},
-        'warmup_steps' : {'value' : 100},
-        'time_steps' : {'value' : 36}
+        'transformations': {'value': {
+            'log1p': ['lr_sb_best', 'lr_ns_best', 'lr_os_best'],
+            'asinh': [],
+            'identity': [],
+        }},
+        'derivations': {'value': {
+            'binary': [
+                {'from': 'lr_sb_best', 'to': 'by_sb_best', 'threshold': 0},
+                {'from': 'lr_ns_best', 'to': 'by_ns_best', 'threshold': 0},
+                {'from': 'lr_os_best', 'to': 'by_os_best', 'threshold': 0},
+            ],
+        }},
+        'steps': {'value': list(range(1, 37))},
+        'time_steps': {'value': 36},
+
+        # ============================================================
+        # Loss Functions — TOBIT baseline + per-target sigma (ADR-054/055).
+        # This sweep keeps the tobit baseline; config_hyperparameters.py runs the
+        # Arm-1 hurdle loss (lognormal_nll) instead. 'hurdle_threshold' is
+        # intentionally omitted here — tobit is censored and does not use it.
+        # ============================================================
+        'loss_reg': {'value': 'tobit'},
+        'loss_reg_sigma': {'value': {'lr_sb_best': 1.0, 'lr_ns_best': 0.75, 'lr_os_best': 0.5}},
+        'loss_class': {'value': 'focal'},
+        'loss_class_alpha': {'value': 0.75},
+        'loss_class_gamma': {'value': 1.5},
+        'onset_bias_init': {'value': -7.0},
+
+        # ============================================================
+        # Scheduled Sampling (ADR-056) — OFF for clean C-113 baseline
+        # ============================================================
+        'ss_schedule': {'value': 'linear'},
+        'ss_warmup_lessons': {'value': 15},
+        'ss_epsilon_max': {'value': 0.0},
+
+        # ============================================================
+        # Strategy (Curriculum)
+        # ============================================================
+        'total_lessons': {'value': 80},
+        'max_ratio': {'value': 0.95},
+        'min_ratio': {'value': 0.05},
+        'slope_ratio': {'value': 0.75},
+        'roof_ratio': {'value': 0.7},
+        'min_events': {'value': 5},
+        'sampling_strategy': {'value': 'sigmoid'},
+        'sampling_steepness': {'value': 1.0},
+
+        # ============================================================
+        # Outbound / Evaluation
+        # ============================================================
+        'n_posterior_samples': {'value': 16},
+        'evaluation_mode': {'value': 'stochastic'},
+        'aggregate_method': {'value': 'arithmetic_mean'},
+        'skip_predictions_delivery': {'value': True},
         }
 
     sweep_config['parameters'] = parameters_dict

--- a/models/wild_rose/configs/config_hyperparameters.py
+++ b/models/wild_rose/configs/config_hyperparameters.py
@@ -9,6 +9,7 @@ def get_hp_config():
     """
     
     hyperparameters = {
+        "target_transform": "identity",
         'steps': [*range(1, 36 + 1, 1)],
         "time_steps": 36,
         'submodels_to_train': 50,

--- a/models/wild_rose/configs/config_meta.py
+++ b/models/wild_rose/configs/config_meta.py
@@ -17,7 +17,7 @@ def get_meta_config():
         "model_reg": "XGBRegressor",
         "model_clf": "XGBClassifier",
         "regression_point_baselines": ["average_cmbaseline", "zero_cmbaseline", "locf_cmbaseline"],
-        "regression_point_metrics": ["RMSLE", "MSE", "MSLE", "y_hat_bar"],
+        "regression_point_metrics": ["MSLE", "MSE", "MCR_point", "y_hat_bar"],
         "queryset": "uncertainty_conflict_nolog",
         "rolling_origin_stride": 1,
     }

--- a/models/wildest_dream/configs/config_hyperparameters.py
+++ b/models/wildest_dream/configs/config_hyperparameters.py
@@ -1,5 +1,6 @@
 def get_hp_config(): 
     hp_config = {
+        "target_transform": "identity",
         "steps": [*range(1, 36 + 1, 1)],
         "time_steps": 36,
         "parameters": {

--- a/models/wuthering_heights/configs/config_hyperparameters.py
+++ b/models/wuthering_heights/configs/config_hyperparameters.py
@@ -9,6 +9,7 @@ def get_hp_config():
     """
     
     hyperparameters = {
+        "target_transform": "identity",
         'steps': [*range(1, 36 + 1, 1)],
         "time_steps": 36,
         'submodels_to_train': 50,

--- a/models/wuthering_heights/configs/config_meta.py
+++ b/models/wuthering_heights/configs/config_meta.py
@@ -17,7 +17,7 @@ def get_meta_config():
         "model_reg": "XGBRegressor",
         "model_clf": "XGBClassifier",
         "regression_point_baselines": ["average_cmbaseline", "zero_cmbaseline", "locf_cmbaseline"],
-        "regression_point_metrics": ["RMSLE", "MSE", "MSLE", "y_hat_bar"],
+        "regression_point_metrics": ["MSLE", "MSE", "MCR_point", "y_hat_bar"],
         "queryset": "uncertainty_deep_conflict_nolog",
         "rolling_origin_stride": 1,
     }

--- a/models/yellow_pikachu/configs/config_hyperparameters.py
+++ b/models/yellow_pikachu/configs/config_hyperparameters.py
@@ -1,5 +1,6 @@
 def get_hp_config(): 
     hp_config = {
+        "target_transform": "identity",
         "steps": [*range(1, 36 + 1, 1)],
         "time_steps": 36,
         "parameters": {

--- a/models/yellow_submarine/configs/config_hyperparameters.py
+++ b/models/yellow_submarine/configs/config_hyperparameters.py
@@ -9,7 +9,7 @@ def get_hp_config():
     """
     
     hyperparameters = {
-        "target_transform": "identity",
+        "target_transform": "log1p",
         'steps': [*range(1, 36 + 1, 1)],
         "time_steps": 36,
         "parameters": {

--- a/models/yellow_submarine/configs/config_hyperparameters.py
+++ b/models/yellow_submarine/configs/config_hyperparameters.py
@@ -9,6 +9,7 @@ def get_hp_config():
     """
     
     hyperparameters = {
+        "target_transform": "identity",
         'steps': [*range(1, 36 + 1, 1)],
         "time_steps": 36,
         "parameters": {

--- a/models/yellow_submarine/configs/config_meta.py
+++ b/models/yellow_submarine/configs/config_meta.py
@@ -11,7 +11,7 @@ def get_meta_config():
         "name": "yellow_submarine", 
         "algorithm": "XGBRFRegressor",
         "regression_point_baselines": ["average_cmbaseline", "zero_cmbaseline", "locf_cmbaseline"],
-        "regression_point_metrics": ["RMSLE", "MSE", "MSLE", "y_hat_bar"],
+        "regression_point_metrics": ["MSLE", "MSE", "MCR_point", "y_hat_bar"],
         "regression_targets": ["lr_ged_sb"],
         "queryset": "fatalities003_imfweo",
         "level": "cm",

--- a/reports/technical_risk_register.md
+++ b/reports/technical_risk_register.md
@@ -1,9 +1,9 @@
 # Technical Risk Register — views-models
 
-**Last updated:** 2026-06-07  
+**Last updated:** 2026-06-09  
 **Governing ADR:** [ADR-010](../docs/ADRs/010_technical_risk_register.md)  
-**Total entries:** 71 (67 concerns + 4 disagreements)  
-**Concerns:** Open 24 | Mitigated 12 | Resolved 29 | Accepted 3 | Partially Resolved 1  
+**Total entries:** 74 (70 concerns + 4 disagreements)  
+**Concerns:** Open 27 | Mitigated 12 | Resolved 29 | Accepted 3 | Partially Resolved 1  
 **Disagreements:** Open 4  
 
 ---
@@ -840,6 +840,45 @@
 | **Status** | Open |
 | **Location** | `tools/catalogs/generate_features_catalog.py:97` |
 | **Notes** | The `colalign` parameter assumes at least 1 data column. Empty DataFrame has 0 columns → `IndexError`. Fix: skip `colalign` if `table_data` is empty, or return header-only table. Characterized as red test `test_empty_dataframe_crashes_tabulate`. |
+
+---
+
+### C-68 — `config_meta.py` fields duplicate operational config keys with no enforcement of doc-only status
+
+| Field | Value |
+|---|---|
+| **Tier** | 4 |
+| **Trigger** | A developer edits `regression_targets` (or `level`, `algorithm`, `prediction_format`) in a model's `config_meta.py` expecting it to change training/evaluation behavior, unaware the file is documentation-only |
+| **Source** | repo-assimilation (2026-06-09) |
+| **Status** | Open |
+| **Location** | `models/*/configs/config_meta.py`, `models/*/configs/config_hyperparameters.py` |
+| **Notes** | `config_meta.py`'s docstring states "modifying it will not affect the model, the training, or the evaluation." Yet several keys it declares — notably `regression_targets` — are also required as *operational* keys in `config_hyperparameters.py` (C-52 added `regression_targets` to 9 hyperparameter files for PFE participation). The same logical field thus lives in two files with opposite semantics: inert in meta, behavioral in hyperparameters. No test asserts the two copies agree, and no warning fires when a developer edits the inert copy. A change to the meta copy is silently ignored; a stale meta copy also misleads readers and the generated catalogs (`tools/catalogs/create_catalogs.py` reads `config_meta.py`). Low severity — no model-output corruption — but a maintainability footgun amplified across 90 models. See also C-52 (regression_targets added to hyperparameters), C-53 (stray `prediction_format` key leaked into hyperparameters during merge). |
+
+---
+
+### C-69 — `config_sweep.py` has zero test coverage and no validation of swept-parameter structure
+
+| Field | Value |
+|---|---|
+| **Tier** | 3 |
+| **Trigger** | A developer edits a model's `config_sweep.py` and mistypes a swept parameter — e.g., `'values': [...]` written as `'value': [...]`, or a parameter name that does not match `config_hyperparameters.py` — then launches `--sweep`; the sweep runs but silently pins or ignores the parameter |
+| **Source** | repo-assimilation (2026-06-09) |
+| **Status** | Open |
+| **Location** | `models/*/configs/config_sweep.py` (observed: `models/violet_visitor/configs/config_sweep.py`) |
+| **Notes** | Unlike `config_meta.py` (`test_config_completeness.py`), `config_partitions.py` (`test_config_partitions.py`), and `config_hyperparameters.py` (C-05 ReproducibilityGate), `config_sweep.py` has no structural or semantic test. The current working-tree rewrite of `models/violet_visitor/configs/config_sweep.py` (a 128-line hand edit mixing `{'value': ...}` and `{'values': [...]}` entries) illustrates the exposure: a `values`→`value` typo silently converts a swept dimension into a fixed constant, and a parameter key that does not correspond to a hyperparameter is silently ignored by W&B. Failures are not loud — the sweep completes but explores the wrong space, wasting GPU/compute and surfacing a misleading "best" run. Affects anyone running sweeps. See also C-05 (HP presence validation — does not cover sweep configs), D-04 (static-analysis vs behavioral-execution test gap). |
+
+---
+
+### C-70 — `run.sh` environment-bootstrap logic duplicated across ~90 protected scripts
+
+| Field | Value |
+|---|---|
+| **Tier** | 4 |
+| **Trigger** | The planned conda→uv migration (see `reports/conda_to_uv_migration_*`) or any change to env-bootstrap logic requires editing the near-identical `run.sh` in every model/ensemble/api/extractor/postprocessor directory |
+| **Source** | repo-assimilation (2026-06-09) |
+| **Status** | Open |
+| **Location** | `models/*/run.sh`, `ensembles/*/run.sh`, `apis/*/run.sh`, `extractors/*/run.sh`, `postprocessors/*/run.sh` (~90+ scripts) |
+| **Notes** | Every model carries a near-identical `run.sh` that bootstraps a conda env, dry-run-checks `requirements.txt`, and invokes `main.py`. The bootstrap logic is duplicated rather than sourced from a shared script, so a change must fan out across all ~90 files — and these files are production infrastructure that must not be casually modified (operating constraint). C-39 already demonstrated the fan-out cost (79 shebangs corrected in one sweep); C-50 notes `run.sh` cannot be edited to fix the local-install path. The duplication is consistent with the project's accepted self-containment stance for configs (D-01), but unlike partition configs there is no `meta/`-style single source of truth or bump tool for `run.sh` — it is accepted-by-default rather than deliberately governed. Low severity (failures are loud, at bootstrap time), but a coordination cost that recurs on every infra change. See also D-01 (intentional config duplication is load-bearing), C-39 (shebang fan-out — resolved), C-50 (`run.sh` modification constraint). |
 
 ---
 

--- a/reports/technical_risk_register.md
+++ b/reports/technical_risk_register.md
@@ -2,8 +2,8 @@
 
 **Last updated:** 2026-06-09  
 **Governing ADR:** [ADR-010](../docs/ADRs/010_technical_risk_register.md)  
-**Total entries:** 74 (70 concerns + 4 disagreements)  
-**Concerns:** Open 27 | Mitigated 12 | Resolved 29 | Accepted 3 | Partially Resolved 1  
+**Total entries:** 75 (71 concerns + 4 disagreements)  
+**Concerns:** Open 26 | Mitigated 12 | Resolved 29 | Accepted 3 | Partially Resolved 1  
 **Disagreements:** Open 4  
 
 ---
@@ -879,6 +879,19 @@
 | **Status** | Open |
 | **Location** | `models/*/run.sh`, `ensembles/*/run.sh`, `apis/*/run.sh`, `extractors/*/run.sh`, `postprocessors/*/run.sh` (~90+ scripts) |
 | **Notes** | Every model carries a near-identical `run.sh` that bootstraps a conda env, dry-run-checks `requirements.txt`, and invokes `main.py`. The bootstrap logic is duplicated rather than sourced from a shared script, so a change must fan out across all ~90 files — and these files are production infrastructure that must not be casually modified (operating constraint). C-39 already demonstrated the fan-out cost (79 shebangs corrected in one sweep); C-50 notes `run.sh` cannot be edited to fix the local-install path. The duplication is consistent with the project's accepted self-containment stance for configs (D-01), but unlike partition configs there is no `meta/`-style single source of truth or bump tool for `run.sh` — it is accepted-by-default rather than deliberately governed. Low severity (failures are loud, at bootstrap time), but a coordination cost that recurs on every infra change. See also D-01 (intentional config duplication is load-bearing), C-39 (shebang fan-out — resolved), C-50 (`run.sh` modification constraint). |
+
+---
+
+### C-71 — violet_visitor regression loss diverged from trio parity (Arm-1 hurdle experiment)
+
+| Field | Value |
+|---|---|
+| **Tier** | 3 |
+| **Trigger** | Someone runs or interprets a golden_hour↔stellar_horizon parity comparison assuming the viewser and datafactory trios share a regression loss — but violet_visitor now uses `lognormal_nll` while the other five trio members use `tobit` |
+| **Source** | review (PR #116, 2026-06-09) |
+| **Status** | Open |
+| **Location** | `models/violet_visitor/configs/config_hyperparameters.py` (`loss_reg: lognormal_nll`), `tests/test_datafactory_parity.py::test_both_trios_use_same_loss` |
+| **Notes** | violet_visitor's regression loss was intentionally changed from `tobit` to `lognormal_nll` (Arm-1 hurdle experiment, magnitude_calibration dossier 2026-06-08, issue #85; commit 908d383). The viewser trio (pink_pirate, blue_stranger, violet_visitor) and datafactory trio (bright_starship, bold_comet, blazing_meteor) were designed to be loss-identical so golden_hour (viewser ensemble) and stellar_horizon (datafactory ensemble) could be compared apples-to-apples (the parity programme behind C-48). violet_visitor's divergence breaks that: a golden_hour↔stellar_horizon comparison now confounds the loss change with the data-source change. `test_both_trios_use_same_loss` previously asserted strict uniformity (`{"tobit"}`); it was updated (PR #116) to pin the expected diverged state (five `tobit` + violet_visitor `lognormal_nll`), so the divergence is explicit and any *further* drift is still caught. The risk is interpretive, not silent — but a reader unaware of the experiment could draw wrong parity conclusions. Revisit when Arm-1 concludes: either restore `tobit`, or promote the hurdle loss across the whole trio. See also C-48 (variable-variant parity — resolved), C-37 (forecasting parity divergence), C-44 (concat aggregation quality), C-69 (sweep config untested). |
 
 ---
 

--- a/tests/test_datafactory_parity.py
+++ b/tests/test_datafactory_parity.py
@@ -294,13 +294,24 @@ class TestCrossEnsembleParityReadiness:
         assert vs["name"] != df["name"]
 
     def test_both_trios_use_same_loss(self):
-        all_losses = {}
+        # 2026-06-09 (PR #116): violet_visitor was intentionally diverged to the
+        # Arm-1 hurdle loss (lognormal_nll) for the magnitude_calibration experiment
+        # (issue #85, commit 908d383). This deliberately breaks viewser<->datafactory
+        # loss parity for the golden_hour<->stellar_horizon comparison — tracked as
+        # C-71 in reports/technical_risk_register.md. We pin the expected per-model
+        # state (five tobit + violet_visitor lognormal_nll) instead of asserting
+        # strict uniformity, so the known divergence is documented in-place and any
+        # *other* drift is still caught. Revert to {"tobit"} when Arm-1 concludes.
+        EXPERIMENT_DIVERGED = {"violet_visitor": "lognormal_nll"}
+        expected = {
+            name: EXPERIMENT_DIVERGED.get(name, "tobit")
+            for name in VIEWSER_TRIO + DATAFACTORY_TRIO
+        }
+        actual = {}
         for name in VIEWSER_TRIO + DATAFACTORY_TRIO:
             hp = _load_hp(name)
-            all_losses[name] = hp["loss_reg"]
-        assert set(all_losses.values()) == {"tobit"}, (
-            f"loss functions: {all_losses}"
-        )
+            actual[name] = hp["loss_reg"]
+        assert actual == expected, f"loss functions: {actual}; expected: {expected}"
 
     def test_constituent_posterior_samples_match(self):
         counts = {}

--- a/tests/test_falsification_merge_readiness.py
+++ b/tests/test_falsification_merge_readiness.py
@@ -102,10 +102,14 @@ class TestF4_StaleDocstrings:
     def test_no_stale_loss_references_in_parity_test(self):
         path = REPO / "tests" / "test_datafactory_parity.py"
         text = path.read_text()
-        for stale in ["shrinkage", "basu_dpd", "lognormal_nll"]:
+        # 'lognormal_nll' removed from this list 2026-06-09 (PR #116): it is now a
+        # *live* loss — violet_visitor's Arm-1 hurdle experiment (C-71) — so a
+        # reference in the parity test is current, not stale. 'shrinkage'/'basu_dpd'
+        # remain genuinely-removed loss functions and must not reappear.
+        for stale in ["shrinkage", "basu_dpd"]:
             assert stale not in text, (
                 f"test_datafactory_parity.py still references '{stale}' — "
-                f"datafactory trio now uses tobit"
+                f"that loss function was removed"
             )
 
 

--- a/tests/test_stepshifter_reproducibility.py
+++ b/tests/test_stepshifter_reproducibility.py
@@ -1,0 +1,92 @@
+"""Tests that all stepshifter models declare a valid ``target_transform`` and pass
+the views_stepshifter ``ReproducibilityGate``.
+
+Mirrors ``test_darts_reproducibility.py`` (which covers the views_r2darts2 package)
+for the views_stepshifter package. Enforces ADR-003 / views-stepshifter#52:
+``target_transform`` is a required config key validated against a closed registry;
+``HurdleModel``/``ShurfModel`` are restricted to ``identity`` (deferred, risk
+register D-26). Skipped when views_stepshifter is not installed.
+"""
+import pytest
+
+from tests.conftest import ALL_MODEL_DIRS, load_config_module
+
+try:
+    from views_stepshifter.infrastructure.reproducibility_gate import (
+        ReproducibilityGate,
+    )
+    from views_stepshifter.infrastructure.transforms import TRANSFORMS
+
+    _HAS_STEPSHIFTER = True
+except ImportError:
+    _HAS_STEPSHIFTER = False
+
+STEPSHIFTER_ALGORITHMS = {
+    "XGBRegressor",
+    "XGBRFRegressor",
+    "LGBMRegressor",
+    "HurdleModel",
+    "ShurfModel",
+}
+DEFERRED_ALGORITHMS = {"HurdleModel", "ShurfModel"}
+
+pytestmark = [
+    pytest.mark.green,
+    pytest.mark.skipif(
+        not _HAS_STEPSHIFTER,
+        reason="views_stepshifter not installed — ReproducibilityGate unavailable",
+    ),
+]
+
+
+def _algorithm(model_dir):
+    module = load_config_module(model_dir / "configs" / "config_meta.py")
+    return module.get_meta_config().get("algorithm")
+
+
+def _hyperparameters(model_dir):
+    module = load_config_module(model_dir / "configs" / "config_hyperparameters.py")
+    return module.get_hp_config()
+
+
+STEPSHIFTER_MODELS = [
+    d for d in ALL_MODEL_DIRS if _algorithm(d) in STEPSHIFTER_ALGORITHMS
+]
+STEPSHIFTER_MODEL_NAMES = [d.name for d in STEPSHIFTER_MODELS]
+
+
+class TestStepshifterTargetTransform:
+    @pytest.mark.parametrize(
+        "model_dir", STEPSHIFTER_MODELS, ids=STEPSHIFTER_MODEL_NAMES
+    )
+    def test_declares_valid_target_transform(self, model_dir):
+        """Every stepshifter model must declare target_transform as a registry member."""
+        hp = _hyperparameters(model_dir)
+        assert "target_transform" in hp, (
+            f"{model_dir.name} config_hyperparameters is missing the required "
+            "'target_transform' key"
+        )
+        assert hp["target_transform"] in TRANSFORMS, (
+            f"{model_dir.name} target_transform={hp['target_transform']!r} is not a "
+            f"registered transform ({sorted(TRANSFORMS)})"
+        )
+
+    @pytest.mark.parametrize(
+        "model_dir", STEPSHIFTER_MODELS, ids=STEPSHIFTER_MODEL_NAMES
+    )
+    def test_deferred_models_declare_identity(self, model_dir):
+        """HurdleModel/ShurfModel must declare identity (non-identity deferred, D-26)."""
+        if _algorithm(model_dir) in DEFERRED_ALGORITHMS:
+            hp = _hyperparameters(model_dir)
+            assert hp.get("target_transform") == "identity", (
+                f"{model_dir.name} ({_algorithm(model_dir)}) must declare "
+                "target_transform='identity' (non-identity is deferred, D-26)"
+            )
+
+    @pytest.mark.parametrize(
+        "model_dir", STEPSHIFTER_MODELS, ids=STEPSHIFTER_MODEL_NAMES
+    )
+    def test_passes_reproducibility_gate(self, model_dir):
+        """The full config must pass the stepshifter ReproducibilityGate (prod parity)."""
+        config = {**_hyperparameters(model_dir), "algorithm": _algorithm(model_dir)}
+        ReproducibilityGate.Config.audit_manifest(config)


### PR DESCRIPTION
## Summary
Restores stepshifter target compression and lands the salvage work on `development`. Brings 6 commits:

- **`acd35ef`** — declare `target_transform: identity` on all 37 stepshifter configs (#113, the mechanism baseline).
- **`b057534`** — `fourtieth_symphony` `log_target` True→False: avoids the Shurf `expm1`-of-raw overflow (views-stepshifter D-27, diagnosed via #68, fixed #69).
- **`908d383`** — `violet_visitor` config work (SS-baseline + Arm-1 hurdle loss; sweep rewrite; C-68–70).
- **`4584a44`** — flip the **13 plain stepshifter constituents** `identity → log1p` (#114, the EXP-01 salvage winner: cm MSLE 4.27 → ~0.4, beats baselines). Hurdle/Shurf stay `identity` (gate-enforced).
- **`f1bbab6`** — declare `regression_point_metrics = ["MSLE", "MSE", "MCR_point", "y_hat_bar"]` on all 25 stepshifter cm conflict models.
- **`d797970`** — add **`chunky_bunny`** ensemble: an exact clone of the original `big_chungus` (23 constituents = 13 plain + 6 Hurdle + 4 DL), with the fixed constituents.

## Verification
- 3 representative plain models re-run through the real pipeline (`-r calibration -t -e -re`): `car_radio` 0.415, `bittersweet_symphony` 0.405, `counting_stars` 0.415 — all sane, all produced reports.
- `ruff` clean; reproducibility gate validation **111 passed**; `chunky_bunny` structurally validated (configs parse, all 23 constituents present, pipeline resolves it).

## Not in this PR / next
- The full `chunky_bunny`/`pink_ponyclub` ensemble **calibration run is not yet executed** — to be run after this lands.
- Tail-aware optimization (EXP-01 F4) explicitly deferred; this is salvage (sane values), not optimization.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
