### PR TITLE
test(targets): single config-derived accessor for regression targets (#155, S1)

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -74,6 +74,58 @@ def load_config_module(config_path: Path, module_name: str = None):
     return module
 
 
+# ── Regression targets: single source of truth (EPIC #154 / S1 #155) ───────
+# A model may declare ``regression_targets`` in config_meta.py and/or
+# config_hyperparameters.py. The pipeline merges both with config_meta taking
+# precedence (ConfigurationManager.get_combined_config). These helpers are the
+# ONE way views-models code should obtain a model's targets — derive, never
+# hardcode a target-name literal.
+
+def _read_regression_targets(config_path: Path, getter_name: str):
+    """Return the regression_targets list declared in one config file, or None
+    if the file / accessor / key is absent. A bare string is normalized to a list."""
+    if not config_path.exists():
+        return None
+    module = load_config_module(config_path)
+    getter = getattr(module, getter_name, None)
+    if getter is None:
+        return None
+    config = getter() or {}
+    targets = config.get("regression_targets")
+    if targets is None:
+        return None
+    if isinstance(targets, str):
+        targets = [targets]
+    return list(targets)
+
+
+def regression_targets_by_location(model_dir: Path) -> dict:
+    """Map each config location that declares regression_targets to its list.
+
+    Keys are a subset of {"meta", "hp"}; a location absent from the dict did not
+    declare the key. Used to enforce cross-location agreement.
+    """
+    config_dir = model_dir / "configs"
+    out = {}
+    meta = _read_regression_targets(config_dir / "config_meta.py", "get_meta_config")
+    if meta is not None:
+        out["meta"] = meta
+    hp = _read_regression_targets(config_dir / "config_hyperparameters.py", "get_hp_config")
+    if hp is not None:
+        out["hp"] = hp
+    return out
+
+
+def get_regression_targets(model_dir: Path) -> list[str]:
+    """The single source of truth for a model's regression targets.
+
+    Mirrors the pipeline merge precedence (config_meta wins over
+    config_hyperparameters; hp is the fallback). Returns ``[]`` if undeclared.
+    """
+    located = regression_targets_by_location(model_dir)
+    return located.get("meta") or located.get("hp") or []
+
+
 @pytest.fixture(params=ALL_MODEL_DIRS, ids=MODEL_NAMES)
 def model_dir(request):
     """Parametrized fixture yielding each model directory."""

--- a/tests/test_pfe_production_readiness.py
+++ b/tests/test_pfe_production_readiness.py
@@ -14,7 +14,7 @@ from pathlib import Path
 import numpy as np
 import pytest
 
-from tests.conftest import load_config_module
+from tests.conftest import load_config_module, regression_targets_by_location
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 MODELS_DIR = REPO_ROOT / "models"
@@ -149,16 +149,16 @@ class TestPFModelConfigReadiness:
         )
 
     def test_regression_targets_consistent_meta_hp(self, pf_model):
-        meta = _load_meta(pf_model)
-        hp = _load_hp(pf_model)
-        meta_targets = meta.get("regression_targets")
-        hp_targets = hp.get("regression_targets")
-        if not meta_targets or not hp_targets:
-            pytest.skip(f"{pf_model}: one or both configs missing regression_targets")
-        assert sorted(meta_targets) == sorted(hp_targets), (
-            f"{pf_model}: config_meta regression_targets {meta_targets} != "
-            f"config_hyperparameters regression_targets {hp_targets}"
-        )
+        # Delegates to the single source of truth (conftest). The repo-wide
+        # agreement guard lives in tests/test_regression_targets.py (all models).
+        located = regression_targets_by_location(MODELS_DIR / pf_model)
+        if "meta" in located and "hp" in located:
+            assert sorted(located["meta"]) == sorted(located["hp"]), (
+                f"{pf_model}: config_meta regression_targets {located['meta']} != "
+                f"config_hyperparameters regression_targets {located['hp']}"
+            )
+        else:
+            pytest.skip(f"{pf_model}: regression_targets not declared in both configs")
 
 
 class TestPFEEnsembleConfigReadiness:

