### PR TITLE
docs(reconcile): repoint CountryMapping docstring to views_frames_reconcile

### DIFF
--- a/reconciliation/country_mapping.py
+++ b/reconciliation/country_mapping.py
@@ -22,7 +22,7 @@ class CountryMapping:
     - ``map_vals``: ``(M,)`` int array; ``map_vals[i]`` is the ``country_id`` for
       ``map_keys[i]`` (1-to-1, same order).
 
-    Shapes line up with `views_postprocessing.reconciliation.ReconciliationModule`,
+    Shapes line up with `views_frames_reconcile.ReconciliationModule`,
     which is constructed as ``ReconciliationModule(map_keys, map_vals)``.
     """
 


### PR DESCRIPTION
Stale-reference cleanup after the Epic 11 cutover. `reconciliation/country_mapping.py` had a shape-comment pointing at `views_postprocessing.reconciliation.ReconciliationModule`, which was deleted in vpp PR #63 (C2). Repoints it to the live `views_frames_reconcile`. Comment-only — no behavior change; ruff clean.