### PR TITLE
feat(reconciliation): source_detection — derive the data source (#193, S1)

### DIFF
--- a/reconciliation/source_detection.py
+++ b/reconciliation/source_detection.py
@@ -1,0 +1,70 @@
+"""Detect a model's / ensemble's data source (EPIC #192 / S1 #193).
+
+The reconciliation geography must use the country-id system of the data being
+reconciled — VIEWS `country_id` (viewser) vs `gaul0_code` (views-datafactory),
+which do not overlap. So the geography source must be **derived** from the
+ensemble's actual data, not assumed. This module is that derivation (SRP:
+detection only — it knows nothing about providers).
+
+Discriminator: a model's `config_queryset.py` declares its source. A
+datafactory model's `generate()` returns a descriptor dict with
+`"source": "views-datafactory"`; a viewser model returns a `Queryset`. We detect
+via AST (the string literal `"views-datafactory"` in the module) — import-free
+(no constituent configs imported at run start) and comment-proof (comments are
+not in the AST). Same discriminator as `tests/test_datafactory_source_names.py`.
+"""
+from __future__ import annotations
+
+import ast
+import importlib.util
+from pathlib import Path
+
+VIEWSER = "viewser"
+DATAFACTORY = "views-datafactory"
+
+
+def detect_model_source(model_dir: Path) -> str:
+    """Return ``"viewser"`` or ``"views-datafactory"`` for a model, from its
+    config_queryset descriptor. Raises ``FileNotFoundError`` if absent."""
+    path = Path(model_dir) / "configs" / "config_queryset.py"
+    if not path.exists():
+        raise FileNotFoundError(f"config_queryset.py not found for model at {model_dir}")
+    tree = ast.parse(path.read_text())
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Constant) and node.value == DATAFACTORY:
+            return DATAFACTORY
+    return VIEWSER
+
+
+def _load_modelset(ensemble_dir: Path) -> dict:
+    path = Path(ensemble_dir) / "configs" / "config_modelset.py"
+    spec = importlib.util.spec_from_file_location(
+        f"_recon_modelset_{Path(ensemble_dir).name}", path
+    )
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module.get_modelset_config()
+
+
+def detect_ensemble_source(ensemble_dir: Path, models_dir: Path | None = None) -> str:
+    """Return the single data source shared by an ensemble's constituents.
+
+    Fails loud (``ValueError``) if the constituents disagree — a mixed-source
+    ensemble cannot be reconciled coherently (the grid→country attribution would
+    mix country-id systems). See C-49.
+    """
+    ensemble_dir = Path(ensemble_dir)
+    if models_dir is None:
+        models_dir = ensemble_dir.parent.parent / "models"
+    models = _load_modelset(ensemble_dir).get("models", [])
+    if not models:
+        raise ValueError(f"{ensemble_dir.name}: config_modelset declares no models")
+    sources = {m: detect_model_source(Path(models_dir) / m) for m in models}
+    distinct = set(sources.values())
+    if len(distinct) != 1:
+        raise ValueError(
+            f"{ensemble_dir.name}: constituents disagree on data source {sources} — "
+            f"a mixed-source ensemble cannot be reconciled coherently (country-id "
+            f"systems differ; see C-49)."
+        )
+    return distinct.pop()

--- a/tests/test_reconciliation_source_detection.py
+++ b/tests/test_reconciliation_source_detection.py
@@ -1,0 +1,60 @@
+"""S1 (#193) — source detection (AST, import-free)."""
+from pathlib import Path
+
+import pytest
+
+from reconciliation.source_detection import (
+    DATAFACTORY,
+    VIEWSER,
+    detect_ensemble_source,
+    detect_model_source,
+)
+
+pytestmark = pytest.mark.green
+
+REPO = Path(__file__).resolve().parent.parent
+MODELS = REPO / "models"
+ENSEMBLES = REPO / "ensembles"
+
+
+def test_detects_viewser_model():
+    assert detect_model_source(MODELS / "car_radio") == VIEWSER
+
+
+def test_detects_datafactory_model():
+    assert detect_model_source(MODELS / "bright_starship") == DATAFACTORY
+
+
+def test_missing_config_fails_loud():
+    with pytest.raises(FileNotFoundError):
+        detect_model_source(MODELS / "no_such_model_xyz")
+
+
+@pytest.mark.parametrize(
+    "ensemble", ["skinny_love", "pink_ponyclub", "white_mustang", "cruel_summer"]
+)
+def test_reconciliation_ensembles_are_viewser_today(ensemble):
+    assert detect_ensemble_source(ENSEMBLES / ensemble) == VIEWSER
+
+
+def _write_model(models_dir: Path, name: str, datafactory: bool):
+    cfg = models_dir / name / "configs"
+    cfg.mkdir(parents=True)
+    if datafactory:
+        body = 'def generate():\n    return {"name": "x", "source": "views-datafactory"}\n'
+    else:
+        body = "def generate():\n    return object()  # stands in for a viewser Queryset\n"
+    (cfg / "config_queryset.py").write_text(body)
+
+
+def test_mixed_source_ensemble_fails_loud(tmp_path):
+    models_dir = tmp_path / "models"
+    _write_model(models_dir, "vw_model", datafactory=False)
+    _write_model(models_dir, "df_model", datafactory=True)
+    ens = tmp_path / "ensembles" / "mixed"
+    (ens / "configs").mkdir(parents=True)
+    (ens / "configs" / "config_modelset.py").write_text(
+        "def get_modelset_config():\n    return {'models': ['vw_model', 'df_model']}\n"
+    )
+    with pytest.raises(ValueError, match="disagree on data source"):
+        detect_ensemble_source(ens, models_dir=models_dir)


### PR DESCRIPTION
Part of EPIC #192. AST detection of a model/ensemble data source (viewser vs datafactory); mixed-source ensembles fail loud. 8 passed.