### PR TITLE
fix(ci): re-scope datafactory readiness probe + shining_codex coverage (C-75, C-41 — hybrid)

### DIFF
--- a/reports/technical_risk_register.md
+++ b/reports/technical_risk_register.md
@@ -3,7 +3,7 @@
 **Last updated:** 2026-06-12  
 **Governing ADR:** [ADR-010](../docs/ADRs/010_technical_risk_register.md)  
 **Total entries:** 87 (83 concerns + 4 disagreements)  
-**Concerns:** Open 33 | Mitigated 12 | Resolved 34 | Accepted 3 | Partially Resolved 1  
+**Concerns:** Open 31 | Mitigated 12 | Resolved 36 | Accepted 3 | Partially Resolved 1  
 **Disagreements:** Open 4  
 
 ---
@@ -465,7 +465,7 @@
 | **Source** | falsify (2026-04-21) |
 | **Status** | Open |
 | **Location** | `models/bright_starship/main.py:33` (`from configs.config_queryset import fetch_data`), `models/bright_starship/configs/config_queryset.py:115` (`from datafactory_query import load_dataset`), `models/shining_codex/main.py:27` (same pattern), `models/shining_codex/configs/config_queryset.py:90` (same pattern) |
-| **Notes** | **Falsification audit F-1/F-2 chain.** `views-datafactory` (which provides `datafactory_query`) is declared in `requirements.txt` but not installed in `views-hydranet-env` — the only conda environment that has both `views_hydranet` and `views_pipeline_core`. When `_ensure_data()` encounters a cache miss, it imports `datafactory_query` at line 96 and crashes with `ModuleNotFoundError`. Two of three run_types (`validation`, `forecasting`) have cached parquets from a prior session, masking the missing dependency. `calibration` has no cache — the standard first run (`-r calibration -t -e`) fails immediately. The local `envs/views-hydranet` directory expected by `run.sh` also does not exist; `run.sh` would create it and install deps from `requirements.txt` (which includes the git+https datafactory dep), but that's a ~10 min bootstrap, not "ready to run." **Fix:** `conda run -n views-hydranet-env pip install 'views-datafactory @ git+https://github.com/views-platform/views-datafactory.git@development'`. See also C-06 (config_queryset external deps — accepted for viewser; this is the datafactory equivalent), C-37 (bright_starship partition deviation), C-40 (generate() contract mismatch). **Cross-repo:** views-pipeline-core C-51 (`get_data()` hardcodes viewser), C-52 (drift detection loss), C-53 (`use_saved` overload). |
+| **Notes** | **Falsification audit F-1/F-2 chain.** `views-datafactory` (which provides `datafactory_query`) is declared in `requirements.txt` but not installed in `views-hydranet-env` — the only conda environment that has both `views_hydranet` and `views_pipeline_core`. When `_ensure_data()` encounters a cache miss, it imports `datafactory_query` at line 96 and crashes with `ModuleNotFoundError`. Two of three run_types (`validation`, `forecasting`) have cached parquets from a prior session, masking the missing dependency. `calibration` has no cache — the standard first run (`-r calibration -t -e`) fails immediately. The local `envs/views-hydranet` directory expected by `run.sh` also does not exist; `run.sh` would create it and install deps from `requirements.txt` (which includes the git+https datafactory dep), but that's a ~10 min bootstrap, not "ready to run." **Fix:** `conda run -n views-hydranet-env pip install 'views-datafactory @ git+https://github.com/views-platform/views-datafactory.git@development'`. See also C-06 (config_queryset external deps — accepted for viewser; this is the datafactory equivalent), C-37 (bright_starship partition deviation), C-40 (generate() contract mismatch). **Cross-repo:** views-pipeline-core C-51 (`get_data()` hardcodes viewser), C-52 (drift detection loss), C-53 (`use_saved` overload). **2026-06-12:** the bright_starship half is fixed on this workstation — `views-hydranet-env` now has datafactory_query and the readiness probe passes locally. Still open for shining_codex (`views-r2darts2` env unprovisioned; its probe skips) and for any fresh machine — keep Open until the env story (run.sh bootstrap or release-pinned install) is settled. |
 
 ---
 
@@ -502,9 +502,9 @@
 | **Tier** | 3 |
 | **Trigger** | A developer clones the repo and runs `python main.py -r calibration` for shining_codex without the `views-r2darts2` environment and `datafactory_query` installed |
 | **Source** | tech-debt-cleanup (2026-04-21) |
