### PR TITLE
feat(reconciliation): ViewserCountryMappingProvider — parity source (#175, S2)

### DIFF
--- a/reconciliation/viewser_country_mapping_provider.py
+++ b/reconciliation/viewser_country_mapping_provider.py
@@ -1,0 +1,62 @@
+"""Viewser country-mapping provider — the parity source (EPIC #172 / S2 #175).
+
+Builds `(time, priogrid_gid) -> VIEWS country_id` for a forecast window, matching
+the **current** reconciliation behaviour bit-for-bit. The current path
+(views-reporting `metadata.build_country_to_grids_cache` → `get_country_id` →
+`build_pg_metadata_cache`) sources `country_id` from a `priogrid_month` queryset
+column `Column("country_id", from_loa="country_month", from_column="country_id")`
+and takes the **first** country per grid (`.groupby(grid).first()`, time-invariant).
+We reproduce exactly that, so swapping the wiring does not change the numbers.
+
+The viewser fetch is injected (a callable) so the build logic is unit-testable
+without viewser, and the viewser/pandas coupling stays isolated to one default.
+A datafactory provider (`gaul0_code`) is a separate class (different id system).
+"""
+from __future__ import annotations
+
+from typing import Callable, Optional
+
+import numpy as np
+
+from reconciliation.country_mapping import CountryMapping
+
+# (start_month, end_month) -> DataFrame indexed by (month_id, priogrid_gid) with a
+# "country_id" column (VIEWS country_id).
+FetchCountryMetadata = Callable[[int, int], "object"]
+
+
+class ViewserCountryMappingProvider:
+    """Builds the VIEWS-`country_id` geography mapping for a forecast window."""
+
+    def __init__(
+        self,
+        start_month: int,
+        end_month: int,
+        fetch_country_metadata: Optional[FetchCountryMetadata] = None,
+    ) -> None:
+        self._start_month = start_month
+        self._end_month = end_month
+        self._fetch = fetch_country_metadata or self._fetch_from_viewser
+
+    def build(self) -> CountryMapping:
+        df = self._fetch(self._start_month, self._end_month)
+        # Time-invariant canonical country per grid — parity with views-reporting's
+        # build_country_to_grids_cache (.groupby(grid)["country_id"].first()).
+        gids_idx = df.index.get_level_values(1)
+        grid_country = df.groupby(gids_idx)["country_id"].first()
+
+        months = np.asarray(df.index.get_level_values(0), dtype=np.int64)
+        gids = np.asarray(df.index.get_level_values(1), dtype=np.int64)
+        map_keys = np.stack([months, gids], axis=1)
+        map_vals = grid_country.reindex(gids).to_numpy().astype(np.int64)
+        return CountryMapping(map_keys, map_vals)
+
+    @staticmethod
+    def _fetch_from_viewser(start_month: int, end_month: int):
+        """The parity fetch — the same column the current reconciliation path uses."""
+        from viewser import Column, Queryset
+
+        queryset = Queryset("recon_pg_country_map", "priogrid_month").with_column(
+            Column("country_id", from_loa="country_month", from_column="country_id")
+        )
+        return queryset.publish().fetch(start_date=start_month, end_date=end_month)

--- a/tests/test_reconciliation_viewser_provider.py
+++ b/tests/test_reconciliation_viewser_provider.py
@@ -1,0 +1,62 @@
+"""S2 (#175) — ViewserCountryMappingProvider.
+
+Build logic is unit-tested with an injected fake fetch (no viewser); a real
+viewser fetch is exercised in a skip-when-unavailable integration test.
+"""
+import numpy as np
+import pandas as pd
+import pytest
+
+from reconciliation.country_mapping import CountryMapping
+from reconciliation.country_mapping_provider import CountryMappingProvider
+from reconciliation.viewser_country_mapping_provider import ViewserCountryMappingProvider
+
+pytestmark = pytest.mark.green
+
+
+def _meta_df(rows):
+    """rows: list of (month_id, priogrid_gid, country_id)."""
+    idx = pd.MultiIndex.from_tuples(
+        [(m, g) for m, g, _ in rows], names=["month_id", "priogrid_gid"]
+    )
+    return pd.DataFrame({"country_id": [c for *_, c in rows]}, index=idx)
+
+
+def test_builds_country_mapping_from_fetch():
+    fetch = lambda s, e: _meta_df(  # noqa: E731
+        [(480, 100, 10), (480, 101, 20), (481, 100, 10), (481, 101, 20)]
+    )
+    cm = ViewserCountryMappingProvider(480, 481, fetch_country_metadata=fetch).build()
+    assert isinstance(cm, CountryMapping)
+    np.testing.assert_array_equal(
+        cm.map_keys, np.array([[480, 100], [480, 101], [481, 100], [481, 101]])
+    )
+    np.testing.assert_array_equal(cm.map_vals, np.array([10, 20, 10, 20]))
+
+
+def test_first_country_per_grid_is_time_invariant_parity():
+    # gid 100 maps to country 10 in month 480, then 99 in 481. Parity with
+    # views-reporting takes .first() per grid → 10 for BOTH rows.
+    fetch = lambda s, e: _meta_df([(480, 100, 10), (481, 100, 99)])  # noqa: E731
+    cm = ViewserCountryMappingProvider(480, 481, fetch_country_metadata=fetch).build()
+    np.testing.assert_array_equal(cm.map_vals, np.array([10, 10]))
+
+
+def test_satisfies_provider_port():
+    fetch = lambda s, e: _meta_df([(480, 100, 10)])  # noqa: E731
+    provider = ViewserCountryMappingProvider(480, 480, fetch_country_metadata=fetch)
+    assert isinstance(provider, CountryMappingProvider)
+
+
+@pytest.mark.red
+def test_viewser_fetch_integration():
+    try:
+        import viewser  # noqa: F401
+    except ImportError as e:
+        pytest.skip(f"viewser unavailable: {e}")
+    try:
+        cm = ViewserCountryMappingProvider(480, 481).build()
+    except Exception as e:  # network/credentials/schema
+        pytest.skip(f"viewser fetch failed: {type(e).__name__}: {e}")
+    assert len(cm) > 0
+    assert cm.map_keys.shape[1] == 2


### PR DESCRIPTION
Part of EPIC #172. The VIEWS-country_id provider, matching views-reporting's geography source bit-for-bit (priogrid_month country_id from country_month, .first() per grid). Injectable fetch for testability. 4 passed incl. live viewser.