### PR TITLE
config(dl-hparams): port tuning_202606 (r7/r8) to the 4 DL constituents

### DIFF
--- a/models/elastic_heart/configs/config_hyperparameters.py
+++ b/models/elastic_heart/configs/config_hyperparameters.py
@@ -5,7 +5,7 @@ def get_hp_config():
     Best run: elastic_heart_tsmixer_shadow_20260508_C
     lr=1e-4, clip=20, dropout=0.35, hidden=64, patience=15, RevIN=True
     """
-
+    # r8
     hyperparameters = {
         # Temporal
         "steps": [*range(1, 36 + 1, 1)],
@@ -23,34 +23,34 @@ def get_hp_config():
         # Training
         "batch_size": 128,
         "n_epochs": 300,
-        "early_stopping_patience": 35,
+        "early_stopping_patience": 20,
         "early_stopping_min_delta": 0.001,
         "force_reset": True,
 
         # Optimizer
         "optimizer_cls": "AdamW",
-        "lr": 0.0001,
-        "weight_decay": 0.001,
-        "gradient_clip_val": 50,
+        "lr": 1e-3,
+        "weight_decay": 3e-4,
+        "gradient_clip_val": 30.0,
 
         # LR Scheduler
         "lr_scheduler_cls": "ReduceLROnPlateau",
         "lr_scheduler_factor": 0.5,
-        "lr_scheduler_patience": 25,
+        "lr_scheduler_patience": 10,
         "lr_scheduler_min_lr": 1e-6,
         "lr_scheduler_kwargs": {
             "mode": "min",
             "factor": 0.5,
-            "patience": 25,
+            "patience": 10,
             "min_lr": 1e-6,
             "monitor": "val_loss",
-            "cooldown": 3,
+            "cooldown": 2,
             "threshold": 0.01,
             "threshold_mode": "rel",
         },
         "optimizer_kwargs": {
-            "lr": 0.0001,
-            "weight_decay": 0.001,
+            "lr": 1e-3,
+            "weight_decay": 3e-4,
         },
         "checkpoint_mode": "best",
         "loss_function": "SpotlightLossLogcosh",
@@ -61,7 +61,7 @@ def get_hp_config():
         "feature_scaler": None,
         "target_scaler": "AsinhTransform",
         "feature_scaler_map": {
-            "AsinhTransform->StandardScaler": [
+            "AsinhTransform->MaxAbsScaler": [
                     # Conflict counts + deltas + spatial lags
                     "lr_ged_ns", "lr_ged_os",
                     "lr_ged_sb_delta", "lr_ged_ns_delta", "lr_ged_os_delta",
@@ -105,16 +105,13 @@ def get_hp_config():
         },
 
         # TSMixer Architecture
-        # 3 blocks × 64 width: sweep-validated configuration. Wider depth
-        # (3 blocks) compensates for narrower hidden_size=64 by stacking
-        # more mixing passes
-        "num_blocks": 2,
-        "hidden_size": 256,
-        "ff_size": 512,
+        "num_blocks": 3,
+        "hidden_size": 64,
+        "ff_size": 256,
         "activation": "GELU",
         "norm_type": "LayerNorm",
         "normalize_before": True,
-        "dropout": 0.25,
+        "dropout": 0.2,
         "use_static_covariates": True,
         "use_reversible_instance_norm": True,
 

--- a/models/new_rules/configs/config_hyperparameters.py
+++ b/models/new_rules/configs/config_hyperparameters.py
@@ -2,7 +2,7 @@ def get_hp_config():
     """
     N-BEATS hyperparameters
     """
-
+    # r8
     hyperparameters = {
         # --- Forecast horizon ---
         "steps": list(range(1, 37)),
@@ -13,48 +13,48 @@ def get_hp_config():
         "num_blocks": 2,
         "num_layers": 3,
         "layer_widths": 256,
-        "expansion_coefficient_dim": 20,
+        "expansion_coefficient_dim": 512,
         "trend_polynomial_degree": 2,
         "activation": "GELU",
-        "dropout": 0.3,
+        "dropout": 0.1,
         "batch_norm": False,
         "use_reversible_instance_norm": True,
-        "use_static_covariates": False,
-        "use_cyclic_encoders": False,
+        "use_static_covariates": True,
+        "use_cyclic_encoders": True,
 
         # --- Input / output structure ---
-        "input_chunk_length": 48,
+        "input_chunk_length": 36,
         "output_chunk_length": 36,
         "output_chunk_shift": 0,
 
         # --- Training ---
         "batch_size": 128,
         "n_epochs": 300,
-        "early_stopping_patience": 30,
+        "early_stopping_patience": 20,
         "early_stopping_min_delta": 0.001,
         "force_reset": True,
 
         # --- Optimizer ---
         "optimizer_cls": "AdamW",
-        "lr": 0.0005,
-        "weight_decay": 0.001,
-        "gradient_clip_val": 5,
+        "lr": 1e-3,
+        "weight_decay": 3e-4,
+        "gradient_clip_val": 50.0,
         "optimizer_kwargs": {
-            "lr": 0.0005,
-            "weight_decay": 0.001,
+            "lr": 1e-3,
+            "weight_decay": 3e-4,
         },
 
         # --- LR Scheduler ---
         "lr_scheduler_cls": "ReduceLROnPlateau",
-        "lr_scheduler_factor": 0.7,
+        "lr_scheduler_factor": 0.5,
         "lr_scheduler_patience": 10,
         "lr_scheduler_min_lr": 1e-6,
         "lr_scheduler_kwargs": {
             "mode": "min",
-            "factor": 0.7,
+            "factor": 0.5,
             "patience": 10,
             "min_lr": 1e-6,
-            "cooldown": 3,
+            "cooldown": 2,
             "threshold": 0.01,
             "threshold_mode": "rel",
         },
@@ -108,8 +108,8 @@ def get_hp_config():
 
         # --- Loss: SpotlightLoss v36 ---
         "loss_function": "SpotlightLossLogcosh",
-        "delta": 0.07139486580318413,
         "non_zero_threshold": 0.88,  # asinh(1) ≈ 0.88 in asinh space (1 battle death)
+        "delta": 0.07139486580318413,
 
         # --- Prediction ---
         "likelihood": None,
@@ -126,4 +126,3 @@ def get_hp_config():
     }
 
     return hyperparameters
-

--- a/models/revolving_door/configs/config_hyperparameters.py
+++ b/models/revolving_door/configs/config_hyperparameters.py
@@ -5,7 +5,7 @@ def get_hp_config():
     Returns:
     - hyperparameters (dict): Training configuration dictionary.
     """