-| **Status** | Open |
+| **Status** | Resolved (2026-06-12) |
 | **Location** | `models/shining_codex/` (no `tests/` directory or test files) |
-| **Notes** | bright_starship has readiness tests (`test_bright_starship_readiness.py`) that verify environment prerequisites (conda env, `datafactory_query`, `DartsForecastingModelManager` import) and config structural validity. shining_codex, cloned from bright_starship, has no equivalent tests. Without readiness tests, failures will surface only at runtime with opaque error messages (e.g., `ModuleNotFoundError` for `datafactory_query` or `views_r2darts2`). See C-38 (datafactory_query not installed), C-03 (integration tests manual-only). |
+| **Notes** | bright_starship has readiness tests (`test_bright_starship_readiness.py`) that verify environment prerequisites (conda env, `datafactory_query`, `DartsForecastingModelManager` import) and config structural validity. shining_codex, cloned from bright_starship, has no equivalent tests. Without readiness tests, failures will surface only at runtime with opaque error messages (e.g., `ModuleNotFoundError` for `datafactory_query` or `views_r2darts2`). See C-38 (datafactory_query not installed), C-03 (integration tests manual-only). **2026-06-12: Resolved** (issue #122, with C-75): `test_bright_starship_readiness.py` is parametrized over both datafactory models — shining_codex gets the same env pre-flight probe (skips while `views-r2darts2` is unprovisioned, which is truthful) and the same static dependency-contract checks (requirements / queryset import / generate()). Single parametrized file avoids the copy-paste drift this entry complained about. |
 
 ---
 
@@ -941,9 +941,9 @@
 | **Tier** | 4 |
 | **Trigger** | CI runs `test_bright_starship_readiness.py::TestF1` — it shells `conda run -n views-hydranet-env` for a workstation-only env absent in CI, erroring (`EnvironmentLocationNotFound`) instead of testing a CI-checkable contract |
 | **Source** | repo-assimilation (2026-06-09) |
-| **Status** | Open |
+| **Status** | Resolved (2026-06-12) |
 | **Location** | `tests/test_bright_starship_readiness.py::TestF1_DatafactoryQueryDependency` (class `skipif` only checks `shutil.which("conda")`, truthy in CI) |
-| **Notes** | The test is a local pre-flight probe (per its docstring) but executes in CI because the `skipif(not shutil.which("conda"))` guard passes (CI has miniconda) while the named env `views-hydranet-env` does not exist → false red. Real fix (no skip): provision `views-datafactory` in the CI job and assert a real `import datafactory_query` in the CI interpreter, plus static contract checks (requirements declares it; descriptor shape; spec resolvable). Add the equivalent for shining_codex (closes C-41). See also C-38 (datafactory_query availability), C-55 (prior stale-xfail on this test — resolved). |
+| **Notes** | The test is a local pre-flight probe (per its docstring) but executes in CI because the `skipif(not shutil.which("conda"))` guard passes (CI has miniconda) while the named env `views-hydranet-env` does not exist → false red. Real fix (no skip): provision `views-datafactory` in the CI job and assert a real `import datafactory_query` in the CI interpreter, plus static contract checks (requirements declares it; descriptor shape; spec resolvable). Add the equivalent for shining_codex (closes C-41). See also C-38 (datafactory_query availability), C-55 (prior stale-xfail on this test — resolved). **2026-06-12: Resolved** (issue #122, HYBRID design decided with maintainer): the conda probe is now a workstation pre-flight that skips truthfully when the target env is absent (`_conda_env_path` basename-matches `conda env list --json`, probes via `conda run -p`); CI-meaningful coverage moved to static contract checks (requirements declares views-datafactory; queryset imports datafactory_query; generate() exists via AST) — static because the queryset imports datafactory at module level and no pinned views-datafactory release exists (C-73 lesson: no unpinned git deps in CI). Real-install CI check deferred to a tracked follow-up issue, conditional on a datafactory release. Guard sanity itself is pinned by `TestEnvGuardSanity`. |
 
 ---
 

--- a/tests/test_bright_starship_readiness.py
+++ b/tests/test_bright_starship_readiness.py
@@ -1,12 +1,25 @@
-"""Failing test stubs from falsification audit: "ready to run bright_starship"
+"""Readiness pre-flight + static dependency contracts for the datafactory models.
 
-Generated: 2026-04-21
-Source: /falsify audit
-Findings: F-1 (hard), F-2 (hard), F-3 (soft)
+History: born 2026-04-21 as falsification stubs for "ready to run
+bright_starship" (F-1 hard, F-2 hard). F-1 (datafactory_query importable)
+is resolved on the workstation — views-hydranet-env is provisioned and the
+probe passes there.
 
-These tests document pre-flight blockers discovered before first run.
-They SHOULD fail until the blockers are resolved — that's the point.
+Re-scoped 2026-06-12 (issue #122, register C-75): the conda probe used to
+false-red in CI — its only guard was `which("conda")`, truthy on runners
+that have miniconda but not the workstation env. The probe is now a
+workstation pre-flight that SKIPS truthfully when the target env is absent,
+and the CI-meaningful contract is covered by static checks that need no
+datafactory install (the queryset imports `datafactory_query` at module
+level, so executing it on CI is impossible until views-datafactory has a
+pinned release — see the C-73 lesson and the hybrid follow-up issue).
+
+Coverage is parametrized over BOTH datafactory models — bright_starship and
+shining_codex (register C-41: shining_codex previously had none).
 """
+import ast
+import functools
+import json
 import shutil
 import subprocess
 from pathlib import Path
@@ -14,40 +27,108 @@ from pathlib import Path
 import pytest
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
+MODELS_DIR = REPO_ROOT / "models"
 
-BRIGHT_STARSHIP = REPO_ROOT / "models" / "bright_starship"
+BRIGHT_STARSHIP = MODELS_DIR / "bright_starship"
 
-pytestmark = [
-    pytest.mark.red,
-    pytest.mark.skipif(
-        not shutil.which("conda"),
-        reason="local pre-flight check — requires conda environment",
-    ),
-]
+# model -> conda env (matched by basename, so both named envs like
+# 'views-hydranet-env' and run.sh path envs like 'envs/views-r2darts2' resolve)
+DATAFACTORY_MODELS = {
+    "bright_starship": "views-hydranet-env",
+    "shining_codex": "views-r2darts2",
+}
 
 
-class TestF1_DatafactoryQueryDependency:
-    """F-1 (hard): datafactory_query must be importable in the run environment.
+@functools.lru_cache(maxsize=None)
+def _conda_env_path(name):
+    """Full path of the conda env whose directory name is `name`, else None.
 
-    Without it, any cache-miss fetch in _ensure_data() crashes at:
-        from datafactory_query import load_dataset
+    None on any conda absence/failure — callers skip, never false-red (C-75).
     """
+    if not shutil.which("conda"):
+        return None
+    try:
+        out = subprocess.run(
+            ["conda", "env", "list", "--json"],
+            capture_output=True, text=True, timeout=120,
+        )
+        envs = json.loads(out.stdout).get("envs", [])
+    except (subprocess.SubprocessError, json.JSONDecodeError, OSError):
+        return None
+    for env in envs:
+        if Path(env).name == name:
+            return env
+    return None
 
-    def test_datafactory_query_importable(self):
-        """datafactory_query must be installed for bright_starship data fetching."""
+
+@pytest.mark.red
+class TestF1_DatafactoryQueryDependency:
+    """Workstation pre-flight: datafactory_query must be importable in the env
+    that runs each datafactory model — without it, any cache-miss fetch in
+    `_ensure_data()` crashes at `from datafactory_query import load_dataset`.
+    Skips (truthfully) wherever the env doesn't exist, e.g. CI."""
+
+    @pytest.mark.parametrize("model,env_name", DATAFACTORY_MODELS.items())
+    def test_datafactory_query_importable(self, model, env_name):
+        env_path = _conda_env_path(env_name)
+        if env_path is None:
+            pytest.skip(
+                f"{model}: conda env '{env_name}' not present on this machine "
+                "(workstation pre-flight; static contract checks below still run)"
+            )
         result = subprocess.run(
-            ["conda", "run", "-n", "views-hydranet-env",
-             "python", "-c", "import datafactory_query"],
+            ["conda", "run", "-p", env_path, "python", "-c", "import datafactory_query"],
             capture_output=True, text=True,
         )
         assert result.returncode == 0, (
-            "datafactory_query is not installed in views-hydranet-env. "
-            "Install via: conda run -n views-hydranet-env pip install "
+            f"{model}: datafactory_query is not installed in {env_name}. "
+            f"Install via: conda run -p {env_path} pip install "
             "'views-datafactory @ git+https://github.com/views-platform/"
-            "views-datafactory.git@development'"
+            f"views-datafactory.git@development'\nstderr: {result.stderr[-300:]}"
         )
 
 
+@pytest.mark.green
+class TestEnvGuardSanity:
+    """The skip guard itself must be trustworthy (a guard that errors or lies
+    recreates the C-75 false red)."""
+
+    def test_nonexistent_env_reports_absent(self):
+        assert _conda_env_path("definitely-not-a-real-env-xyz") is None
+
+
+@pytest.mark.beige
+@pytest.mark.parametrize("model", list(DATAFACTORY_MODELS))
+class TestDatafactoryContract:
+    """CI-runnable static contract: each datafactory model declares and wires
+    its dependency. Text/AST checks only — config_queryset.py imports
+    datafactory_query at module level, so it cannot be imported here without
+    views-datafactory installed (no pinned release exists yet)."""
+
+    def test_requirements_declare_views_datafactory(self, model):
+        req = (MODELS_DIR / model / "requirements.txt").read_text()
+        assert "views-datafactory" in req, (
+            f"{model}/requirements.txt does not declare views-datafactory — "
+            "a fresh run.sh env could not fetch data"
+        )
+
+    def test_queryset_imports_datafactory_query(self, model):
+        source = (MODELS_DIR / model / "configs" / "config_queryset.py").read_text()
+        assert "datafactory_query" in source, (
+            f"{model}/configs/config_queryset.py no longer references "
+            "datafactory_query — the declared dependency and the code disagree"
+        )
+
+    def test_queryset_defines_generate(self, model):
+        source = (MODELS_DIR / model / "configs" / "config_queryset.py").read_text()
+        tree = ast.parse(source)
+        assert any(
+            isinstance(node, ast.FunctionDef) and node.name == "generate"
+            for node in ast.walk(tree)
+        ), f"{model}/configs/config_queryset.py has no generate() function"
+
+
+@pytest.mark.red
 @pytest.mark.xfail(reason="F-2 pre-flight blocker: calibration_viewser_df.parquet not yet cached", strict=False)
 class TestF2_CalibrationParquetCached:
     """F-2 (hard): calibration parquet must exist if datafactory_query is unavailable.
@@ -65,5 +146,3 @@ class TestF2_CalibrationParquetCached:
             "Either fetch calibration data first (requires datafactory_query) "
             "or copy from a machine that has it cached."
         )
-
-


### PR DESCRIPTION
## Summary
Implements #122 per the HYBRID design decision: the conda probe becomes a truthful workstation pre-flight (skips where the env doesn't exist, e.g. CI), CI-meaningful coverage moves to static dependency-contract checks, and the real-install CI check is deferred to #134 until views-datafactory has a pinned release.

Removes 1 of the 4 remaining CI reds → only the scaffold trio (#121, blocked on views-platform/views-pipeline-core#176) should remain.

## What changed
- `_conda_env_path()`: basename-matches `conda env list --json` (handles both named envs like `views-hydranet-env` and run.sh path envs like `envs/views-r2darts2`); probes via `conda run -p`. Any conda absence/failure → skip, never a false red. The guard itself is pinned by `TestEnvGuardSanity`.
- Static contract checks (beige, text/AST — the queryset imports `datafactory_query` at module level, so executing it on CI is impossible without the package): requirements declares `views-datafactory`; queryset imports `datafactory_query`; `generate()` exists.
- Probe + contracts **parametrized over bright_starship and shining_codex** — closes the C-41 gap in one file, no copy-paste drift. `TestF2` untouched.
- Register: C-75 → Resolved, C-41 → Resolved, C-38 → dated residual note (bright_starship env provisioned locally; shining_codex + fresh machines remain).

## Why not provision datafactory in CI
views-datafactory has no PyPI release — CI would need `git+https@development`, an unpinned moving target: exactly the C-73 failure class that broke CI via pipeline-core. Deferred to #134, conditional on a release/pin (the #176→#121 pattern).

## Verification
- Local: bright_starship probe PASSES (real import in the provisioned env); shining_codex probe SKIPS truthfully; 6 contract checks + guard sanity pass; full suite 5405 passed, failures = golden_hour (#131) + uncommitted-guard only.
- CI on this PR's head should show **exactly 3 failures** (the scaffold trio) — will verify on the run.

⚠️ Targets `development` — close #122 manually on merge and tick the #132 box.

🤖 Generated with [Claude Code](https://claude.com/claude-code)