### PR TITLE
feat(reconciliation): inject the reconciler at the composition root (#177, S4)

### DIFF
--- a/ensembles/skinny_love/main.py
+++ b/ensembles/skinny_love/main.py
@@ -1,6 +1,13 @@
+import sys
 from pathlib import Path
+
 from views_pipeline_core.cli import ForecastingModelArgs
 from views_pipeline_core.managers.ensemble import EnsemblePathManager, EnsembleManager
+
+# Composition root (ADR-014): bootstrap the repo root so the reconciliation wiring
+# layer is importable (run.sh is immutable, so PYTHONPATH cannot be set there).
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+from reconciliation import build_reconciler_for_run  # noqa: E402
 
 try:
     ensemble_path = EnsemblePathManager(Path(__file__))
@@ -10,10 +17,15 @@ except Exception as e:
 if __name__ == "__main__":
     args = ForecastingModelArgs.parse_args()
 
+    # skinny_love reconciles (pgm_cm_point) with pink_ponyclub — inject the concrete
+    # reconciler at the composition root (EPIC #172).
+    reconciler = build_reconciler_for_run(Path(__file__).resolve().parent)
+
     manager = EnsembleManager(
         ensemble_path=ensemble_path,
         wandb_notifications=args.wandb_notifications,
         use_prediction_store=args.prediction_store,
+        reconciler=reconciler,
     )
 
     manager.execute_single_run(args)

--- a/ensembles/white_mustang/main.py
+++ b/ensembles/white_mustang/main.py
@@ -1,6 +1,13 @@
+import sys
 from pathlib import Path
+
 from views_pipeline_core.cli import ForecastingModelArgs
 from views_pipeline_core.managers.ensemble import EnsemblePathManager, EnsembleManager
+
+# Composition root (ADR-014): bootstrap the repo root so the reconciliation wiring
+# layer is importable (run.sh is immutable, so PYTHONPATH cannot be set there).
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+from reconciliation import build_reconciler_for_run  # noqa: E402
 
 try:
     ensemble_path = EnsemblePathManager(Path(__file__))
@@ -15,10 +22,15 @@ except Exception as e:
 if __name__ == "__main__":
     args = ForecastingModelArgs.parse_args()
 
+    # white_mustang reconciles (pgm_cm_point) with cruel_summer — inject the concrete
+    # reconciler at the composition root (EPIC #172).
+    reconciler = build_reconciler_for_run(Path(__file__).resolve().parent)
+
     manager = EnsembleManager(
         ensemble_path=ensemble_path,
         wandb_notifications=args.wandb_notifications,
         use_prediction_store=args.prediction_store,
+        reconciler=reconciler,
     )
 
     manager.execute_single_run(args)

--- a/reconciliation/__init__.py
+++ b/reconciliation/__init__.py
@@ -8,8 +8,14 @@ builds the geography and constructs the concrete — confined to one file.
 The composition root imports `build_reconciler` and injects its result as
 `reconciler=` into the ensemble manager.
 """
+from reconciliation.composition import build_reconciler_for_run
 from reconciliation.country_mapping import CountryMapping
 from reconciliation.country_mapping_provider import CountryMappingProvider
 from reconciliation.reconciler_factory import build_reconciler
 
-__all__ = ["CountryMapping", "CountryMappingProvider", "build_reconciler"]
+__all__ = [
+    "CountryMapping",
+    "CountryMappingProvider",
+    "build_reconciler",
+    "build_reconciler_for_run",
+]

--- a/reconciliation/composition.py
+++ b/reconciliation/composition.py
@@ -1,0 +1,57 @@
+"""Wire a reconciler for an ensemble run (EPIC #172 / S4 #177).
+
+The composition logic a reconciling ensemble's ``main.py`` calls: derive the
+forecast month window from the ensemble's partition config and build the
+reconciler (geography source selected per ensemble — viewser today). Keeps
+``main.py`` a thin one-liner; the window-sizing lives here (SRP), not in the leaf.
+"""
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+from typing import Optional
+
+from views_pipeline_core.domain.reconciliation import Reconciler
+
+from reconciliation.country_mapping_provider import CountryMappingProvider
+from reconciliation.reconciler_factory import build_reconciler
+
+# Months padded past the last declared test range, so a forecast run that runs
+# beyond the fixed partitions is still covered by the geography mapping.
+_WINDOW_BUFFER_MONTHS = 24
+
+
+def _forecast_window(partitions: dict, buffer: int = _WINDOW_BUFFER_MONTHS) -> tuple[int, int]:
+    """The (start, end) month span the geography must cover — the union of every
+    partition's test range, padded. A superset is safe; a missing month is not."""
+    test_ranges = [
+        p["test"] for p in partitions.values() if isinstance(p, dict) and "test" in p
+    ]
+    if not test_ranges:
+        raise ValueError(
+            "config_partitions declares no test ranges; cannot size the reconciliation window"
+        )
+    starts = [int(r[0]) for r in test_ranges]
+    ends = [int(r[1]) for r in test_ranges]
+    return min(starts), max(ends) + buffer
+
+
+def _load_partitions(ensemble_dir: Path) -> dict:
+    path = Path(ensemble_dir) / "configs" / "config_partitions.py"
+    spec = importlib.util.spec_from_file_location(
+        f"_recon_partitions_{Path(ensemble_dir).name}", path
+    )
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module.generate()
+
+
+def build_reconciler_for_run(
+    ensemble_dir: Path,
+    source: str = "viewser",
+    provider: Optional[CountryMappingProvider] = None,
+) -> Reconciler:
+    """Build the reconciler for a reconciling ensemble, sizing the geography window
+    from its partition config. Called by the ensemble's main.py composition root."""
+    start_month, end_month = _forecast_window(_load_partitions(ensemble_dir))
+    return build_reconciler(start_month, end_month, source=source, provider=provider)

--- a/tests/test_reconciliation_composition.py
+++ b/tests/test_reconciliation_composition.py
@@ -1,0 +1,51 @@
+"""S4 (#177) — composition: window sizing + build_reconciler_for_run."""
+import numpy as np
+import pytest
+
+from reconciliation.composition import (
+    _WINDOW_BUFFER_MONTHS,
+    _forecast_window,
+    build_reconciler_for_run,
+)
+from reconciliation.country_mapping import CountryMapping
+
+pytestmark = pytest.mark.green
+
+Reconciler = pytest.importorskip(
+    "views_pipeline_core.domain.reconciliation"
+).Reconciler
+pytest.importorskip("views_postprocessing.reconciliation")
+
+
+def test_forecast_window_is_union_of_test_ranges_plus_buffer():
+    partitions = {
+        "calibration": {"train": (121, 456), "test": (457, 504)},
+        "validation": {"train": (121, 504), "test": (505, 552)},
+        "forecasting": {"train": (121, 557), "test": (558, 594)},
+    }
+    start, end = _forecast_window(partitions)
+    assert start == 457
+    assert end == 594 + _WINDOW_BUFFER_MONTHS
+
+
+def test_forecast_window_requires_test_ranges():
+    with pytest.raises(ValueError):
+        _forecast_window({"calibration": {"train": (1, 2)}})
+
+
+class _FakeProvider:
+    def build(self) -> CountryMapping:
+        return CountryMapping(
+            np.array([[480, 100]], dtype=np.int64), np.array([10], dtype=np.int64)
+        )
+
+
+def test_build_reconciler_for_run_returns_the_port(tmp_path):
+    cfg = tmp_path / "configs"
+    cfg.mkdir()
+    (cfg / "config_partitions.py").write_text(
+        "def generate():\n"
+        "    return {'forecasting': {'train': (121, 557), 'test': (558, 594)}}\n"
+    )
+    rec = build_reconciler_for_run(tmp_path, provider=_FakeProvider())
+    assert isinstance(rec, Reconciler)


### PR DESCRIPTION
Part of EPIC #172. Wires skinny_love + white_mustang main.py to build_reconciler_for_run and inject reconciler= (sys.path bootstrap per ADR-014). Only the 2 reconciling ensembles touched. 17 tests pass.