### PR TITLE
refactor(scripts): de-hardcode target names in tooling/investigation scripts (#159, S5)

### DIFF
--- a/investigations/compare_parity.py
+++ b/investigations/compare_parity.py
@@ -25,7 +25,21 @@ MODEL_PAIRS = [
 
 ENSEMBLE_PAIR = ("golden_hour", "stellar_horizon")
 
-TARGETS = ["lr_sb_best", "lr_ns_best", "lr_os_best"]
+def _discover_targets(pred_dir):
+    """Target subdir names produced under the prediction store — agnostic, never
+    hardcoded (EPIC #154 / S5)."""
+    origin = pred_dir / "origin_0"
+    if not origin.is_dir():
+        origins = sorted(pred_dir.glob("origin_*"))
+        origin = origins[0] if origins else None
+    if origin is None or not origin.is_dir():
+        return []
+    return sorted(d.name for d in origin.iterdir() if d.is_dir())
+
+
+def _short(target):
+    """Short column label for a target name (presentation only)."""
+    return target[:8]
 
 
 def find_prediction_dir(name, kind, run_type):
@@ -125,9 +139,10 @@ def compare_pair(name_a, name_b, kind, run_type):
     if not dir_b:
         return {"status": "MISSING", "detail": f"{name_b} has no {run_type} predictions"}
 
+    targets = _discover_targets(dir_a)
     results = {"status": "OK", "dir_a": str(dir_a.name), "dir_b": str(dir_b.name), "targets": {}}
 
-    for target in TARGETS:
+    for target in targets:
         preds_a, ids_a = load_origins(dir_a, target)
         preds_b, ids_b = load_origins(dir_b, target)
 
@@ -215,23 +230,24 @@ def print_summary(all_results):
     print(f"\n{'='*72}")
     print("PARITY SUMMARY")
     print(f"{'='*72}")
-    print(f"\n{'Pair':<35} {'Run':<14} {'lr_sb':>8} {'lr_ns':>8} {'lr_os':>8} {'Verdict':>10}")
-    print(f"{'-'*35:<35} {'-'*14:<14} {'-'*8:>8} {'-'*8:>8} {'-'*8:>8} {'-'*10:>10}")
+    # Target columns are discovered from the results — no hardcoded names.
+    targets = sorted({t for _, res in all_results for t in (res.get("targets") or {})})
+    header = " ".join(f"{_short(t):>8}" for t in targets)
+    sep = " ".join(f"{'-'*8:>8}" for _ in targets)
+    print(f"\n{'Pair':<35} {'Run':<14} {header} {'Verdict':>10}")
+    print(f"{'-'*35:<35} {'-'*14:<14} {sep} {'-'*10:>10}")
+    rank = {"EXCELLENT": 5, "GOOD": 4, "FAIR": 3, "POOR": 2, "DIVERGENT": 1, "N/A": 0, "—": 0}
     for (na, nb, kind, run_type), res in all_results:
         label = f"{na} ↔ {nb}"
         if res["status"] == "MISSING":
-            print(f"{label:<35} {run_type:<14} {'—':>8} {'—':>8} {'—':>8} {'MISSING':>10}")
+            cells = " ".join(f"{'—':>8}" for _ in targets)
+            print(f"{label:<35} {run_type:<14} {cells} {'MISSING':>10}")
             continue
-        grades = []
-        for t in TARGETS:
-            g = res["targets"].get(t, {}).get("grade", "—")
-            grades.append(g)
-        worst = "MISSING"
-        rank = {"EXCELLENT": 5, "GOOD": 4, "FAIR": 3, "POOR": 2, "DIVERGENT": 1, "N/A": 0, "—": 0}
-        valid = [g for g in grades if g in rank and rank[g] > 0]
-        if valid:
-            worst = min(valid, key=lambda g: rank[g])
-        print(f"{label:<35} {run_type:<14} {grades[0]:>8} {grades[1]:>8} {grades[2]:>8} {worst:>10}")
+        grades = [res["targets"].get(t, {}).get("grade", "—") for t in targets]
+        valid = [g for g in grades if rank.get(g, 0) > 0]
+        worst = min(valid, key=lambda g: rank[g]) if valid else "MISSING"
+        cells = " ".join(f"{g:>8}" for g in grades)
+        print(f"{label:<35} {run_type:<14} {cells} {worst:>10}")
 
 
 def main():

--- a/investigations/deep_parity_analysis.py
+++ b/investigations/deep_parity_analysis.py
@@ -10,22 +10,25 @@ REPO = Path(__file__).resolve().parent.parent
 PA_DIR = REPO / "models/purple_alien/data/generated/predictions_calibration_20260525_063227"
 BS_DIR = REPO / "models/bright_starship/data/generated/predictions_calibration_20260526_013733"
 
-TARGETS = ["lr_sb_best", "lr_ns_best", "lr_os_best"]
-TARGET_LABELS = {
-    "lr_sb_best": "State-based fatalities (best estimate)",
-    "lr_ns_best": "Non-state fatalities (best estimate)",
-    "lr_os_best": "One-sided violence fatalities (best estimate)",
-}
-VARIABLE_MAP = {
-    "lr_sb_best": ("ged_sb_best_sum_nokgi", "ged_sb_best"),
-    "lr_ns_best": ("ged_ns_best_sum_nokgi", "ged_ns_best"),
-    "lr_os_best": ("ged_os_best_sum_nokgi", "ged_os_best"),
-}
+def _discover_targets(pred_dir):
+    """Targets produced in the prediction store — agnostic, never hardcoded
+    (EPIC #154 / S5)."""
+    origin = pred_dir / "origin_0"
+    if not origin.is_dir():
+        return []
+    return sorted(d.name for d in origin.iterdir() if d.is_dir())
+
+
+TARGETS = _discover_targets(BS_DIR)
+# Optional presentation only — human labels / UCDP source-column pairing for the
+# diagnostic printout; absent keys degrade gracefully. Annotations, not load-bearing.
+TARGET_LABELS = {}
+VARIABLE_MAP = {}
 
 
 def analyze_target(target):
-    viewser_var, factory_var = VARIABLE_MAP[target]
-    label = TARGET_LABELS[target]
+    viewser_var, factory_var = VARIABLE_MAP.get(target, ("?", "?"))
+    label = TARGET_LABELS.get(target, target)
 
     print(f"\n{'='*72}")
     print(f"TARGET: {target}")

--- a/investigations/plot_sanity_checks.py
+++ b/investigations/plot_sanity_checks.py
@@ -37,6 +37,9 @@ COLOR_NS = "#4878A8"
 COLOR_OS = "#D4752E"
 COLOR_GRAY = "#666666"
 
+# Presentation-only style lookups (color / short label per target). These are
+# documented plot constants, NOT load-bearing logic — keyed by name purely for
+# display; missing keys fall back to neutral defaults at the call sites (EPIC #154 / S5).
 TARGET_COLORS = {
     "lr_sb_best": COLOR_SB,
     "lr_ns_best": COLOR_NS,

--- a/models/bright_starship/scripts/audit_data_parity.py
+++ b/models/bright_starship/scripts/audit_data_parity.py
@@ -25,6 +25,7 @@ Prerequisites:
 
 from __future__ import annotations
 
+import importlib.util
 import sys
 import time
 from pathlib import Path
@@ -41,19 +42,23 @@ PURPLE_ALIEN_PARQUET = (
 
 ZARR_URL = DEFAULT_REMOTE.zarr_url
 REGION = "africa_me_legacy"
-FACTORY_FEATURES = ["ged_sb_best", "ged_ns_best", "ged_os_best", "gaul0_code"]
-FEATURE_RENAME = {
-    "ged_sb_best": "lr_sb_best",
-    "ged_ns_best": "lr_ns_best",
-    "ged_os_best": "lr_os_best",
-    "gaul0_code": "c_id",
-}
+# Derive the datafactory descriptor from bright_starship's own config_queryset
+# (single source of truth) instead of duplicating the feature/target names here
+# (EPIC #154 / S5).
+_QS_PATH = Path(__file__).resolve().parents[1] / "configs" / "config_queryset.py"
+_qs_spec = importlib.util.spec_from_file_location("_bright_starship_queryset", _QS_PATH)
+_qs = importlib.util.module_from_spec(_qs_spec)
+_qs_spec.loader.exec_module(_qs)
+FACTORY_FEATURES = _qs.FACTORY_FEATURES
+FEATURE_RENAME = _qs.FEATURE_RENAME
+
 NCOL = 720
 CALIBRATION_TRAIN = (121, 444)
 CALIBRATION_TEST = (445, 492)
 
-EVENT_COLS = ["lr_sb_best", "lr_ns_best", "lr_os_best"]
 IDENTITY_COLS = ["c_id", "row", "col"]
+# Event (fatality) columns = the descriptor's renamed features minus identity cols.
+EVENT_COLS = [name for name in FEATURE_RENAME.values() if name not in IDENTITY_COLS]
 
 
 def fetch_from_hetzner() -> pd.DataFrame:


### PR DESCRIPTION
## S5 (#159) — de-hardcode tooling/investigation/audit scripts

Removes **load-bearing** target-name literals from non-test scripts:

- `models/bright_starship/scripts/audit_data_parity.py` — derives `FACTORY_FEATURES`/`FEATURE_RENAME`/`EVENT_COLS` from bright_starship's own `config_queryset` (single source of truth) instead of duplicating them.
- `investigations/compare_parity.py` + `deep_parity_analysis.py` — `TARGETS` are now **discovered** from the prediction store (`origin_*/<target>/`); the summary table and labels derive dynamically. No hardcoded trio drives logic.
- `investigations/plot_sanity_checks.py` — style dicts kept (presentation only; call sites already use `.get()` fallbacks) and documented as such, per the plan.

Verified: ruff clean; all 4 scripts compile; only the documented plot style dict retains literals. The repo's **load-bearing** target-name literals are now gone from `tests/`, `tools/`, `investigations/`, and model `scripts/`.

Part of EPIC #154 · tracking #162.