-
+    # r7
     hyperparameters = {
         # Temporal
         "steps": [*range(1, 36 + 1)],
@@ -23,41 +23,42 @@ def get_hp_config():
         # Training
         "batch_size": 128,
         "n_epochs": 300,
-        "early_stopping_patience": 35,
+        "early_stopping_patience": 20,
         "early_stopping_min_delta": 0.001,
         "force_reset": True,
 
         # Optimizer
         "optimizer_cls": "AdamW",
-        "lr": 0.0005,
-        "weight_decay": 0.00005,
-        "gradient_clip_val": 20,
+        "lr": 1e-3,
+        "weight_decay": 3e-4,
+        "gradient_clip_val": 50.0,
 
         # LR Scheduler
         "lr_scheduler_cls": "ReduceLROnPlateau",
         "lr_scheduler_factor": 0.5,
-        "lr_scheduler_patience": 12,
+        "lr_scheduler_patience": 10,
         "lr_scheduler_min_lr": 1e-6,
         "lr_scheduler_kwargs": {
             "mode": "min",
             "factor": 0.5,
-            "patience": 12,
+            "patience": 10,
             "min_lr": 1e-6,
-            "cooldown": 3,
+            "cooldown": 2,
             "threshold": 0.01,
             "threshold_mode": "rel",
         },
+
         "optimizer_kwargs": {
-            "lr": 0.0005,
-            "weight_decay": 0.00005,
+            "lr": 1e-3,
+            "weight_decay": 3e-4,
         },
 
         # SpotlightLossLogcosh: logcosh base shape (gradient saturates at ±1)
         # Safe for basis-expansion architectures — bounded gradients prevent
         # learned interpolation coefficients from growing unbounded.
         "loss_function": "SpotlightLossLogcosh",
-        "delta": 0.041685644972051974,
         "non_zero_threshold": 0.88,
+        "delta": 0.041685644972051974,
 
         # Scaling
         "feature_scaler": None,
@@ -107,26 +108,17 @@ def get_hp_config():
         },
 
         # N-HiTS Architecture
