### PR TITLE
chore(naming): standardize regression target to lr_ged_sb in 11 models (#151)

### DIFF
--- a/models/adolecent_slob/configs/config_meta.py
+++ b/models/adolecent_slob/configs/config_meta.py
@@ -11,7 +11,7 @@ def get_meta_config():
         "name": "adolecent_slob", 
         "algorithm": "TCNModel",
         # Uncomment and modify the following lines as needed for additional metadata:
-        "regression_targets": ["lr_ged_sb_dep"],
+        "regression_targets": ["lr_ged_sb"],
         # "queryset": "escwa001_cflong",
         "level": "cm",
         "creator": "Simon",

--- a/models/adolecent_slob/configs/config_queryset.py
+++ b/models/adolecent_slob/configs/config_queryset.py
@@ -20,13 +20,6 @@ def generate():
         return (
             queryset.with_column(
                 Column(
-                    "lr_ged_sb_dep",
-                    from_loa="country_month",
-                    from_column="ged_sb_best_sum_nokgi",
-                ).transform.missing.fill()
-            )
-            .with_column(
-                Column(
                     "lr_ged_sb",
                     from_loa="country_month",
                     from_column="ged_sb_best_sum_nokgi",

--- a/models/bouncy_organ/configs/config_meta.py
+++ b/models/bouncy_organ/configs/config_meta.py
@@ -11,7 +11,7 @@ def get_meta_config():
         "name": "bouncy_organ", 
         "algorithm": "TSMixerModel",
         # Uncomment and modify the following lines as needed for additional metadata:
-        "regression_targets": ["lr_ged_sb_dep"],
+        "regression_targets": ["lr_ged_sb"],
         # "queryset": "escwa001_cflong",
         "level": "cm",
         "creator": "Simon",

--- a/models/bouncy_organ/configs/config_queryset.py
+++ b/models/bouncy_organ/configs/config_queryset.py
@@ -20,13 +20,6 @@ def generate():
         return (
             queryset.with_column(
                 Column(
-                    "lr_ged_sb_dep",
-                    from_loa="country_month",
-                    from_column="ged_sb_best_sum_nokgi",
-                ).transform.missing.fill()
-            )
-            .with_column(
-                Column(
                     "lr_ged_sb",
                     from_loa="country_month",
                     from_column="ged_sb_best_sum_nokgi",

--- a/models/cheap_thrills/configs/config_meta.py
+++ b/models/cheap_thrills/configs/config_meta.py
@@ -10,7 +10,7 @@ def get_meta_config():
     meta_config = {
         "name": "cheap_thrills", 
         "algorithm": "ShurfModel",
-        "regression_targets": ["lr_sb_best"],
+        "regression_targets": ["lr_ged_sb"],
         "level": "cm",
         "creator": "Håvard",
         "prediction_format": "dataframe",

--- a/models/cheap_thrills/configs/config_queryset.py
+++ b/models/cheap_thrills/configs/config_queryset.py
@@ -16,7 +16,7 @@ def generate():
         .with_column(Column('lr_gleditsch_ward', from_loa='country', from_column='gwcode')
             )
 
-        .with_column(Column('lr_sb_best', from_loa='country_month', from_column='ged_sb_best_sum_nokgi')
+        .with_column(Column('lr_ged_sb', from_loa='country_month', from_column='ged_sb_best_sum_nokgi')
             .transform.missing.fill()
             .transform.missing.replace_na()
             )

--- a/models/fancy_feline/configs/config_meta.py
+++ b/models/fancy_feline/configs/config_meta.py
@@ -11,7 +11,7 @@ def get_meta_config():
         "name": "fancy_feline", 
         "algorithm": "TiDEModel",
         # Uncomment and modify the following lines as needed for additional metadata:
-        "regression_targets": ["lr_ged_sb_dep"],
+        "regression_targets": ["lr_ged_sb"],
         # "queryset": "escwa001_cflong",
         "level": "cm",
         "creator": "Simon",

--- a/models/fancy_feline/configs/config_queryset.py
+++ b/models/fancy_feline/configs/config_queryset.py
@@ -20,13 +20,6 @@ def generate():
         return (
             queryset.with_column(
                 Column(
-                    "lr_ged_sb_dep",
-                    from_loa="country_month",
-                    from_column="ged_sb_best_sum_nokgi",
-                ).transform.missing.fill()
-            )
-            .with_column(
-                Column(
                     "lr_ged_sb",
                     from_loa="country_month",
                     from_column="ged_sb_best_sum_nokgi",

--- a/models/fourtieth_symphony/configs/config_meta.py
+++ b/models/fourtieth_symphony/configs/config_meta.py
@@ -10,7 +10,7 @@ def get_meta_config():
     meta_config = {
         "name": "fourtieth_symphony", 
         "algorithm": "ShurfModel",
-        "regression_targets": ["lr_sb_best"],
+        "regression_targets": ["lr_ged_sb"],
         "level": "cm",
         "creator": "Håvard",
         "prediction_format": "dataframe",

--- a/models/fourtieth_symphony/configs/config_queryset.py
+++ b/models/fourtieth_symphony/configs/config_queryset.py
@@ -14,12 +14,6 @@ def generate():
 
     queryset = (Queryset('uncertainty_broad_nolog','country_month')
 
-        .with_column(Column('lr_sb_best', from_loa='country_month', from_column='ged_sb_best_sum_nokgi')
-            .transform.missing.fill()
-            .transform.missing.replace_na()
-            # .transform.ops.ln()
-            # .transform.missing.replace_na()
-            )
         .with_column(Column('lr_gleditsch_ward', from_loa='country', from_column='gwcode')
             )
 

--- a/models/hot_stream/configs/config_meta.py
+++ b/models/hot_stream/configs/config_meta.py
@@ -11,7 +11,7 @@ def get_meta_config():
         "name": "hot_stream", 
         "algorithm": "TFTModel",
         # Uncomment and modify the following lines as needed for additional metadata:
-        "regression_targets": ["lr_ged_sb_dep"],
+        "regression_targets": ["lr_ged_sb"],
         # "queryset": "escwa001_cflong",
         "level": "cm",
         "creator": "Simon",

--- a/models/hot_stream/configs/config_queryset.py
+++ b/models/hot_stream/configs/config_queryset.py
@@ -20,13 +20,6 @@ def generate():
         return (
             queryset.with_column(
                 Column(
-                    "lr_ged_sb_dep",
-                    from_loa="country_month",
-                    from_column="ged_sb_best_sum_nokgi",
-                ).transform.missing.fill()
-            )
-            .with_column(
-                Column(
                     "lr_ged_sb",
                     from_loa="country_month",
                     from_column="ged_sb_best_sum_nokgi",

--- a/models/lovely_creature/configs/config_meta.py
+++ b/models/lovely_creature/configs/config_meta.py
@@ -10,7 +10,7 @@ def get_meta_config():
     meta_config = {
         "name": "lovely_creature", 
         "algorithm": "ShurfModel",
-        "regression_targets": ["lr_sb_best"],
+        "regression_targets": ["lr_ged_sb"],
         "level": "cm",
         "creator": "Håvard",
         "prediction_format": "dataframe",

--- a/models/lovely_creature/configs/config_queryset.py
+++ b/models/lovely_creature/configs/config_queryset.py
@@ -19,11 +19,6 @@ def generate():
         .with_column(Column('lr_gleditsch_ward', from_loa='country', from_column='gwcode')
             )
 
-        .with_column(Column('lr_sb_best', from_loa='country_month', from_column='ged_sb_best_sum_nokgi')
-            .transform.missing.fill()
-            .transform.missing.replace_na()
-            )
-
         .with_column(Column('lr_ged_sb', from_loa='country_month', from_column='ged_sb_best_sum_nokgi')
             .transform.missing.fill()
             .transform.missing.replace_na()

--- a/models/party_princess/configs/config_meta.py
+++ b/models/party_princess/configs/config_meta.py
@@ -11,7 +11,7 @@ def get_meta_config():
         "name": "party_princess", 
         "algorithm": "BlockRNNModel",
         # Uncomment and modify the following lines as needed for additional metadata:
-        "regression_targets": ["lr_ged_sb_dep"],
+        "regression_targets": ["lr_ged_sb"],
         # "queryset": "escwa001_cflong",
         "level": "cm",
         "creator": "Simon",

--- a/models/party_princess/configs/config_queryset.py
+++ b/models/party_princess/configs/config_queryset.py
@@ -20,13 +20,6 @@ def generate():
         return (
             queryset.with_column(
                 Column(
-                    "lr_ged_sb_dep",
-                    from_loa="country_month",
-                    from_column="ged_sb_best_sum_nokgi",
-                ).transform.missing.fill()
-            )
-            .with_column(
-                Column(
                     "lr_ged_sb",
                     from_loa="country_month",
                     from_column="ged_sb_best_sum_nokgi",

--- a/models/purple_haze/configs/config_meta.py
+++ b/models/purple_haze/configs/config_meta.py
@@ -10,7 +10,7 @@ def get_meta_config():
     meta_config = {
         "name": "purple_haze", 
         "algorithm": "ShurfModel",
-        "regression_targets": ["lr_sb_best"],
+        "regression_targets": ["lr_ged_sb"],
         "level": "cm",
         "creator": "Håvard",
         "prediction_format": "dataframe",

--- a/models/purple_haze/configs/config_queryset.py
+++ b/models/purple_haze/configs/config_queryset.py
@@ -16,11 +16,6 @@ def generate():
         .with_column(Column('lr_gleditsch_ward', from_loa='country', from_column='gwcode')
             )
 
-        .with_column(Column('lr_sb_best', from_loa='country_month', from_column='ged_sb_best_sum_nokgi')
-            .transform.missing.fill()
-            .transform.missing.replace_na()
-            )
-
         .with_column(Column('lr_ged_sb', from_loa='country_month', from_column='ged_sb_best_sum_nokgi')
             .transform.missing.fill()
             .transform.missing.replace_na()

--- a/models/wild_rose/configs/config_meta.py
+++ b/models/wild_rose/configs/config_meta.py
@@ -10,7 +10,7 @@ def get_meta_config():
     meta_config = {
         "name": "wild_rose", 
         "algorithm": "ShurfModel",
-        "regression_targets": ["lr_sb_best"],
+        "regression_targets": ["lr_ged_sb"],
         "level": "cm",
         "creator": "Håvard",
         "prediction_format": "dataframe",

--- a/models/wild_rose/configs/config_queryset.py
+++ b/models/wild_rose/configs/config_queryset.py
@@ -13,11 +13,6 @@ def generate():
 
     queryset = (Queryset('uncertainty_conflict_nolog','country_month')
 
-        .with_column(Column('lr_sb_best', from_loa='country_month', from_column='ged_sb_best_sum_nokgi')
-            .transform.missing.fill()
-            .transform.missing.replace_na()
-            )
-
         .with_column(Column('lr_ged_sb', from_loa='country_month', from_column='ged_sb_best_sum_nokgi')
             .transform.missing.fill()
             .transform.missing.replace_na()

--- a/models/wuthering_heights/configs/config_meta.py
+++ b/models/wuthering_heights/configs/config_meta.py
@@ -10,7 +10,7 @@ def get_meta_config():
     meta_config = {
         "name": "wuthering_heights", 
         "algorithm": "ShurfModel",
-        "regression_targets": ["lr_sb_best"],
+        "regression_targets": ["lr_ged_sb"],
         "level": "cm",
         "creator": "Håvard",
         "prediction_format": "dataframe",

--- a/models/wuthering_heights/configs/config_queryset.py
+++ b/models/wuthering_heights/configs/config_queryset.py
@@ -13,7 +13,7 @@ def generate():
 
     queryset = (Queryset('uncertainty_deep_conflict_nolog','country_month')
 
-        .with_column(Column('lr_sb_best', from_loa='country_month', from_column='ged_sb_best_sum_nokgi')
+        .with_column(Column('lr_ged_sb', from_loa='country_month', from_column='ged_sb_best_sum_nokgi')
             .transform.missing.fill()
             .transform.missing.replace_na()
             )

--- a/tests/test_config_completeness.py
+++ b/tests/test_config_completeness.py
@@ -73,6 +73,30 @@ class TestConfigMeta:
             f"rename to 'regression_point_metrics'"
         )
 
+    def test_regression_targets_canonical(self, model_dir, meta_config):
+        """Regression targets must use the canonical lr_ged_{sb,ns,os} name (#151).
+
+        Guards against the historical drift (lr_sb_best, lr_ged_sb_dep, lr_*_best)
+        re-entering as a *target*. Checks regression_targets only — feature columns
+        may legitimately use other names. Stays until the pipeline-core scaffold
+        template (views-pipeline-core#201) stops seeding non-canonical names.
+        """
+        canonical = {"lr_ged_sb", "lr_ged_ns", "lr_ged_os"}
+        synthetic = {"synth_target"}  # synthetic pipeline-test models (e.g. *_dream) are exempt
+        # Non-canonical targets that can't be flipped config-only because stored
+        # prediction artifacts embed the old name — pending regeneration (#152).
+        pending_regeneration = {"black_ranger", "green_ranger", "pink_ranger", "yellow_ranger"}
+        targets = meta_config.get("regression_targets")
+        if not targets or any(t in synthetic for t in targets):
+            pytest.skip(f"{model_dir.name} has no real regression_targets")
+        if model_dir.name in pending_regeneration:
+            pytest.skip(f"{model_dir.name}: ns/os target rename pending prediction regeneration (#152)")
+        noncanonical = [t for t in targets if t not in canonical]
+        assert not noncanonical, (
+            f"{model_dir.name} uses non-canonical regression target(s) {noncanonical} — "
+            f"standardize to lr_ged_sb/ns/os (#151)"
+        )
+
 
 # ── config_deployment.py ───────────────────────────────────────────────
 


### PR DESCRIPTION
## #151 — standardize the regression target to `lr_ged_sb` (views-models half)

Converges the **11 config-only-safe** stepshifter stragglers onto the canonical `lr_ged_sb` (the 54-of-87 majority; matches un_fao actuals + the faoapi plotting default).

### What changed (per the canonical `car_radio` template)
- **5 `_dep` models** (adolecent_slob, bouncy_organ, fancy_feline, party_princess, hot_stream): the target was `lr_ged_sb_dep` while `lr_ged_sb` already existed as a conflict-history *feature*. Dropped the redundant `lr_ged_sb_dep` column; the existing `lr_ged_sb` becomes target+feature.
- **4 `_best` w/ canonical present** (lovely_creature, fourtieth_symphony, purple_haze, wild_rose): dropped the redundant `lr_sb_best` column (canonical `lr_ged_sb` already there).
- **2 minimal `_best`** (cheap_thrills, wuthering_heights): renamed `lr_sb_best → lr_ged_sb`.
- All 11 `config_meta` `regression_targets → ["lr_ged_sb"]`.

### Why it's safe
Pure config/label change — the framework treats the target name as an arbitrary string, target *values* are numerically identical (same UCDP source + transform), and the 11 have **empty prediction-artifact dirs → no retrain**. Each edited model now matches the canonical template exactly.

### Guard
`tests/test_config_completeness.py::test_regression_targets_canonical` (beige) asserts every model's `regression_targets ⊆ {lr_ged_sb, lr_ged_ns, lr_ged_os}`. Exempts synthetic `*_dream` models and the 4 `ranger` ns/os baselines.

### Out of scope → #152
The investigation surfaced **4 baseline rangers** (black/green/pink/yellow) with `lr_ns_best`/`lr_os_best` targets. They have **stored predictions keyed by the old name** (`eval_*_lr_ns_best_*.parquet` + per-target dirs), so a config-only flip desyncs them and fails the PF/transform tests. Split to **#152** (rename + prediction regeneration); the guard exempts them until then.

### Verification
- `ruff` clean; every config builds offline with a single canonical target column.
- config/structure/ensemble/datafactory-parity suites green — the only failure is the **pre-existing** `golden_hour` aggregated-sample-count mismatch (C-74/#131, fails on `development` without this change).

Part of #151.
