### PR TITLE
fix(partitions): preserve file mode in atomic writes

### DIFF
--- a/docs/CICs/PartitionBump.md
+++ b/docs/CICs/PartitionBump.md
@@ -38,10 +38,10 @@ Invocation: `python -m tools.partitions.bump [--execute] [--bump N] [--force REA
 ### Execute mode (`--execute`)
 All of the above, plus:
 - Rewrites calibration/validation tuples in all standard config_partitions.py files
-- Uses atomic writes (tempfile + os.replace) — no partial file corruption
+- Uses atomic writes (`fileops.write_atomic`: tempfile + os.replace) — no partial file corruption, and existing files keep their permission bits (mode is preserved)
 - Re-reads and verifies every written file before proceeding
 - Skips files with `PARTITION_OVERRIDE = True`
-- Updates `meta/partitions.json` with new canonical values
+- Updates `meta/partitions.json` with new canonical values (via `write_atomic`, so its mode is preserved too — `_save_canonical` delegates rather than duplicating the tempfile/replace pattern)
 - Writes a JSONL lockfile to `meta/partition_bump_YYYYMMDD_HHMMSS.jsonl` recording: before/after values, dates, git state, every file updated, every file skipped, verification status
 
 ### Safety checks (both modes)

--- a/docs/CICs/PartitionFileOps.md
+++ b/docs/CICs/PartitionFileOps.md
@@ -30,7 +30,7 @@ Located in: `tools/partitions/fileops.py`
 - `discover_entity_dirs(repo_root)` — finds all real entity directories (main.py for models/ensembles, config_partitions.py for extractors/postprocessors), excluding fixtures from `meta/fixtures.json`
 - `extract_values(source)` — parses calibration/validation train/test tuples from Python source text. Accepts both single and double quotes. Strips comments before matching. Returns `None` if unparseable.
 - `rewrite_values(source, new_values)` — replaces calibration/validation tuples in source text. Anchors to `return {` to avoid matching comments. Never touches the forecasting section. Raises `ValueError` if the expected structure is not found.
-- `write_atomic(path, content)` — writes via tempfile + `os.replace`. Cleans up temp file on failure.
+- `write_atomic(path, content)` — writes via tempfile + `os.replace`. **Preserves the destination file's permission bits when overwriting an existing file; applies a umask-respecting default (typically `0o644`) for a new file.** Cleans up temp file on failure.
 - `verify_file(path, expected)` — re-reads a file after writing and compares against expected values. Returns list of error strings.
 - `has_partition_override(source)` — checks for `PARTITION_OVERRIDE = True` as a real Python variable (not a comment)
 - Fixture names loaded from `meta/fixtures.json` at module import time
@@ -50,7 +50,7 @@ Located in: `tools/partitions/fileops.py`
 
 - `extract_values()` — pure, no side effects, returns `dict[str, tuple[int, int]] | None`
 - `rewrite_values()` — pure, returns modified source string
-- `write_atomic()` — writes to filesystem. Atomic: either the file is fully written or nothing changes.
+- `write_atomic()` — writes to filesystem. Atomic: either the file is fully written or nothing changes. Permission bits of an existing target are preserved across the replace (a new target gets the umask default, not `NamedTemporaryFile`'s `0o600`).
 - `verify_file()` — reads from filesystem. No writes.
 - `discover_*()` — reads filesystem (directory listing). No writes.
 

--- a/tests/test_bump_partitions.py
+++ b/tests/test_bump_partitions.py
@@ -417,6 +417,40 @@ def generate():
             os.chmod(str(target.parent), 0o755)
 
 
+class TestWriteAtomicModePreservation:
+    """write_atomic must keep an existing file's permission bits and use a
+    umask-respecting default for new files. Regression: a partition bump once
+    silently flipped 101 config files 755->644 because os.replace kept the temp
+    file's 0o600. See docs/CICs/PartitionFileOps.md.
+    """
+
+    def test_write_atomic_preserves_existing_file_mode(self, tmp_path):
+        import os
+        import stat
+        from tools.partitions.fileops import write_atomic
+
+        target = tmp_path / "config_partitions.py"
+        target.write_text("old")
+        os.chmod(target, 0o755)
+        write_atomic(target, "new content")
+        assert stat.S_IMODE(target.stat().st_mode) == 0o755
+        assert target.read_text() == "new content"
+
+    def test_write_atomic_new_file_uses_umask_default_not_0o600(self, tmp_path):
+        import os
+        import stat
+        from tools.partitions.fileops import write_atomic
+
+        target = tmp_path / "new_lockfile.jsonl"
+        write_atomic(target, "x")
+        current_umask = os.umask(0)
+        os.umask(current_umask)
+        expected = 0o666 & ~current_umask
+        actual = stat.S_IMODE(target.stat().st_mode)
+        assert actual == expected, f"new file mode {oct(actual)} != {oct(expected)}"
+        assert actual != 0o600
+
+
 # ---------------------------------------------------------------------------
 # Beige tests: structural compliance
 # ---------------------------------------------------------------------------

--- a/tools/partitions/bump.py
+++ b/tools/partitions/bump.py
@@ -27,10 +27,8 @@ Usage:
 import argparse
 import datetime
 import json
-import os
 import subprocess
 import sys
-import tempfile
 from pathlib import Path
 
 from tools.partitions.domain import (
@@ -67,14 +65,9 @@ def _save_canonical(
     canonical: dict, boundaries: PartitionBoundaries, partitions_file: Path
 ) -> None:
     merged = {**canonical, **boundaries.to_json_dict()}
-    dir_name = partitions_file.parent
-    with tempfile.NamedTemporaryFile(
-        mode="w", dir=dir_name, suffix=".tmp", delete=False
-    ) as tmp:
-        json.dump(merged, tmp, indent=2)
-        tmp.write("\n")
-        tmp_path = tmp.name
-    os.replace(tmp_path, str(partitions_file))
+    # Delegate to write_atomic so meta/partitions.json inherits the same
+    # mode-preserving atomic write as the config files (no duplicated pattern).
+    write_atomic(partitions_file, json.dumps(merged, indent=2) + "\n")
 
 
 def _git_state(cwd: Path | None = None) -> dict:

--- a/tools/partitions/fileops.py
+++ b/tools/partitions/fileops.py
@@ -7,6 +7,7 @@ shared by the bump CLI and the test suite.
 import json
 import os
 import re
+import stat
 import tempfile
 from pathlib import Path
 
@@ -145,14 +146,32 @@ def rewrite_values(source: str, new_values: dict[str, tuple[int, int]]) -> str:
 
 
 def write_atomic(path: Path, content: str) -> None:
-    """Write content to path atomically via tempfile + os.replace."""
+    """Write content to path atomically via tempfile + os.replace.
+
+    Preserves the destination file's permission bits when overwriting an
+    existing file; for a new file, applies the umask-respecting default
+    (typically 0o644). Without this, the replace would leave the file with
+    NamedTemporaryFile's restrictive 0o600 and drop any execute bit — which
+    is exactly what silently changed 101 config modes during a partition bump.
+    Cleans up the temp file if the chmod or replace fails.
+    """
     dir_name = path.parent
+    try:
+        dest_mode = stat.S_IMODE(os.stat(path).st_mode)
+    except FileNotFoundError:
+        dest_mode = None
     with tempfile.NamedTemporaryFile(
         mode="w", dir=dir_name, suffix=".tmp", delete=False
     ) as tmp:
         tmp.write(content)
         tmp_path = tmp.name
     try:
+        if dest_mode is not None:
+            os.chmod(tmp_path, dest_mode)
+        else:
+            current_umask = os.umask(0)
+            os.umask(current_umask)
+            os.chmod(tmp_path, 0o666 & ~current_umask)
         os.replace(tmp_path, str(path))
     except OSError:
         os.unlink(tmp_path)


### PR DESCRIPTION
## Root cause
`fileops.write_atomic` wrote via `NamedTemporaryFile` (created `0o600`) + `os.replace`. `os.replace` keeps the **temp file's** mode, so every rewritten file silently lost its permission bits. This is exactly what flipped **101 `config_partitions.py` files `755→644`** during the 2026 partition bump (PR #119) and forced a manual two-commit cleanup.

## Fix
- **`write_atomic`** now captures the destination's mode and `chmod`s the temp file to match before the replace; **new** files get the umask default (`0o644`-ish), not `0o600`. Temp cleanup now also covers a `chmod` failure.
- **`_save_canonical`** (bump.py) delegates to `write_atomic` instead of duplicating the tempfile/replace pattern, so `meta/partitions.json` inherits the fix. Removes now-unused `os`/`tempfile` imports.
- **Tests:** `TestWriteAtomicModePreservation` — preserves existing `0o755`; new file is umask-default, not `0o600`.
- **CICs** `PartitionFileOps.md` + `PartitionBump.md` updated (paired with the code per `cic_sync_check`).

## Verification
- `pytest` partition + tooling suites: **117 passed**.
- End-to-end: a bump-like rewrite on a `755` file now stays `755` (no mode churn).

## Follow-up (out of scope)
`tools/catalogs/create_catalogs.py` uses the same `NamedTemporaryFile`+`os.replace` pattern (C-19) — same latent mode-drop, worth a separate fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)