### PR TITLE
config(metrics): align 4 DL constituents to [MSLE, MSE, MCR_point, y_hat_bar]

### DIFF
--- a/models/elastic_heart/configs/config_meta.py
+++ b/models/elastic_heart/configs/config_meta.py
@@ -15,7 +15,7 @@ def get_meta_config():
         "level": "cm",
         "creator": "Dylan",
         "regression_point_baselines": ["average_cmbaseline", "zero_cmbaseline", "locf_cmbaseline"],
-        "regression_point_metrics": ["RMSLE", "MSE", "MSLE", "y_hat_bar"],
+        "regression_point_metrics": ["MSLE", "MSE", "MCR_point", "y_hat_bar"],
         # "regression_sample_metrics": ["CRPS", "y_hat_bar"],
         # "regression_sample_baselines": ["red_ranger"],
         "rolling_origin_stride": 1,

--- a/models/new_rules/configs/config_meta.py
+++ b/models/new_rules/configs/config_meta.py
@@ -14,7 +14,7 @@ def get_meta_config():
         "level": "cm",
         "creator": "Dylan",
         "regression_point_baselines": ["average_cmbaseline", "zero_cmbaseline", "locf_cmbaseline"],
-        "regression_point_metrics": ["RMSLE", "MSE", "MSLE", "y_hat_bar"],
+        "regression_point_metrics": ["MSLE", "MSE", "MCR_point", "y_hat_bar"],
         # "regression_sample_metrics": ["CRPS", "y_hat_bar"],
         # "regression_sample_baselines": ["red_ranger"],
         "rolling_origin_stride": 1,

--- a/models/revolving_door/configs/config_meta.py
+++ b/models/revolving_door/configs/config_meta.py
@@ -17,7 +17,7 @@ def get_meta_config():
         "level": "cm",
         "creator": "Dylan",
         "regression_point_baselines": ["average_cmbaseline", "zero_cmbaseline", "locf_cmbaseline"],
-        "regression_point_metrics": ["RMSLE", "MSE", "MSLE", "y_hat_bar"],
+        "regression_point_metrics": ["MSLE", "MSE", "MCR_point", "y_hat_bar"],
         "regression_sample_metrics": ["CRPS", "y_hat_bar"],
         "regression_sample_baselines": ["red_ranger"],
         "rolling_origin_stride": 1,

--- a/models/smol_cat/configs/config_meta.py
+++ b/models/smol_cat/configs/config_meta.py
@@ -15,7 +15,7 @@ def get_meta_config():
         "level": "cm",
         "creator": "Dylan",
         "regression_point_baselines": ["average_cmbaseline", "zero_cmbaseline", "locf_cmbaseline"],
-        "regression_point_metrics": ["RMSLE", "MSE", "MSLE", "y_hat_bar"],
+        "regression_point_metrics": ["MSLE", "MSE", "MCR_point", "y_hat_bar"],
         # "regression_sample_metrics": ["CRPS", "y_hat_bar", "twCRPS", "QIS", "MIS", "MCR_sample"],
         # "regression_sample_baselines": ["red_ranger"],
         "rolling_origin_stride": 1,


### PR DESCRIPTION
Updates `regression_point_metrics` on the 4 deep-learning chunky_bunny constituents (elastic_heart, new_rules, revolving_door, smol_cat) from the original `["RMSLE","MSE","MSLE","y_hat_bar"]` to `["MSLE","MSE","MCR_point","y_hat_bar"]`, matching the 25 cm models updated in #116. `config_meta` is documentation-only; `MCR_point` is already declared on 25 merged models. 4 files, 4 lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)