-        # Inverted pyramid: coarse stack is narrow (64), fine stack is wide (256).
-        # This matches the decomposition task — the coarse stack only needs to capture
-        # slow level shifts and physically cannot build complex crisis trend extrapolations
-        # with only 64-wide FC layers. The fine stack gets 256 width to fit spike residuals
-        # accurately, which drives MSLE down. Reverting to this from [160,80,64] which
-        # gave the coarse stack too much capacity and caused Niger-type runaway.
-        # Pooling: [4,2,1] → 9, 18, 36 FC inputs. Safe with 64-wide coarse stack +
-        # RevIN sigma cap (sigma_raw now capped to 5× batch mean, so even if n_freq=4
-        # extrapolates trend, the denorm multiplier is bounded).
         "num_stacks": 3,
-        "num_blocks": 1,
-        "num_layers": 4,
-        "layer_widths": [32, 64, 128],
-        "pooling_kernel_sizes": [[4], [2], [1]],
-        "n_freq_downsample": [[4], [2], [1]],
-        "max_pool_1d": False,
-        "activation": "GELU",
-        "dropout": 0.15,
+        "num_blocks": 2,
+        "num_layers": 3,
+        "layer_widths": 256,
+        "pooling_kernel_sizes": [[4, 4], [2, 2], [1, 1]],
+        "n_freq_downsample": [[4, 4], [2, 2], [1, 1]],
+        "activation": "Tanh",
+        "dropout": 0.1,
         "use_static_covariates": True,
         "use_reversible_instance_norm": True,
+        "max_pool_1d": True,
         "checkpoint_mode": "best",
         # "static_covariate_stats": {
         #     "transform": "AsinhTransform->MaxAbsScaler",

--- a/models/revolving_door/configs/config_meta.py
+++ b/models/revolving_door/configs/config_meta.py
@@ -19,7 +19,7 @@ def get_meta_config():
         "regression_point_baselines": ["average_cmbaseline", "zero_cmbaseline", "locf_cmbaseline"],
         "regression_point_metrics": ["MSLE", "MSE", "MCR_point", "y_hat_bar"],
         "regression_sample_metrics": ["CRPS", "y_hat_bar"],
-        "regression_sample_baselines": ["red_ranger"],
+        # "regression_sample_baselines": ["red_ranger"],  # commented to match elastic_heart/new_rules/smol_cat; red_ranger's latest wandb run is stale (pre +12mo bump) and trips the report partition check. Does not affect chunky_bunny (point baselines only).
         "rolling_origin_stride": 1,
         "prediction_format": "dataframe",
     }

--- a/models/smol_cat/configs/config_hyperparameters.py
+++ b/models/smol_cat/configs/config_hyperparameters.py
@@ -15,16 +15,16 @@ def get_hp_config():
         "output_chunk_shift": 0,
         "hidden_size": 384,
         "decoder_output_dim": 64,
-        "temporal_decoder_hidden": 256,
+        "temporal_decoder_hidden": 128,
         "temporal_width_past": 24,
         "temporal_width_future": 4,
-        "temporal_hidden_size_past": 64,
+        "temporal_hidden_size_past": 128,
         "temporal_hidden_size_future": 32,
         "num_encoder_layers": 3,
         "num_decoder_layers": 2,
         "use_layer_norm": True,
         "use_reversible_instance_norm": True,
-        "dropout": 0.25,
+        "dropout": 0.1,
         "use_static_covariates": True,
 
         # Training
@@ -36,29 +36,29 @@ def get_hp_config():
         # Optimizer
         "optimizer_cls": "AdamW",
         "lr": 0.0005,
-        "weight_decay": 0.0001,
+        "weight_decay": 0.0,
         "optimizer_kwargs": {
             "lr": 0.0005,
-            "weight_decay": 0.0001,
+            "weight_decay": 0.0,
         },
 
         # LR Scheduler
         "lr_scheduler_cls": "ReduceLROnPlateau",
         "lr_scheduler_factor": 0.5,
