### PR TITLE
feat(reconciliation): CountryMapping value + CountryMappingProvider port (#174, S1)

### DIFF
--- a/reconciliation/__init__.py
+++ b/reconciliation/__init__.py
@@ -1,0 +1,13 @@
+"""Reconciliation composition layer for views-models (EPIC #172 / ADR-014).
+
+The single sanctioned place that wires the reconciler Dependency-Inversion seam:
+pipeline-core defines the `Reconciler` port, views-postprocessing provides the
+concrete `ReconciliationModule`, and this layer (the composition root's helper)
+builds the geography and constructs the concrete — confined to one file.
+
+`build_reconciler` is added in S3 (#176).
+"""
+from reconciliation.country_mapping import CountryMapping
+from reconciliation.country_mapping_provider import CountryMappingProvider
+
+__all__ = ["CountryMapping", "CountryMappingProvider"]

--- a/reconciliation/country_mapping.py
+++ b/reconciliation/country_mapping.py
@@ -1,0 +1,53 @@
+"""The geography mapping value for reconciliation (EPIC #172 / ADR-014).
+
+A `CountryMapping` is the injected `(time, priogrid_gid) -> country_id` mapping the
+reconciler needs. Geography is *injected*, never embedded in the reconciler
+(views-frames ADR-014); this immutable value object only holds and validates it.
+The country-id system (VIEWS `country_id` vs datafactory `gaul0_code`) is the
+provider's concern — this value is agnostic to which one it carries.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import numpy as np
+from numpy.typing import NDArray
+
+
+@dataclass(frozen=True)
+class CountryMapping:
+    """Immutable `(time, priogrid_gid) -> country_id` mapping.
+
+    - ``map_keys``: ``(M, 2)`` int array; row ``i`` is ``(time_i, priogrid_gid_i)``.
+    - ``map_vals``: ``(M,)`` int array; ``map_vals[i]`` is the ``country_id`` for
+      ``map_keys[i]`` (1-to-1, same order).
+
+    Shapes line up with `views_postprocessing.reconciliation.ReconciliationModule`,
+    which is constructed as ``ReconciliationModule(map_keys, map_vals)``.
+    """
+
+    map_keys: NDArray[np.integer]
+    map_vals: NDArray[np.integer]
+
+    def __post_init__(self) -> None:
+        keys = np.asarray(self.map_keys)
+        vals = np.asarray(self.map_vals)
+        if keys.ndim != 2 or keys.shape[1] != 2:
+            raise ValueError(
+                f"map_keys must be a (M, 2) array of (time, priogrid_gid); got shape {keys.shape}"
+            )
+        if vals.ndim != 1 or vals.shape[0] != keys.shape[0]:
+            raise ValueError(
+                f"map_vals must be a (M,) array aligned 1-to-1 with map_keys "
+                f"(M={keys.shape[0]}); got shape {vals.shape}"
+            )
+        if not np.issubdtype(keys.dtype, np.integer) or not np.issubdtype(vals.dtype, np.integer):
+            raise ValueError(
+                f"map_keys/map_vals must be integer arrays; got {keys.dtype} / {vals.dtype}"
+            )
+        # frozen dataclass: store the coerced arrays.
+        object.__setattr__(self, "map_keys", keys)
+        object.__setattr__(self, "map_vals", vals)
+
+    def __len__(self) -> int:
+        return int(self.map_keys.shape[0])

--- a/reconciliation/country_mapping_provider.py
+++ b/reconciliation/country_mapping_provider.py
@@ -1,0 +1,28 @@
+"""The `CountryMappingProvider` port (EPIC #172 / ADR-014).
+
+The geography source differs by data source — VIEWS `country_id` (viewser) vs
+`gaul0_code` (views-datafactory) — and both coexist during the migration. So the
+source is a port: concrete providers (`ViewserCountryMappingProvider` now, a
+datafactory provider later) are selected per ensemble, derived from its data
+source (ADR-013). A provider encapsulates *how* to obtain the mapping (window,
+region, fetch); `build()` takes no arguments and returns the value.
+
+This module is the stable abstraction (SAP/SDP): it imports nothing concrete —
+not viewser, not views-postprocessing.
+"""
+from __future__ import annotations
+
+from typing import Protocol, runtime_checkable
+
+from reconciliation.country_mapping import CountryMapping
+
+
+@runtime_checkable
+class CountryMappingProvider(Protocol):
+    """Port: build the `(time, priogrid_gid) -> country_id` mapping for a
+    reconciliation run, in the country-id system matching the ensemble's data
+    source. Implementations hold whatever inputs they need (window, region)."""
+
+    def build(self) -> CountryMapping:
+        """Return the geography mapping covering the run's grid x time universe."""
+        ...

--- a/tests/test_reconciliation_country_mapping.py
+++ b/tests/test_reconciliation_country_mapping.py
@@ -1,0 +1,60 @@
+"""S1 (#174) — `CountryMapping` value invariants + `CountryMappingProvider` port.
+
+Pure value/port contracts — no viewser/postprocessing dependency.
+"""
+import numpy as np
+import pytest
+
+from reconciliation.country_mapping import CountryMapping
+from reconciliation.country_mapping_provider import CountryMappingProvider
+
+pytestmark = pytest.mark.green
+
+
+def _valid_arrays():
+    keys = np.array([[480, 100], [480, 101], [481, 100]], dtype=np.int64)
+    vals = np.array([10, 10, 10], dtype=np.int64)
+    return keys, vals
+
+
+def test_valid_mapping_constructs_and_holds_arrays():
+    keys, vals = _valid_arrays()
+    cm = CountryMapping(keys, vals)
+    assert len(cm) == 3
+    np.testing.assert_array_equal(cm.map_keys, keys)
+    np.testing.assert_array_equal(cm.map_vals, vals)
+
+
+def test_rejects_keys_not_M_by_2():
+    with pytest.raises(ValueError):
+        CountryMapping(np.array([1, 2, 3], dtype=np.int64), np.array([1, 2, 3], dtype=np.int64))
+
+
+def test_rejects_vals_misaligned_with_keys():
+    keys, _ = _valid_arrays()
+    with pytest.raises(ValueError):
+        CountryMapping(keys, np.array([10, 10], dtype=np.int64))
+
+
+def test_rejects_non_integer_arrays():
+    keys, vals = _valid_arrays()
+    with pytest.raises(ValueError):
+        CountryMapping(keys.astype(float), vals)
+
+
+def test_is_frozen():
+    cm = CountryMapping(*_valid_arrays())
+    with pytest.raises(Exception):
+        cm.map_vals = np.array([1], dtype=np.int64)
+
+
+def test_provider_port_is_runtime_checkable():
+    class _Provider:
+        def build(self) -> CountryMapping:
+            return CountryMapping(*_valid_arrays())
+
+    class _NotAProvider:
+        pass
+
+    assert isinstance(_Provider(), CountryMappingProvider)
+    assert not isinstance(_NotAProvider(), CountryMappingProvider)


### PR DESCRIPTION
Part of EPIC #172. The geography value type + the provider port (the stable abstraction). No concrete deps. 6 tests pass.