### PR TITLE
fix: clear 3 standing suite reds — README preserve + restore (C-77/C-78), stale tripwire (C-79), ZeroModel invariant (C-76)

### DIFF
--- a/ensembles/synthetic_chant/README.md
+++ b/ensembles/synthetic_chant/README.md
@@ -27,6 +27,7 @@ Synthetic Chant
 │   ├── config_deployment.py
 │   ├── config_hyperparameters.py
 │   ├── config_meta.py
+│   ├── config_modelset.py
 │   ├── config_partitions.py
 ├── data
 │   ├── generated
@@ -52,4 +53,41 @@ or
 ./run.sh -r calibration -t -e
 ```
 
+<!-- manual -->
+## What
 
+A concat-aggregation ensemble over three distributional synthetic models, using `PredictionFrameEnsembleManager` (composition-based, numpy-native). Each constituent produces 64 posterior samples; concat joins them horizontally into `(N, 192)`.
+
+## Why
+
+The repo has two synthetic ensembles testing two of the three ensemble managers:
+
+- `synthetic_chorus` -- `EnsembleManager` (legacy, inheritance-based)
+- `synthetic_choir` -- `DataFrameEnsembleManager` (composition-based, DataFrame)
+
+This ensemble completes the coverage by testing `PredictionFrameEnsembleManager`, which works with numpy-native PredictionFrame objects. The constituent models use distributional baselines (ConflictologyModel, MixtureBaseline) that produce posterior samples instead of point predictions.
+
+## Evaluation semantics
+
+The three constituent models are trained on **different synthetic patterns** (lucid_dream: `vertical_stripe`, vivid_dream: `horizontal_stripe`, waking_dream: `diagonal_gradient`). The ensemble evaluates all predictions against the first model's actuals (lucid_dream / `vertical_stripe`), following the standard `models[0]` actuals-selection rule in `EvaluationStage`. This means ensemble CRPS (~1.04) is much higher than any constituent's individual CRPS (0.000, 0.002, 0.043) because 128 of 192 samples come from models trained on different target distributions. The metric reflects cross-pattern disagreement, not prediction quality degradation. This ensemble tests infrastructure correctness (aggregation, serialisation, evaluation pipeline), not meaningful forecast skill.
+
+## How
+
+### Aggregation
+
+`concat` aggregation horizontally joins the posterior sample arrays:
+
+```
+lucid_dream:  (N, 64)  ]
+vivid_dream:  (N, 64)  ] --> concat --> (N, 192)
+waking_dream: (N, 64)  ]
+```
+
+### Partition boundaries
+
+| Partition    | Train       | Test        |
+|-------------|-------------|-------------|
+| Calibration | (121, 444)  | (445, 492)  |
+| Validation  | (121, 492)  | (493, 540)  |
+| Forecasting | (121, 540)  | (541, 577)  |
+<!-- /manual -->

--- a/reports/technical_risk_register.md
+++ b/reports/technical_risk_register.md
@@ -2,8 +2,8 @@
 
 **Last updated:** 2026-06-12  
 **Governing ADR:** [ADR-010](../docs/ADRs/010_technical_risk_register.md)  
-**Total entries:** 84 (80 concerns + 4 disagreements)  
-**Concerns:** Open 31 | Mitigated 12 | Resolved 33 | Accepted 3 | Partially Resolved 1  
+**Total entries:** 85 (81 concerns + 4 disagreements)  
+**Concerns:** Open 32 | Mitigated 12 | Resolved 33 | Accepted 3 | Partially Resolved 1  
 **Disagreements:** Open 4  
 
 ---
@@ -1009,6 +1009,19 @@
 | **Status** | Open |
 | **Location** | `.github/workflows/run_tests.yml`; GitHub Actions history (last green: 2026-06-04 01:21) |
 | **Notes** | Every run_tests.yml run since 2026-06-04 01:21 has failed (40/40 checked). The standing red is the union of C-73 (scaffold/pipeline-core skew, since June 5), C-75 (bright_starship env probe, structural), and C-77/C-78 (README wipe, June 4). Consequence observed this week: three independent NEW breakages (June 5 scaffold skew, June 8 chunky_bunny tripwire fire, June 9 zero_cmbaseline false invariant) accumulated unnoticed because red-on-red signals nothing, and PRs #116–#126 were all merged on red CI. Tier 2: structural fragility with a realistic, recurring trigger — every merge until CI is green again. Exit: resolve C-73 + C-75 + C-77/C-78 (tracked as the CI-green umbrella issue), then adopt the policy that development merges require green CI. See also C-28 (CI only checks last exit code), C-03 (integration tests not in CI). |
+
+---
+
+### C-81 — README regeneration crashes mid-iteration on incomplete model/ensemble dirs, leaving partial regeneration
+
+| Field | Value |
+|---|---|
+| **Tier** | 3 |
+| **Trigger** | `update_catalogs.yml` runs on a fresh checkout (where `ensembles/cruel_summer` and `ensembles/white_mustang` have no tracked `artifacts/`), or a local regeneration runs while a stray partial model dir sits in `models/` — the script crashes after rewriting an arbitrary prefix of READMEs |
+| **Source** | session verification of PR #133 (2026-06-12) |
+| **Status** | Open |
+| **Location** | `tools/catalogs/update_readme.py` (both loops construct `ModelPathManager`/`EnsemblePathManager` with default `validate=True`; writes happen per-directory as iteration proceeds) |
+| **Notes** | Observed live, three separate crash points: stray untracked `models/teenage_dirtbag` and `models/cool_cat` (partial dirs, no `artifacts/`), then tracked `ensembles/white_mustang` (no `artifacts/` in git; `cruel_summer` same gap — the C-32 `.gitkeep` backfill covered models, not these ensembles). `ModelPathManager` raises `FileNotFoundError` on a missing standard dir, killing the whole run. Because the script writes each README as it iterates (`iterdir()`, unsorted), a crash leaves an arbitrary subset regenerated — locally confusing; in the workflow the step fails (post-C-28 `set -e`), so catalogs go silently stale rather than partially committed. Fix directions: (a) construct path managers with `validate=False` (catalog generation is read-only on the dir structure) or per-entry try/except + end-of-run failure summary; (b) backfill `artifacts/.gitkeep` for cruel_summer/white_mustang (C-32 extension to ensembles); (c) iterate only git-tracked dirs so workstation strays can't break tooling. See also C-32 (root cause for the tracked gaps — Mitigated, recurrence here), C-28 (exit-code masking in this workflow — Resolved), C-65 (catalog tools untested), C-78 (manual-block preservation — Resolved; orthogonal fix in the same script). |
 
 ---
 

--- a/reports/technical_risk_register.md
+++ b/reports/technical_risk_register.md
@@ -2,8 +2,8 @@
 
 **Last updated:** 2026-06-12  
 **Governing ADR:** [ADR-010](../docs/ADRs/010_technical_risk_register.md)  
-**Total entries:** 85 (81 concerns + 4 disagreements)  
-**Concerns:** Open 32 | Mitigated 12 | Resolved 33 | Accepted 3 | Partially Resolved 1  
+**Total entries:** 87 (83 concerns + 4 disagreements)  
+**Concerns:** Open 33 | Mitigated 12 | Resolved 34 | Accepted 3 | Partially Resolved 1  
 **Disagreements:** Open 4  
 
 ---
@@ -1022,6 +1022,32 @@
 | **Status** | Open |
 | **Location** | `tools/catalogs/update_readme.py` (both loops construct `ModelPathManager`/`EnsemblePathManager` with default `validate=True`; writes happen per-directory as iteration proceeds) |
 | **Notes** | Observed live, three separate crash points: stray untracked `models/teenage_dirtbag` and `models/cool_cat` (partial dirs, no `artifacts/`), then tracked `ensembles/white_mustang` (no `artifacts/` in git; `cruel_summer` same gap — the C-32 `.gitkeep` backfill covered models, not these ensembles). `ModelPathManager` raises `FileNotFoundError` on a missing standard dir, killing the whole run. Because the script writes each README as it iterates (`iterdir()`, unsorted), a crash leaves an arbitrary subset regenerated — locally confusing; in the workflow the step fails (post-C-28 `set -e`), so catalogs go silently stale rather than partially committed. Fix directions: (a) construct path managers with `validate=False` (catalog generation is read-only on the dir structure) or per-entry try/except + end-of-run failure summary; (b) backfill `artifacts/.gitkeep` for cruel_summer/white_mustang (C-32 extension to ensembles); (c) iterate only git-tracked dirs so workstation strays can't break tooling. See also C-32 (root cause for the tracked gaps — Mitigated, recurrence here), C-28 (exit-code masking in this workflow — Resolved), C-65 (catalog tools untested), C-78 (manual-block preservation — Resolved; orthogonal fix in the same script). |
+
+---
+
+### C-82 — Manual blocks duplicate when a README also carries a `## Created on` section
+
+| Field | Value |
+|---|---|
+| **Tier** | 4 |
+| **Trigger** | A README processed by `update_readme.py` carries BOTH a `## Created on` section and a `<!-- manual -->` block, and a regeneration runs — the block is emitted twice and multiplies on every subsequent run |
+| **Source** | falsify (PR #133 audit, probe P1, 2026-06-12) |
+| **Status** | Resolved (2026-06-12) |
+| **Location** | `tools/catalogs/update_readme.py` (Created-on capture `re.search(r"(## Created on.*)", …, re.DOTALL)`, both loops); interaction with `readme_preserve.merge_manual_blocks` |
+| **Notes** | The Created-on regex captures from the heading to END OF FILE; merged manual blocks live at the end of the file, so they get swallowed into the captured created-section (re-inserted via `{{CREATED_SECTION}}`) AND re-appended by the merge → duplication, compounding per regeneration. Latent when found: no README the script processes had a Created section (test_model/test_ensemble are fixture-skipped; apis/ and postprocessors/ are not iterated). Wrong-output is duplication, not loss → Tier 4. **Resolved same day:** `readme_preserve.strip_manual_blocks()` added; both loops now run the Created-on capture on the stripped text (blocks extracted from the original first). Falsification stub `tests/test_falsification_readme_preserve.py` un-xfailed to a plain regression guard. See also C-78 (sibling failure mode — loss), C-81 (sibling failure mode — crash), C-65 (catalog tools untested — now partially chipped). |
+
+---
+
+### C-83 — `## Created on` sections are lost on the second regeneration (heading rename breaks recapture)
+
+| Field | Value |
+|---|---|
+| **Tier** | 4 |
+| **Trigger** | A README gains a `## Created on` section and `update_readme.py` runs twice — the first run renames the heading to `## Model Created on`, which the capture regex `(## Created on.*)` no longer matches, so the second run drops the section entirely |
+| **Source** | falsify (PR #133 audit, bonus discovery while pinning C-82, 2026-06-12) |
+| **Status** | Open |
+| **Location** | `tools/catalogs/update_readme.py` (both loops: `re.search(r"(## Created on.*)" …)` followed by the `[:2] + " Model"` heading rewrite) |
+| **Notes** | Pre-existing, unrelated to the C-78/C-82 fixes. The rename-then-recapture mismatch means any created-section survives exactly one regeneration — which likely explains why NO currently-processed README has one (they were silently eaten by successive catalog runs over time; only fixture/non-iterated READMEs retain theirs). Same content-loss family as C-78 but a different mechanism. Fix directions: match both headings (`(## (?:Model )?Created on.*)`) and stop re-prefixing if already prefixed, or stop renaming the heading altogether. Alternatively: deprecate the special-cased created-section in favor of the `<!-- manual -->` mechanism (C-78), which is rename-proof. See also C-78, C-82, C-65. |
 
 ---
 

--- a/reports/technical_risk_register.md
+++ b/reports/technical_risk_register.md
@@ -3,7 +3,7 @@
 **Last updated:** 2026-06-12  
 **Governing ADR:** [ADR-010](../docs/ADRs/010_technical_risk_register.md)  
 **Total entries:** 84 (80 concerns + 4 disagreements)  
-**Concerns:** Open 35 | Mitigated 12 | Resolved 29 | Accepted 3 | Partially Resolved 1  
+**Concerns:** Open 31 | Mitigated 12 | Resolved 33 | Accepted 3 | Partially Resolved 1  
 **Disagreements:** Open 4  
 
 ---
@@ -954,9 +954,9 @@
 | **Tier** | 4 |
 | **Trigger** | The PFE log-compression test runs against a zero/constant baseline (e.g. zero_cmbaseline) and asserts `max>10`, which a correct all-zeros prediction can never satisfy |
 | **Source** | repo-assimilation + expert-review (2026-06-09) |
-| **Status** | Open |
+| **Status** | Resolved (2026-06-12) |
 | **Location** | `tests/test_pfe_production_readiness.py::TestTransformUndoScale::test_values_not_log_compressed` |
-| **Notes** | The `max>10` heuristic (guarding against predictions left on `log1p` scale) is valid for learned-magnitude models but FALSE for `ZeroModel`, which correctly emits all-zeros (zero_cmbaseline max=0.0 → perpetual fail). Verified `locf_cmbaseline` (max 17412) and `average_cmbaseline` (max 4743) legitimately pass and MUST keep the guard — so the fix is to exclude **`ZeroModel` only** (keyed off `config_meta["algorithm"]`) and, better, assert `max==0 and min==0` for ZeroModel (a ZeroModel emitting nonzero is itself a bug). Local-only (CI has no prediction artifacts). A test-design correction, not a coverage skip. |
+| **Notes** | The `max>10` heuristic (guarding against predictions left on `log1p` scale) is valid for learned-magnitude models but FALSE for `ZeroModel`, which correctly emits all-zeros (zero_cmbaseline max=0.0 → perpetual fail). Verified `locf_cmbaseline` (max 17412) and `average_cmbaseline` (max 4743) legitimately pass and MUST keep the guard — so the fix is to exclude **`ZeroModel` only** (keyed off `config_meta["algorithm"]`) and, better, assert `max==0 and min==0` for ZeroModel (a ZeroModel emitting nonzero is itself a bug). Local-only (CI has no prediction artifacts). A test-design correction, not a coverage skip. **2026-06-12: Resolved** exactly as described (issue #129) — ZeroModel branch asserts all-zeros, all other models keep the `max>10` guard. |
 
 ---
 
@@ -967,9 +967,9 @@
 | **Tier** | 4 |
 | **Trigger** | A reader interprets synthetic_chant's ensemble CRPS as prediction quality, unaware it reflects cross-pattern disagreement measured against models[0]'s actuals |
 | **Source** | repo-assimilation + falsify (2026-06-09) |
-| **Status** | Open |
+| **Status** | Resolved (2026-06-12) |
 | **Location** | `ensembles/synthetic_chant/README.md`; `tests/test_falsification_synthetic_runs.py::test_falsify_01_synthetic_chant_readme_documents_crps_inflation` |
-| **Notes** | Genuine documentation gap (TDD-red test). Constituents use different synthetic patterns — `lucid_dream`=`vertical_stripe` (models[0] → supplies ground-truth actuals), `vivid_dream`=`horizontal_stripe`, `waking_dream`=`diagonal_gradient`; the ensemble evaluates all predictions against models[0]'s actuals, so CRPS (constituent 0.000/0.002/0.043 → ensemble 1.044) measures cross-pattern disagreement, not prediction quality. Real fix: document these facts in the README (mirror `ensembles/synthetic_chorus/README.md`). See also C-43 (synthetic_chorus order-dependency), C-42 (synthetic models on unreleased core). **2026-06-12 (root cause):** the documentation EXISTED — added 2026-05-26 (`8af868e`, the same commit that added the test) — and was deleted by the 2026-06-04 README regeneration (`243873a`); `tools/catalogs/update_readme.py` rebuilds READMEs from the scaffold, preserving only the `## Created on…` tail. Re-writing the docs without fixing the generator (C-78) just re-arms the failure — sequence with C-78. |
+| **Notes** | Genuine documentation gap (TDD-red test). Constituents use different synthetic patterns — `lucid_dream`=`vertical_stripe` (models[0] → supplies ground-truth actuals), `vivid_dream`=`horizontal_stripe`, `waking_dream`=`diagonal_gradient`; the ensemble evaluates all predictions against models[0]'s actuals, so CRPS (constituent 0.000/0.002/0.043 → ensemble 1.044) measures cross-pattern disagreement, not prediction quality. Real fix: document these facts in the README (mirror `ensembles/synthetic_chorus/README.md`). See also C-43 (synthetic_chorus order-dependency), C-42 (synthetic models on unreleased core). **2026-06-12 (root cause):** the documentation EXISTED — added 2026-05-26 (`8af868e`, the same commit that added the test) — and was deleted by the 2026-06-04 README regeneration (`243873a`); `tools/catalogs/update_readme.py` rebuilds READMEs from the scaffold, preserving only the `## Created on…` tail. Re-writing the docs without fixing the generator (C-78) just re-arms the failure — sequence with C-78. **2026-06-12: Resolved together with C-78** (issues #123/#130) — semantics restored inside a `<!-- manual -->` block, which the fixed generator now preserves. |
 
 ---
 
@@ -980,9 +980,9 @@
 | **Tier** | 3 |
 | **Trigger** | `tools/catalogs/update_readme.py` is run (manually or via `update_catalogs.yml`) against any model/ensemble README carrying manual content outside the preserved `## Created on…` tail |
 | **Source** | session investigation (2026-06-12) |
-| **Status** | Open |
+| **Status** | Resolved (2026-06-12) |
 | **Location** | `tools/catalogs/update_readme.py:125-135` (scaffold rebuild, `## Created on` regex tail-preserve); `.github/workflows/update_catalogs.yml` (automated path) |
-| **Notes** | Verified incident: the synthetic_chant CRPS-semantics documentation added 2026-05-26 (`8af868e`) was deleted by the 2026-06-04 regeneration (`243873a`, "docs: regenerate model catalog tables and per-model READMEs") — the direct cause of the C-77 test failure and the first June 4 CI red. The generator rebuilds each README from `README_scaffold.md` and preserves only the `## Created on…` tail, so ANY hand-written section in any of the ~100 model/ensemble READMEs is silently destroyed on every regeneration — no diff review gate on the automated path, no error signal. Tier 3 (silent destruction of committed work product; affects every contributor who documents a model). Real fix: preserve-markers (e.g. a `<!-- manual -->` block) or regenerate only the generated tables, plus a regression test that a marked manual section survives regeneration (C-65: the tool currently has zero tests). See also C-77 (the wiped instance), C-65, C-36. |
+| **Notes** | Verified incident: the synthetic_chant CRPS-semantics documentation added 2026-05-26 (`8af868e`) was deleted by the 2026-06-04 regeneration (`243873a`, "docs: regenerate model catalog tables and per-model READMEs") — the direct cause of the C-77 test failure and the first June 4 CI red. The generator rebuilds each README from `README_scaffold.md` and preserves only the `## Created on…` tail, so ANY hand-written section in any of the ~100 model/ensemble READMEs is silently destroyed on every regeneration — no diff review gate on the automated path, no error signal. Tier 3 (silent destruction of committed work product; affects every contributor who documents a model). Real fix: preserve-markers (e.g. a `<!-- manual -->` block) or regenerate only the generated tables, plus a regression test that a marked manual section survives regeneration (C-65: the tool currently has zero tests). See also C-77 (the wiped instance), C-65, C-36. **2026-06-12: Resolved** (issue #130) — `tools/catalogs/readme_preserve.py` extracts `<!-- manual -->…<!-- /manual -->` blocks from the old README and re-appends them after regeneration (wired into both loops of `update_readme.py`); regression tests in `tests/test_readme_preserve.py` (chips at C-65). |
 
 ---
 
@@ -993,9 +993,9 @@
 | **Tier** | 4 |
 | **Trigger** | Anyone runs the local suite (or reads its output) while `test_target_transform_fix_is_released` still carries `@pytest.mark.xfail(strict=True)` — the XPASS registers as a hard failure and noise-trains readers to ignore red |
 | **Source** | session investigation (2026-06-12) |
-| **Status** | Open |
+| **Status** | Resolved (2026-06-12) |
 | **Location** | `tests/test_chunky_bunny_readiness.py::test_target_transform_fix_is_released` |
-| **Notes** | The tripwire worked exactly as designed: it was armed 2026-06-09 against "published views-stepshifter lacks `target_transform`" and fired when views-stepshifter merged the mechanism to main on 2026-06-08/09 (`261ef6c`, PR #74 → main merge #76, released as 1.3.0). The strict-xfail marker is now stale and produces a permanent suite failure (same genre as resolved C-55). Fix: flip to a plain assertion. The two sibling tripwires remain LEGITIMATELY red and must stay armed: `test_per_model_envs_exist` (envs/views_stepshifter, envs/views_r2darts2 unprovisioned on this box) and `test_ensemble_uses_the_fixed_code_path` (validation env ≠ execution env, placeholder). I.e., the release precondition is met but chunky_bunny is NOT yet runnable via run.sh envs — the #117 dev-mode run tracker sidesteps this. See also C-55 (genre), issues #117, #114, views-stepshifter#55. |
+| **Notes** | The tripwire worked exactly as designed: it was armed 2026-06-09 against "published views-stepshifter lacks `target_transform`" and fired when views-stepshifter merged the mechanism to main on 2026-06-08/09 (`261ef6c`, PR #74 → main merge #76, released as 1.3.0). The strict-xfail marker is now stale and produces a permanent suite failure (same genre as resolved C-55). Fix: flip to a plain assertion. The two sibling tripwires remain LEGITIMATELY red and must stay armed: `test_per_model_envs_exist` (envs/views_stepshifter, envs/views_r2darts2 unprovisioned on this box) and `test_ensemble_uses_the_fixed_code_path` (validation env ≠ execution env, placeholder). I.e., the release precondition is met but chunky_bunny is NOT yet runnable via run.sh envs — the #117 dev-mode run tracker sidesteps this. See also C-55 (genre), issues #117, #114, views-stepshifter#55. **2026-06-12: Resolved** (issue #128) — xfail removed; the test is now a plain regression guard with a `skipif` when the sibling views-stepshifter checkout is absent (CI-safe, the C-75 lesson applied proactively). The two sibling tripwires remain armed. |
 
 ---
 

--- a/tests/test_chunky_bunny_readiness.py
+++ b/tests/test_chunky_bunny_readiness.py
@@ -16,9 +16,14 @@ Our entire validation (car_radio/bittersweet_symphony/counting_stars MSLE ~0.41)
 was run in `views_pipeline` (editable install of the FIXED branch) — which is NOT
 the env the ensemble uses. The green test gave false confidence.
 
-These tests encode the readiness preconditions. They FAIL today; they pass once the
-fix is released (merged to main + published) OR the per-model envs are provisioned
-with the fixed code.
+These tests encode the readiness preconditions.
+
+STATUS 2026-06-12 (C-79): precondition (b) is MET — views-stepshifter merged
+`target_transform` to main on 2026-06-08 (261ef6c, PR #74/#76) and released
+1.3.0, so a fresh env would now pip-install the FIXED code. That tripwire is
+flipped to a plain assertion below (issue #128). Precondition (a) — the
+per-model envs — is still open, and the validation-env ≠ execution-env
+placeholder still stands; those two tripwires stay armed (strict xfail).
 """
 import subprocess
 from pathlib import Path
@@ -37,10 +42,16 @@ def _origin_main_gate_has_target_transform() -> bool:
     return "target_transform" in out.stdout
 
 
-@pytest.mark.xfail(reason="FALSIFIED: target_transform fix not merged to main / not released", strict=True)
+@pytest.mark.skipif(
+    not STEPSHIFTER_REPO.is_dir(),
+    reason="sibling views-stepshifter checkout not present (workstation pre-flight probe)",
+)
 def test_target_transform_fix_is_released():
     """The published views-stepshifter that constituents pip-install must support
-    target_transform — otherwise the log1p fix is silently ignored at ensemble run."""
+    target_transform — otherwise the log1p fix is silently ignored at ensemble run.
+
+    Fired and resolved: the mechanism reached origin/main 2026-06-08 (261ef6c,
+    released 1.3.0). Now a plain regression guard against the fix disappearing."""
     assert _origin_main_gate_has_target_transform(), (
         "origin/main reproducibility_gate has no target_transform — a fresh "
         "envs/views_stepshifter (pip install views-stepshifter>=1.0.0,<2.0.0) "

--- a/tests/test_falsification_readme_preserve.py
+++ b/tests/test_falsification_readme_preserve.py
@@ -1,0 +1,69 @@
+"""Falsification finding — manual-block duplication via the Created-section capture.
+
+Found by a falsification audit of PR #133 (2026-06-12), probe P1; register C-82.
+RESOLVED same day: update_readme.py now runs its '## Created on' tail-capture
+on strip_manual_blocks(old) so blocks at end-of-file are never swallowed into
+the captured created-section. These tests pin the fixed behavior.
+"""
+import re
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT))
+
+from tools.catalogs.readme_preserve import (  # noqa: E402
+    extract_manual_blocks,
+    merge_manual_blocks,
+    strip_manual_blocks,
+)
+
+OLD = (
+    "# Old\nbody\n"
+    "## Created on 2026-01-01\ncreated text\n\n"
+    "<!-- manual -->\n## Precious docs\n<!-- /manual -->\n"
+)
+SCAFFOLD = "# New\nfresh body\n{{CREATED_SECTION}}\n"
+
+
+def _regenerate(old, scaffold):
+    """Replicate update_readme.py's post-C-82 logic verbatim (incl. the
+    match-is-None branch: after one regeneration the heading reads
+    '## Model Created on', which the regex no longer matches — C-83)."""
+    match = re.search(r"(## Created on.*)", strip_manual_blocks(old), re.DOTALL)
+    if match is None:
+        created = ""
+    else:
+        created = match.group(1).strip()
+        created = created[:2] + " Model" + created[2:]
+    content = scaffold.replace("{{CREATED_SECTION}}", created)
+    return merge_manual_blocks(content, extract_manual_blocks(old))
+
+
+@pytest.mark.green
+class TestNoDuplicationWithCreatedSection:
+    def test_manual_block_emitted_exactly_once(self):
+        merged = _regenerate(OLD, SCAFFOLD)
+        assert merged.count("## Precious docs") == 1, (
+            "manual block emitted twice: once inside the captured "
+            "Created-on section, once via merge_manual_blocks (C-82)"
+        )
+
+    def test_created_section_still_preserved(self):
+        merged = _regenerate(OLD, SCAFFOLD)
+        assert "## Model Created on 2026-01-01" in merged
+        assert "created text" in merged
+
+    def test_stable_under_repeated_regeneration(self):
+        # Manual-block stability is the C-82 guarantee. (The created-section
+        # does NOT survive a second regeneration — pre-existing C-83, out of
+        # scope here.)
+        once = _regenerate(OLD, SCAFFOLD)
+        twice = _regenerate(once, SCAFFOLD)
+        assert twice.count("## Precious docs") == 1
+
+    def test_strip_is_inverse_of_block_presence(self):
+        assert "Precious" not in strip_manual_blocks(OLD)
+        assert strip_manual_blocks("no markers here") == "no markers here"

--- a/tests/test_pfe_production_readiness.py
+++ b/tests/test_pfe_production_readiness.py
@@ -376,6 +376,15 @@ class TestTransformUndoScale:
         if target.startswith("synth_"):
             pytest.skip(f"{name}/{target}: synthetic target, log-compression check N/A")
         y = np.load(origin / target / "y_pred.npy", mmap_mode="r")
+        if _load_meta(name)["algorithm"] == "ZeroModel":
+            # C-76: a zero baseline correctly emits all-zeros — the max>10
+            # heuristic is a false invariant for it. Assert the inverse:
+            # a ZeroModel emitting nonzero is itself a bug.
+            assert y.max() == 0 and y.min() == 0, (
+                f"{name}/{target}: ZeroModel must predict all zeros, got "
+                f"[{y.min():.4f}, {y.max():.4f}]"
+            )
+            return
         assert y.max() > 10, (
             f"{name}/{target}: max value {y.max():.4f} suggests log-scale — "
             f"measurement-scale fatality counts should exceed 10 in high-conflict cells"

--- a/tests/test_readme_preserve.py
+++ b/tests/test_readme_preserve.py
@@ -84,6 +84,17 @@ class TestGeneratorWiring:
             "update_readme.py must merge manual blocks in BOTH the models and ensembles loops"
         )
 
+    def test_created_on_capture_runs_on_stripped_text(self):
+        """C-82 guard: the duplication tests replicate the script's logic, so
+        they cannot detect a revert in the script itself — this pins that both
+        Created-on captures actually search strip_manual_blocks(...) output."""
+        source = UPDATE_README.read_text()
+        assert source.count("strip_manual_blocks(old_readme_content)") >= 2, (
+            "both '## Created on' captures in update_readme.py must search "
+            "strip_manual_blocks(old_readme_content), or end-of-file manual "
+            "blocks get swallowed into the created section and duplicate (C-82)"
+        )
+
 
 @pytest.mark.beige
 class TestSyntheticChantRestoration:

--- a/tests/test_readme_preserve.py
+++ b/tests/test_readme_preserve.py
@@ -59,9 +59,16 @@ class TestManualBlockSurvival:
         merged_twice = merge_manual_blocks("gen v2\n", extract_manual_blocks(merged_once))
         assert extract_manual_blocks(merged_twice) == [block]
 
-    def test_unterminated_block_is_not_extracted(self):
-        """An opening marker without a closing one must not swallow the file."""
-        assert extract_manual_blocks(f"{MANUAL_START}\nno end marker\n") == []
+    def test_unterminated_block_fails_loud(self):
+        """A dangling start marker must crash the regeneration, not silently
+        drop the content it was meant to protect (the C-78 failure mode)."""
+        with pytest.raises(ValueError, match="unterminated"):
+            extract_manual_blocks(f"{MANUAL_START}\nno end marker\n")
+
+    def test_terminated_plus_dangling_still_fails_loud(self):
+        block = _block("## kept")
+        with pytest.raises(ValueError, match="unterminated"):
+            extract_manual_blocks(f"{block}\n{MANUAL_START}\ndangling\n")
 
 
 @pytest.mark.beige

--- a/tests/test_readme_preserve.py
+++ b/tests/test_readme_preserve.py
@@ -1,0 +1,93 @@
+"""Tests for readme_preserve.py — manual-block survival through README regeneration.
+
+Guards risk register C-78: tools/catalogs/update_readme.py rebuilds READMEs
+from a scaffold; before this mechanism existed, the 2026-06-04 regeneration
+(243873a) silently destroyed the hand-written synthetic_chant evaluation
+semantics (C-77). Content wrapped in <!-- manual --> ... <!-- /manual -->
+must survive regeneration byte-for-byte.
+"""
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT))
+
+from tools.catalogs.readme_preserve import (  # noqa: E402
+    MANUAL_END,
+    MANUAL_START,
+    extract_manual_blocks,
+    merge_manual_blocks,
+)
+
+UPDATE_README = REPO_ROOT / "tools" / "catalogs" / "update_readme.py"
+CHANT_README = REPO_ROOT / "ensembles" / "synthetic_chant" / "README.md"
+
+
+def _block(body):
+    return f"{MANUAL_START}\n{body}\n{MANUAL_END}"
+
+
+@pytest.mark.green
+class TestManualBlockSurvival:
+    """A marked manual section survives a simulated regeneration."""
+
+    def test_single_block_survives_byte_for_byte(self):
+        block = _block("## Hand-written\n\nPrecious | content – with *markdown*.")
+        old = f"# Old Generated Title\n\nstale tables\n\n{block}\n"
+        regenerated = "# New Generated Title\n\nfresh tables\n"
+        merged = merge_manual_blocks(regenerated, extract_manual_blocks(old))
+        assert block in merged
+        assert "fresh tables" in merged
+
+    def test_multiple_blocks_preserved_in_order(self):
+        first = _block("## First")
+        second = _block("## Second")
+        old = f"intro\n{first}\nmiddle\n{second}\nend\n"
+        merged = merge_manual_blocks("generated\n", extract_manual_blocks(old))
+        assert merged.index(first) < merged.index(second)
+
+    def test_no_markers_is_a_no_op(self):
+        generated = "# Generated\n\ncontent\n"
+        assert merge_manual_blocks(generated, extract_manual_blocks("old, no markers")) == generated
+
+    def test_merge_is_a_stable_fixed_point(self):
+        """Blocks extracted from merged output reproduce themselves on re-merge."""
+        block = _block("## Survives forever")
+        merged_once = merge_manual_blocks("gen v1\n", extract_manual_blocks(f"old\n{block}\n"))
+        merged_twice = merge_manual_blocks("gen v2\n", extract_manual_blocks(merged_once))
+        assert extract_manual_blocks(merged_twice) == [block]
+
+    def test_unterminated_block_is_not_extracted(self):
+        """An opening marker without a closing one must not swallow the file."""
+        assert extract_manual_blocks(f"{MANUAL_START}\nno end marker\n") == []
+
+
+@pytest.mark.beige
+class TestGeneratorWiring:
+    """update_readme.py must actually use the preserve mechanism (static check —
+    importing the script would execute the full regeneration)."""
+
+    def test_update_readme_imports_and_calls_preserve(self):
+        source = UPDATE_README.read_text()
+        assert "readme_preserve" in source, "update_readme.py does not import readme_preserve"
+        # Once per loop: models and ensembles.
+        assert source.count("merge_manual_blocks(") >= 2, (
+            "update_readme.py must merge manual blocks in BOTH the models and ensembles loops"
+        )
+
+
+@pytest.mark.beige
+class TestSyntheticChantRestoration:
+    """The C-77 documentation is restored inside a manual block (so the next
+    regeneration cannot wipe it again)."""
+
+    def test_chant_readme_has_manual_block_with_semantics(self):
+        blocks = extract_manual_blocks(CHANT_README.read_text())
+        assert blocks, "synthetic_chant README has no <!-- manual --> block"
+        joined = "\n".join(blocks)
+        for needle in ("vertical_stripe", "actuals", "cross-pattern disagreement"):
+            assert needle in joined, (
+                f"synthetic_chant manual block lost the evaluation-semantics docs ({needle!r} missing)"
+            )

--- a/tools/catalogs/readme_preserve.py
+++ b/tools/catalogs/readme_preserve.py
@@ -44,6 +44,17 @@ def extract_manual_blocks(text):
     return blocks
 
 
+def strip_manual_blocks(text):
+    """Return `text` with all manual blocks removed.
+
+    update_readme.py must run its '## Created on' tail-capture on stripped
+    text: that regex captures to end-of-file, and merged blocks live at the
+    end — capturing them inside the created-section would emit them twice
+    (C-82: once via {{CREATED_SECTION}}, once via merge_manual_blocks).
+    """
+    return _BLOCK_RE.sub("", text)
+
+
 def merge_manual_blocks(generated, blocks):
     """Append `blocks` verbatim to `generated`, separated by blank lines.
 

--- a/tools/catalogs/readme_preserve.py
+++ b/tools/catalogs/readme_preserve.py
@@ -29,8 +29,19 @@ _BLOCK_RE = re.compile(
 
 
 def extract_manual_blocks(text):
-    """Return all manual blocks in `text`, markers included, in order."""
-    return _BLOCK_RE.findall(text)
+    """Return all manual blocks in `text`, markers included, in order.
+
+    Raises ValueError on a dangling start marker (no closing marker):
+    silently dropping it would wipe the very content these markers
+    protect — a crashed regeneration is recoverable, deleted docs are not.
+    """
+    blocks = _BLOCK_RE.findall(text)
+    if text.count(MANUAL_START) > len(blocks):
+        raise ValueError(
+            f"unterminated {MANUAL_START} block (missing {MANUAL_END}) — "
+            "fix the README before regenerating, or its manual content would be lost"
+        )
+    return blocks
 
 
 def merge_manual_blocks(generated, blocks):

--- a/tools/catalogs/readme_preserve.py
+++ b/tools/catalogs/readme_preserve.py
@@ -1,0 +1,47 @@
+"""Manual-block preservation for generated READMEs.
+
+`update_readme.py` rebuilds every model/ensemble README from a scaffold,
+which destroys hand-written content (risk register C-78; the 2026-06-04
+regeneration wiped the synthetic_chant evaluation-semantics docs, C-77).
+
+Any content wrapped in marker comments survives regeneration verbatim:
+
+    <!-- manual -->
+    ## My hand-written section
+    ...
+    <!-- /manual -->
+
+Blocks are extracted from the pre-regeneration README and re-appended,
+in order, at the end of the regenerated content.
+
+Pure stdlib on purpose: unlike update_readme.py (which executes the full
+regeneration at import time and needs views_pipeline_core), this module
+is safely importable from tests.
+"""
+import re
+
+MANUAL_START = "<!-- manual -->"
+MANUAL_END = "<!-- /manual -->"
+
+_BLOCK_RE = re.compile(
+    re.escape(MANUAL_START) + r".*?" + re.escape(MANUAL_END), re.DOTALL
+)
+
+
+def extract_manual_blocks(text):
+    """Return all manual blocks in `text`, markers included, in order."""
+    return _BLOCK_RE.findall(text)
+
+
+def merge_manual_blocks(generated, blocks):
+    """Append `blocks` verbatim to `generated`, separated by blank lines.
+
+    No-op when `blocks` is empty. The end of the file is the stable
+    fixed point: blocks extracted from the merged output land in the
+    same place on the next regeneration.
+    """
+    if not blocks:
+        return generated
+    parts = [generated.rstrip("\n")]
+    parts.extend(blocks)
+    return "\n\n".join(parts) + "\n"

--- a/tools/catalogs/update_readme.py
+++ b/tools/catalogs/update_readme.py
@@ -4,6 +4,12 @@ import re
 from views_pipeline_core.managers.model import ModelManager, ModelPathManager
 from views_pipeline_core.managers.ensemble import EnsembleManager, EnsemblePathManager
 
+# Run as a script (sys.path[0] = this dir) or imported as tools.catalogs.*
+try:
+    from readme_preserve import extract_manual_blocks, merge_manual_blocks
+except ImportError:
+    from tools.catalogs.readme_preserve import extract_manual_blocks, merge_manual_blocks
+
 
 base_dir = os.getcwd()
 target_dir = Path(base_dir + "/models")
@@ -175,7 +181,12 @@ for subfolder in target_dir.iterdir():
         updated_readme = content.replace("## Repository Structure",
                 f"## Repository Structure\n\n{formatted_structure}",
             )
-        
+
+        # Re-attach hand-written <!-- manual --> blocks from the old README (C-78)
+        updated_readme = merge_manual_blocks(
+            updated_readme, extract_manual_blocks(old_readme_content)
+        )
+
         # Write the updated content to README.md
         with open(readme_path, "w") as file:
             file.write(updated_readme)
@@ -268,7 +279,11 @@ for subfolder in target_ens_dir.iterdir():
         updated_readme = content.replace("## Repository Structure",
                 f"## Repository Structure\n\n{formatted_structure}",
             )
-        
+
+        # Re-attach hand-written <!-- manual --> blocks from the old README (C-78)
+        updated_readme = merge_manual_blocks(
+            updated_readme, extract_manual_blocks(old_readme_content)
+        )
 
         # Write the updated content to README.md
         with open(readme_path, "w") as file:

--- a/tools/catalogs/update_readme.py
+++ b/tools/catalogs/update_readme.py
@@ -6,9 +6,13 @@ from views_pipeline_core.managers.ensemble import EnsembleManager, EnsemblePathM
 
 # Run as a script (sys.path[0] = this dir) or imported as tools.catalogs.*
 try:
-    from readme_preserve import extract_manual_blocks, merge_manual_blocks
+    from readme_preserve import (
+        extract_manual_blocks, merge_manual_blocks, strip_manual_blocks,
+    )
 except ImportError:
-    from tools.catalogs.readme_preserve import extract_manual_blocks, merge_manual_blocks
+    from tools.catalogs.readme_preserve import (
+        extract_manual_blocks, merge_manual_blocks, strip_manual_blocks,
+    )
 
 
 base_dir = os.getcwd()
@@ -138,7 +142,11 @@ for subfolder in target_dir.iterdir():
 
         # Add created section if it exists
 
-        match = re.search(r"(## Created on.*)", old_readme_content, re.DOTALL)
+        # C-82: capture on stripped text — the DOTALL tail-capture would otherwise
+        # swallow manual blocks (which sit at end-of-file) into the created section.
+        match = re.search(
+            r"(## Created on.*)", strip_manual_blocks(old_readme_content), re.DOTALL
+        )
         if match is None:
             new_string=''
         else:
@@ -239,7 +247,11 @@ for subfolder in target_ens_dir.iterdir():
 
         # Add created section if it exists
 
-        match = re.search(r"(## Created on.*)", old_readme_content, re.DOTALL)
+        # C-82: capture on stripped text — the DOTALL tail-capture would otherwise
+        # swallow manual blocks (which sit at end-of-file) into the created section.
+        match = re.search(
+            r"(## Created on.*)", strip_manual_blocks(old_readme_content), re.DOTALL
+        )
         if match is None:
             new_string=''
         else:


### PR DESCRIPTION
## Summary
Implements three of the fixes tracked in the CI-green umbrella #132, taking the local suite from **4 standing failures to 1** (only golden_hour/#131 remains) and removing one of the three CI reds (the synthetic_chant README test).

| Fix | Issue | Register |
|---|---|---|
| README generator preserves `<!-- manual -->` blocks + restore the wiped synthetic_chant docs | #130, #123 | C-78, C-77 → Resolved |
| chunky_bunny tripwire: stale strict-xfail flipped to plain guard (+ skipif for CI, where the sibling repo doesn't exist) | #128 | C-79 → Resolved |
| ZeroModel exemption: assert all-zeros instead of `max>10` | #129 | C-76 → Resolved |

## Detail
- **New `tools/catalogs/readme_preserve.py`** (pure stdlib): extracts `<!-- manual -->…<!-- /manual -->` blocks from the pre-regeneration README and re-appends them verbatim; wired into both loops of `update_readme.py`. Regression tests in `tests/test_readme_preserve.py` (survival, ordering, no-op, fixed-point, generator wiring, chant restoration).
- **Verified end-to-end**: ran the real regeneration (`python tools/catalogs/update_readme.py` in the views_pipeline env) — the restored manual block survived; other ensemble README refreshes were deliberately left out of this PR (the catalog workflow's job).
- **Note for the next catalog run**: the script currently dies on stray untracked model dirs without `artifacts/` (local `cool_cat`, `teenage_dirtbag`) and on tracked ensembles missing `artifacts/` (`cruel_summer`, `white_mustang` — the C-32 empty-dirs gap). Pre-existing fragility, not addressed here.
- **Tripwire**: the probe's condition became true 2026-06-08 (views-stepshifter `261ef6c`, PR #74/#76, released 1.3.0). The two sibling tripwires (per-model envs; validation-env ≠ execution-env) remain armed — chunky_bunny is still not run.sh-runnable (see #117).
- Register entries C-76/C-77/C-78/C-79 marked Resolved with dated notes; header counts updated.

## Verification
- `ruff check .` clean.
- Full suite (views_pipeline env): **5392 passed**, 2 failed = golden_hour sample-count (#131, untouched) + the uncommitted-work guard (clears on merge).
- Targeted: `test_readme_preserve.py`, `test_chunky_bunny_readiness.py` (1 pass + 2 armed xfail), `test_falsification_synthetic_runs.py`, `TestTransformUndoScale` all green.

⚠️ This PR targets `development` (not the default branch), so the `Closes #…` keywords in the commits won't auto-close — **close #123, #128, #129, #130 manually on merge** and tick their boxes in #132.

🤖 Generated with [Claude Code](https://claude.com/claude-code)