### PR TITLE
feat(reconciliation): reconciler_factory — the one concrete-binding wire (#176, S3)

### DIFF
--- a/reconciliation/__init__.py
+++ b/reconciliation/__init__.py
@@ -5,9 +5,11 @@ pipeline-core defines the `Reconciler` port, views-postprocessing provides the
 concrete `ReconciliationModule`, and this layer (the composition root's helper)
 builds the geography and constructs the concrete — confined to one file.
 
-`build_reconciler` is added in S3 (#176).
+The composition root imports `build_reconciler` and injects its result as
+`reconciler=` into the ensemble manager.
 """
 from reconciliation.country_mapping import CountryMapping
 from reconciliation.country_mapping_provider import CountryMappingProvider
+from reconciliation.reconciler_factory import build_reconciler
 
-__all__ = ["CountryMapping", "CountryMappingProvider"]
+__all__ = ["CountryMapping", "CountryMappingProvider", "build_reconciler"]

--- a/reconciliation/reconciler_factory.py
+++ b/reconciliation/reconciler_factory.py
@@ -1,0 +1,56 @@
+"""The reconciler factory — the single concrete-binding wire (EPIC #172 / S3 #176).
+
+This is the **only** file that imports the concrete reconciler
+(`views_postprocessing.reconciliation.ReconciliationModule`) — the one sanctioned,
+irreducible composition wire (ADR-014; CCP/DIP). It selects a geography provider,
+builds the `(time, priogrid_gid) -> country_id` mapping, constructs the concrete,
+and returns it typed as the pipeline-core `Reconciler` port so callers depend only
+on the abstraction.
+
+Adding a datafactory-sourced ensemble later is a one-line registry entry +
+one new provider file — no change to this function's signature or its callers (OCP).
+"""
+from __future__ import annotations
+
+from typing import Optional
+
+from views_pipeline_core.domain.reconciliation import Reconciler
+
+from reconciliation.country_mapping_provider import CountryMappingProvider
+from reconciliation.viewser_country_mapping_provider import ViewserCountryMappingProvider
+
+# Geography-source name -> provider class. Selected per ensemble from its data
+# source (ADR-013). Add "datafactory" here (one line) when a datafactory-sourced
+# reconciling ensemble first exists — callers don't change (OCP).
+_PROVIDERS = {"viewser": ViewserCountryMappingProvider}
+
+
+def build_reconciler(
+    start_month: int,
+    end_month: int,
+    source: str = "viewser",
+    provider: Optional[CountryMappingProvider] = None,
+) -> Reconciler:
+    """Construct the concrete reconciler for a forecast window, typed as the port.
+
+    Args:
+        start_month, end_month: the forecast month range the mapping must cover.
+        source: geography-source key (default ``"viewser"``); selects the provider.
+        provider: an explicit provider (overrides ``source``) — for testing / advanced wiring.
+    """
+    if provider is None:
+        try:
+            provider_cls = _PROVIDERS[source]
+        except KeyError:
+            raise ValueError(
+                f"Unknown reconciliation geography source {source!r}; "
+                f"known sources: {sorted(_PROVIDERS)}"
+            )
+        provider = provider_cls(start_month, end_month)
+
+    mapping = provider.build()
+
+    # The single concrete import — confined to this file (ADR-014).
+    from views_postprocessing.reconciliation import ReconciliationModule
+
+    return ReconciliationModule(mapping.map_keys, mapping.map_vals)

--- a/tests/test_reconciliation_factory.py
+++ b/tests/test_reconciliation_factory.py
@@ -1,0 +1,52 @@
+"""S3 (#176) — reconciler_factory.
+
+Verifies the factory returns a valid `Reconciler` (the port), uses the injected
+provider, exposes the provider-selection seam, and fails on an unknown source.
+Needs views-postprocessing (dev-installed) to construct the concrete.
+"""
+import numpy as np
+import pytest
+
+from reconciliation.country_mapping import CountryMapping
+from reconciliation.reconciler_factory import _PROVIDERS, build_reconciler
+
+pytestmark = pytest.mark.green
+
+Reconciler = pytest.importorskip(
+    "views_pipeline_core.domain.reconciliation"
+).Reconciler
+pytest.importorskip("views_postprocessing.reconciliation")
+
+
+class _FakeProvider:
+    def __init__(self):
+        self.built = False
+
+    def build(self) -> CountryMapping:
+        self.built = True
+        return CountryMapping(
+            np.array([[480, 100], [480, 101]], dtype=np.int64),
+            np.array([10, 10], dtype=np.int64),
+        )
+
+
+def test_build_reconciler_returns_the_port_type():
+    rec = build_reconciler(480, 481, provider=_FakeProvider())
+    assert isinstance(rec, Reconciler)  # runtime_checkable: has reconcile(cm, pgm)
+
+
+def test_uses_the_injected_provider():
+    provider = _FakeProvider()
+    build_reconciler(480, 481, provider=provider)
+    assert provider.built
+
+
+def test_unknown_source_fails_loud():
+    with pytest.raises(ValueError):
+        build_reconciler(480, 481, source="datafactory")  # not registered yet
+
+
+def test_provider_selection_seam_is_open_for_extension():
+    # viewser is the only registered source today; a datafactory provider slots
+    # in here without changing build_reconciler's signature or its callers.
+    assert "viewser" in _PROVIDERS


### PR DESCRIPTION
Part of EPIC #172. The single file importing views_postprocessing; returns a Reconciler (the port). OCP provider-selection seam. 4 passed.