-        "lr_scheduler_patience": 8,
+        "lr_scheduler_patience": 20,
         "lr_scheduler_min_lr": 1e-6,
         "lr_scheduler_kwargs": {
             "mode": "min",
             "factor": 0.5,
-            "patience": 8,
-            "min_lr": 1e-6,
-            "cooldown": 3,
+            "patience": 20,
+            "min_lr": 1e-5,
+            "cooldown": 5,
             "threshold": 0.01,
             "threshold_mode": "rel",
         },
 
         # Trainer
-        "gradient_clip_val": 3,
+        "gradient_clip_val": 200,
         "early_stopping_patience": 35,
         "early_stopping_min_delta": 0.001,
 

--- a/models/yellow_submarine/configs/config_queryset.py
+++ b/models/yellow_submarine/configs/config_queryset.py
@@ -22,24 +22,28 @@ def generate():
 
     # .with_column(Column('raw_ged_os', from_loa='country_month', from_column='ged_os_best_sum_nokgi'))
 
-    .with_column(Column('lr_imfweo_ngdp_rpch', from_loa='country_year', from_column='ngdp_rpch')
-        .transform.missing.replace_na(0)
-        )
+    # NOTE (2026-06-09, views-models#125): the imfweo_ngdp_rpch (IMF WEO annual GDP,
+    # country_year) columns fail the viewser fetch ("Input is not a df or a df index"),
+    # likely no annual data for the bumped +12-month window. Commented out so the model
+    # can fetch + run; restore once the viewser data is confirmed available.
+    # .with_column(Column('lr_imfweo_ngdp_rpch', from_loa='country_year', from_column='ngdp_rpch')
+    #     .transform.missing.replace_na(0)
+    #     )
 
-    .with_column(Column('lr_imfweo_ngdp_rpch_tlag12', from_loa='country_year', from_column='ngdp_rpch')
-        .transform.missing.replace_na(0)
-        .transform.temporal.tlag(12)
-        )
+    # .with_column(Column('lr_imfweo_ngdp_rpch_tlag12', from_loa='country_year', from_column='ngdp_rpch')
+    #     .transform.missing.replace_na(0)
+    #     .transform.temporal.tlag(12)
+    #     )
 
-    .with_column(Column('lr_imfweo_ngdp_rpch_tlag24', from_loa='country_year', from_column='ngdp_rpch')
-        .transform.missing.replace_na(0)
-        .transform.temporal.tlag(24)
-        )
+    # .with_column(Column('lr_imfweo_ngdp_rpch_tlag24', from_loa='country_year', from_column='ngdp_rpch')
+    #     .transform.missing.replace_na(0)
+    #     .transform.temporal.tlag(24)
+    #     )
 
-    .with_column(Column('lr_imfweo_ngdp_rpch_tlag36', from_loa='country_year', from_column='ngdp_rpch')
-        .transform.missing.replace_na(0)
-        .transform.temporal.tlag(36)
-        )
+    # .with_column(Column('lr_imfweo_ngdp_rpch_tlag36', from_loa='country_year', from_column='ngdp_rpch')
+    #     .transform.missing.replace_na(0)
+    #     .transform.temporal.tlag(36)
+    #     )
 
     # .with_column(Column('lr_ged_sb_dep', from_loa='country_month', from_column='ged_sb_best_sum_nokgi')
     #     # .transform.ops.ln()