--- a/tests/test_regression_targets.py
+++ b/tests/test_regression_targets.py
@@ -1,0 +1,53 @@
+"""Regression-target naming contracts — config is the single source of truth (EPIC #154).
+
+These are **agnostic** contracts: they assert *structure* (a model's targets are
+declared and discoverable via the one accessor, and the two declaration locations
+agree) without ever referencing a literal target name. A model may call its target
+whatever it likes; nothing here hardcodes `lr_ged_sb` or any other string.
+
+The accessor under test (`tests/conftest.py::get_regression_targets`) is THE way
+views-models code should obtain a model's targets — see S2–S6 for its adoption
+across the test suite and tooling.
+"""
+import pytest
+
+from tests.conftest import (
+    ALL_MODEL_DIRS,
+    MODEL_NAMES,
+    get_regression_targets,
+    regression_targets_by_location,
+)
+
+pytestmark = pytest.mark.beige
+
+
+@pytest.mark.parametrize("model_dir", ALL_MODEL_DIRS, ids=MODEL_NAMES)
+def test_meta_and_hp_agree(model_dir):
+    """If a model declares regression_targets in BOTH config_meta and
+    config_hyperparameters, the two must agree. (Single-location is fine.)"""
+    located = regression_targets_by_location(model_dir)
+    if "meta" in located and "hp" in located:
+        assert sorted(located["meta"]) == sorted(located["hp"]), (
+            f"{model_dir.name}: config_meta regression_targets {located['meta']} != "
+            f"config_hyperparameters {located['hp']} — the two declarations must agree"
+        )
+
+
+@pytest.mark.parametrize("model_dir", ALL_MODEL_DIRS, ids=MODEL_NAMES)
+def test_accessor_resolves_declared_targets(model_dir):
+    """The accessor resolves a model's declared targets (config_meta precedence,
+    config_hyperparameters fallback) — and resolves nothing only when nothing is
+    declared. Dogfoods the single source of truth across all archetypes."""
+    located = regression_targets_by_location(model_dir)
+    resolved = get_regression_targets(model_dir)
+    if located:
+        expected = located.get("meta") or located.get("hp")
+        assert resolved == expected, (
+            f"{model_dir.name}: accessor returned {resolved} but expected {expected} "
+            f"(meta precedence over hp) from {located}"
+        )
+        assert resolved, f"{model_dir.name}: declares targets {located} but accessor resolved none"
+    else:
+        assert resolved == [], (
+            f"{model_dir.name}: declares no regression_targets but accessor returned {resolved}"
+        )


### PR DESCRIPTION
## S1 (#155) — single config-derived accessor for regression targets *(foundation)*

The keystone of EPIC #154: **one** way views-models code obtains a model's targets — derive from config, never hardcode a literal. Everything in S2–S6 builds on this.

- `tests/conftest.py`: `get_regression_targets(model_dir)` — `config_meta` precedence, `config_hyperparameters` fallback (mirrors `ConfigurationManager.get_combined_config`) — plus `regression_targets_by_location()`.
- `tests/test_regression_targets.py` (new, beige): **literal-free** contracts over all models — (a) where both `config_meta` and `config_hyperparameters` declare targets they must agree; (b) the accessor resolves a model's declared targets (or none). Covers stepshifter (meta-only), DL (hp-only), and dual-declaring archetypes — closing the blind spot where a `config_meta`-only check silently skipped the 11 DL models.
- `test_pfe_production_readiness.py`: the PF consistency test now delegates to the shared helper (single logic, dogfooded).

Verified: ruff clean; 190 passed / 11 skipped on the new contracts; full config/structure suite green except the **pre-existing** golden_hour sample-count failure (C-74/#131, fails on `development` without this change).

Part of EPIC #154 · tracking #162.
