### PR TITLE
fix(reconciliation): derive the geography source + fail-loud guards (#194, S2)

### DIFF
--- a/reconciliation/composition.py
+++ b/reconciliation/composition.py
@@ -2,8 +2,9 @@
 
 The composition logic a reconciling ensemble's ``main.py`` calls: derive the
 forecast month window from the ensemble's partition config and build the
-reconciler (geography source selected per ensemble — viewser today). Keeps
-``main.py`` a thin one-liner; the window-sizing lives here (SRP), not in the leaf.
+reconciler (geography source **derived** from the ensemble's data — viewser vs
+datafactory). Keeps ``main.py`` a thin one-liner; window-sizing and source
+derivation live here (SRP), not in the leaf.
 """
 from __future__ import annotations
 
@@ -15,6 +16,7 @@ from views_pipeline_core.domain.reconciliation import Reconciler
 
 from reconciliation.country_mapping_provider import CountryMappingProvider
 from reconciliation.reconciler_factory import build_reconciler
+from reconciliation.source_detection import detect_ensemble_source
 
 # Months padded past the last declared test range, so a forecast run that runs
 # beyond the fixed partitions is still covered by the geography mapping.
@@ -46,12 +48,57 @@ def _load_partitions(ensemble_dir: Path) -> dict:
     return module.generate()
 
 
+def _load_meta(ensemble_dir: Path) -> dict:
+    path = Path(ensemble_dir) / "configs" / "config_meta.py"
+    spec = importlib.util.spec_from_file_location(
+        f"_recon_meta_{Path(ensemble_dir).name}", path
+    )
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module.get_meta_config()
+
+
+def _derive_source(ensemble_dir: Path) -> str:
+    """Derive the geography source from the data being reconciled (EPIC #192).
+
+    The country-id system must match the CM forecast this ensemble reconciles
+    against (its ``reconcile_with`` partner — VIEWS ``country_id`` vs ``gaul0_code``).
+    The PGM ensemble's own source must agree, or the pairing is incoherent. Fails
+    loud on mismatch; an unsupported source (e.g. datafactory before its provider
+    exists) then fails loud at the factory — never a silent viewser fallback.
+    """
+    ensemble_dir = Path(ensemble_dir)
+    partner = _load_meta(ensemble_dir).get("reconcile_with")
+    if not partner:
+        raise ValueError(
+            f"{ensemble_dir.name}: reconciliation is configured but no reconcile_with "
+            f"partner is declared — cannot derive the geography source."
+        )
+    cm_source = detect_ensemble_source(ensemble_dir.parent / partner)
+    pgm_source = detect_ensemble_source(ensemble_dir)
+    if pgm_source != cm_source:
+        raise ValueError(
+            f"{ensemble_dir.name} (source={pgm_source}) and its reconcile_with partner "
+            f"'{partner}' (source={cm_source}) disagree on data source — reconciliation "
+            f"would mix country-id systems. Both must share one source (C-49, EPIC #192)."
+        )
+    return cm_source
+
+
 def build_reconciler_for_run(
     ensemble_dir: Path,
-    source: str = "viewser",
+    source: Optional[str] = None,
     provider: Optional[CountryMappingProvider] = None,
 ) -> Reconciler:
-    """Build the reconciler for a reconciling ensemble, sizing the geography window
-    from its partition config. Called by the ensemble's main.py composition root."""
+    """Build the reconciler for a reconciling ensemble. Sizes the geography window
+    from the partition config and **derives** the geography source from the data
+    (via the ``reconcile_with`` CM partner) unless an explicit ``source``/``provider``
+    is given. A datafactory-sourced ensemble fails loud at the factory until its
+    provider exists — never a silent viewser fallback (EPIC #192 / ADR-014)."""
+    ensemble_dir = Path(ensemble_dir)
     start_month, end_month = _forecast_window(_load_partitions(ensemble_dir))
-    return build_reconciler(start_month, end_month, source=source, provider=provider)
+    if provider is not None:
+        return build_reconciler(start_month, end_month, provider=provider)
+    if source is None:
+        source = _derive_source(ensemble_dir)
+    return build_reconciler(start_month, end_month, source=source)

--- a/tests/test_reconciliation_source_derivation.py
+++ b/tests/test_reconciliation_source_derivation.py
@@ -1,0 +1,69 @@
+"""S2 (#194) — the geography source is derived, with fail-loud guards."""
+import pytest
+
+from reconciliation.composition import _derive_source, build_reconciler_for_run
+
+pytestmark = pytest.mark.green
+
+
+def _model(root, name, datafactory):
+    cfg = root / "models" / name / "configs"
+    cfg.mkdir(parents=True)
+    body = (
+        'def generate():\n    return {"source": "views-datafactory"}\n'
+        if datafactory
+        else "def generate():\n    return object()  # stands in for a Queryset\n"
+    )
+    (cfg / "config_queryset.py").write_text(body)
+
+
+def _ensemble(root, name, reconcile_with, constituents):
+    ens = root / "ensembles" / name
+    (ens / "configs").mkdir(parents=True)
+    rw = f"'{reconcile_with}'" if reconcile_with else "None"
+    (ens / "configs" / "config_meta.py").write_text(
+        f"def get_meta_config():\n    return {{'name': '{name}', 'reconcile_with': {rw}}}\n"
+    )
+    (ens / "configs" / "config_modelset.py").write_text(
+        f"def get_modelset_config():\n    return {{'models': {constituents!r}}}\n"
+    )
+    (ens / "configs" / "config_partitions.py").write_text(
+        "def generate():\n    return {'forecasting': {'train': (121, 557), 'test': (558, 594)}}\n"
+    )
+    return ens
+
+
+def test_derives_viewser_for_an_all_viewser_pair(tmp_path):
+    _model(tmp_path, "vw1", datafactory=False)
+    _model(tmp_path, "vw2", datafactory=False)
+    _ensemble(tmp_path, "cm", None, ["vw2"])
+    pgm = _ensemble(tmp_path, "pgm", "cm", ["vw1"])
+    assert _derive_source(pgm) == "viewser"
+
+
+def test_pgm_cm_source_mismatch_fails_loud(tmp_path):
+    _model(tmp_path, "vw1", datafactory=False)
+    _model(tmp_path, "df1", datafactory=True)
+    _ensemble(tmp_path, "cm", None, ["df1"])  # CM is datafactory
+    pgm = _ensemble(tmp_path, "pgm", "cm", ["vw1"])  # PGM is viewser
+    with pytest.raises(ValueError, match="disagree on data source"):
+        _derive_source(pgm)
+
+
+def test_missing_reconcile_with_fails_loud(tmp_path):
+    _model(tmp_path, "vw1", datafactory=False)
+    pgm = _ensemble(tmp_path, "pgm", None, ["vw1"])
+    with pytest.raises(ValueError, match="no reconcile_with"):
+        _derive_source(pgm)
+
+
+def test_datafactory_pair_fails_loud_no_provider(tmp_path):
+    # both datafactory -> derives "views-datafactory" -> factory has no provider ->
+    # fail loud (never a silent viewser fallback). Fails at the provider lookup,
+    # before any viewser/postprocessing is touched.
+    _model(tmp_path, "df1", datafactory=True)
+    _model(tmp_path, "df2", datafactory=True)
+    _ensemble(tmp_path, "cm", None, ["df2"])
+    pgm = _ensemble(tmp_path, "pgm", "cm", ["df1"])
+    with pytest.raises(ValueError, match="[Uu]nknown reconciliation geography source"):
+        build_reconciler_for_run(pgm)


### PR DESCRIPTION
Part of EPIC #192. The geography source is now derived from the data; datafactory/mismatch fail loud (no silent viewser). Closes the silent-corruption hole; docstrings corrected. 10 passed.