--- a/tests/test_chunky_bunny_readiness.py
+++ b/tests/test_chunky_bunny_readiness.py
@@ -1,0 +1,66 @@
+"""
+Falsification stubs — "chunky_bunny is ready to run" (2026-06-09).
+
+FALSIFIED. The ensemble (`EnsembleManager._train_model_artifact`) trains each
+constituent by subprocessing that model's own `run.sh`, which activates a PER-MODEL
+conda env (`envs/views_stepshifter` for plain/Hurdle, `envs/views_r2darts2` for the
+4 DL models). Those envs:
+  (a) do NOT exist on this box (only views-baseline / views_ensemble / views-hydranet
+      are present), so run.sh would create them from `requirements.txt`, and
+  (b) pin the PUBLISHED `views-stepshifter>=1.0.0,<2.0.0`, which has NO
+      `target_transform` mechanism (origin/main: 0 occurrences) — so the `log1p`
+      fix we put in the configs would be SILENTLY IGNORED and the constituents
+      would train RAW again (the exact bug we are fixing), or error.
+
+Our entire validation (car_radio/bittersweet_symphony/counting_stars MSLE ~0.41)
+was run in `views_pipeline` (editable install of the FIXED branch) — which is NOT
+the env the ensemble uses. The green test gave false confidence.
+
+These tests encode the readiness preconditions. They FAIL today; they pass once the
+fix is released (merged to main + published) OR the per-model envs are provisioned
+with the fixed code.
+"""
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parents[1]
+STEPSHIFTER_REPO = REPO.parent / "views-stepshifter"
+
+
+def _origin_main_gate_has_target_transform() -> bool:
+    out = subprocess.run(
+        ["git", "show", "origin/main:views_stepshifter/infrastructure/reproducibility_gate.py"],
+        cwd=STEPSHIFTER_REPO, capture_output=True, text=True,
+    )
+    return "target_transform" in out.stdout
+
+
+@pytest.mark.xfail(reason="FALSIFIED: target_transform fix not merged to main / not released", strict=True)
+def test_target_transform_fix_is_released():
+    """The published views-stepshifter that constituents pip-install must support
+    target_transform — otherwise the log1p fix is silently ignored at ensemble run."""
+    assert _origin_main_gate_has_target_transform(), (
+        "origin/main reproducibility_gate has no target_transform — a fresh "
+        "envs/views_stepshifter (pip install views-stepshifter>=1.0.0,<2.0.0) "
+        "would train RAW, silently discarding the log1p fix."
+    )
+
+
+@pytest.mark.xfail(reason="FALSIFIED: per-model envs not provisioned", strict=True)
+def test_per_model_envs_exist():
+    """The ensemble runs each constituent via run.sh in its own env; those envs must
+    exist (and carry the fixed code), not be created on-the-fly from published reqs."""
+    envs = REPO / "envs"
+    assert (envs / "views_stepshifter").is_dir(), "envs/views_stepshifter missing"
+    assert (envs / "views_r2darts2").is_dir(), "envs/views_r2darts2 missing (4 DL constituents)"
+
+
+@pytest.mark.xfail(reason="FALSIFIED: chunky_bunny constituents not all artifact-ready in a consistent env", strict=True)
+def test_ensemble_uses_the_fixed_code_path():
+    """Guard against the views_pipeline (tested) vs run.sh/views_stepshifter (executed)
+    mismatch: the env the ensemble actually invokes must be the one validated."""
+    # Placeholder for an integration assertion once the release/env path is decided.
+    assert False, "ensemble execution env != validation env (views_pipeline editable)"


### PR DESCRIPTION
Brings the latest tuned hyperparameters from `tuning_202606` into the 4 DL chunky_bunny constituents, applied onto `development` so **every obligatory key is preserved**.

## Hyperparameter tuning (commit 1)
| Model | Algo | Round | Notes |
|---|---|---|---|
| elastic_heart | TSMixer | r8 | lr/wd/dropout + arch (blocks 2→3, hidden 256→64), scaler→MaxAbs |
| new_rules | NBEATS | r8 | expansion_dim 20→512, static/cyclic on, input_chunk 48→36 |
| revolving_door | NHiTS | r7 | layer_widths→256, blocks 1→2, activation→Tanh, pooling retuned |
| smol_cat | TiDE | — | temporal hidden retuned, wd→0, scheduler patience↑ |

- **Obligatory keys preserved**: `delta` (3 models) + `monitor` (elastic_heart) re-injected (tuning_202606 predates them). Verified: zero dev keys dropped, no duplicates.
- **No metrics changed** by the tuning commit.
- DARTS-reproducibility + config-completeness gates pass; ruff clean.

## Folded-in WIP (commit 2, at maintainer request)
Uncommitted/untracked working-tree changes carried in so they aren't lost: `revolving_door/config_meta.py` (red_ranger sample-baseline comment-out), `yellow_submarine/config_queryset.py`, and `tests/test_chunky_bunny_readiness.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)