### PR TITLE
Hotfix: add target_transform to pink_ponyclub stepshifter models (run against released stack)

### DIFF
--- a/models/bittersweet_symphony/configs/config_hyperparameters.py
+++ b/models/bittersweet_symphony/configs/config_hyperparameters.py
@@ -9,6 +9,7 @@ def get_hp_config():
     """
     
     hyperparameters = {
+        "target_transform": "log1p",
         "steps": [*range(1, 36 + 1, 1)],
         "time_steps": 36,
         "parameters": {

--- a/models/brown_cheese/configs/config_hyperparameters.py
+++ b/models/brown_cheese/configs/config_hyperparameters.py
@@ -9,6 +9,7 @@ def get_hp_config():
     """
     
     hyperparameters = {
+        "target_transform": "log1p",
         "steps": [*range(1, 36 + 1, 1)],
         "time_steps": 36,
         "parameters": {

--- a/models/car_radio/configs/config_hyperparameters.py
+++ b/models/car_radio/configs/config_hyperparameters.py
@@ -9,6 +9,7 @@ def get_hp_config():
     """
     
     hyperparameters = {
+        "target_transform": "log1p",
         "steps": [*range(1, 36 + 1, 1)],
         "time_steps": 36,
         "parameters": {

--- a/models/counting_stars/configs/config_hyperparameters.py
+++ b/models/counting_stars/configs/config_hyperparameters.py
@@ -9,6 +9,7 @@ def get_hp_config():
     """
     
     hyperparameters = {
+        "target_transform": "log1p",
         "steps": [*range(1, 36 + 1, 1)],
         "time_steps": 36,
         "parameters": {

--- a/models/demon_days/configs/config_hyperparameters.py
+++ b/models/demon_days/configs/config_hyperparameters.py
@@ -9,6 +9,7 @@ def get_hp_config():
     """
     
     hyperparameters = {
+        "target_transform": "log1p",
         "steps": [*range(1, 36 + 1, 1)],
         "time_steps": 36,
         "parameters": {

--- a/models/fast_car/configs/config_hyperparameters.py
+++ b/models/fast_car/configs/config_hyperparameters.py
@@ -9,6 +9,7 @@ def get_hp_config():
     """
     
     hyperparameters = {
+        "target_transform": "identity",
         "steps": [*range(1, 36 + 1, 1)],
         "time_steps": 36,
         "parameters": {

--- a/models/fluorescent_adolescent/configs/config_hyperparameters.py
+++ b/models/fluorescent_adolescent/configs/config_hyperparameters.py
@@ -9,6 +9,7 @@ def get_hp_config():
     """
     
     hyperparameters = {
+        "target_transform": "identity",
         "steps": [*range(1, 36 + 1, 1)],
         "time_steps": 36,
         "parameters": {

--- a/models/good_riddance/configs/config_hyperparameters.py
+++ b/models/good_riddance/configs/config_hyperparameters.py
@@ -9,6 +9,7 @@ def get_hp_config():
     """
     
     hyperparameters = {
+        "target_transform": "log1p",
         "steps": [*range(1, 36 + 1, 1)],
         "time_steps": 36,
         "parameters": {

--- a/models/green_squirrel/configs/config_hyperparameters.py
+++ b/models/green_squirrel/configs/config_hyperparameters.py
@@ -9,6 +9,7 @@ def get_hp_config():
     """
     
     hyperparameters = {
+        "target_transform": "identity",
         "steps": [*range(1, 36 + 1, 1)],
         "time_steps": 36,
         "parameters": {

--- a/models/heavy_rotation/configs/config_hyperparameters.py
+++ b/models/heavy_rotation/configs/config_hyperparameters.py
@@ -9,6 +9,7 @@ def get_hp_config():
     """
     
     hyperparameters = {
+        "target_transform": "log1p",
         "steps": [*range(1, 36 + 1, 1)],
         "time_steps": 36,
         "parameters": {

--- a/models/high_hopes/configs/config_hyperparameters.py
+++ b/models/high_hopes/configs/config_hyperparameters.py
@@ -9,6 +9,7 @@ def get_hp_config():
     """
     
     hyperparameters = {
+        "target_transform": "identity",
         'steps': [*range(1, 36 + 1, 1)],
         "time_steps": 36,
         "parameters": {

--- a/models/little_lies/configs/config_hyperparameters.py
+++ b/models/little_lies/configs/config_hyperparameters.py
@@ -9,6 +9,7 @@ def get_hp_config():
     """
     
     hyperparameters = {
+        "target_transform": "identity",
         "steps": [*range(1, 36 + 1, 1)],
         "time_steps": 36,
         "parameters": {

--- a/models/national_anthem/configs/config_hyperparameters.py
+++ b/models/national_anthem/configs/config_hyperparameters.py
@@ -9,6 +9,7 @@ def get_hp_config():
     """
     
     hyperparameters = {
+        "target_transform": "log1p",
         "steps": [*range(1, 36 + 1, 1)],
         "time_steps": 36,
         "parameters": {

--- a/models/ominous_ox/configs/config_hyperparameters.py
+++ b/models/ominous_ox/configs/config_hyperparameters.py
@@ -9,6 +9,7 @@ def get_hp_config():
     """
     
     hyperparameters = {
+        "target_transform": "log1p",
         'steps': [*range(1, 36 + 1, 1)],
         "time_steps": 36,
         "parameters": {

--- a/models/plastic_beach/configs/config_hyperparameters.py
+++ b/models/plastic_beach/configs/config_hyperparameters.py
@@ -9,6 +9,7 @@ def get_hp_config():
     """
     
     hyperparameters = {
+        "target_transform": "log1p",
         "steps": [*range(1, 36 + 1, 1)],
         "time_steps": 36,
         "parameters": {

--- a/models/popular_monster/configs/config_hyperparameters.py
+++ b/models/popular_monster/configs/config_hyperparameters.py
@@ -9,6 +9,7 @@ def get_hp_config():
     """
     
     hyperparameters = {
+        "target_transform": "log1p",
         "steps": [*range(1, 36 + 1, 1)],
         "time_steps": 36,
         "parameters": {

--- a/models/teen_spirit/configs/config_hyperparameters.py
+++ b/models/teen_spirit/configs/config_hyperparameters.py
@@ -9,6 +9,7 @@ def get_hp_config():
     """
     
     hyperparameters = {
+        "target_transform": "log1p",
         "steps": [*range(1, 36 + 1, 1)],
         "time_steps": 36,
         "parameters": {

--- a/models/twin_flame/configs/config_hyperparameters.py
+++ b/models/twin_flame/configs/config_hyperparameters.py
@@ -9,6 +9,7 @@ def get_hp_config():
     """
     
     hyperparameters = {
+        "target_transform": "identity",
         "steps": [*range(1, 36 + 1, 1)],
         "time_steps": 36,
         "parameters": {

--- a/models/yellow_submarine/configs/config_hyperparameters.py
+++ b/models/yellow_submarine/configs/config_hyperparameters.py
@@ -9,6 +9,7 @@ def get_hp_config():
     """
     
     hyperparameters = {
+        "target_transform": "log1p",
         'steps': [*range(1, 36 + 1, 1)],
         "time_steps": 36,
         "parameters": {


### PR DESCRIPTION
## Why

Running the `pink_ponyclub` ensemble from **main** against the **released** stack (`views-pipeline-core` 2.3.0 + `views-stepshifter` 1.3.0) fails during training:

```
views_stepshifter.infrastructure.exceptions.MissingHyperparameterError:
REPRODUCIBILITY CONTRACT VIOLATED: Missing core parameters: ['target_transform']
```

stepshifter 1.3.0 added a `ReproducibilityGate` whose `CORE_GENOME` is `["steps", "time_steps", "parameters", "target_transform"]`. Main's model configs predate this and never declared `target_transform`.

## What

Adds `target_transform` to the 19 pink_ponyclub members' `config_hyperparameters.py`, matching `development`:
- `"log1p"` — 13 XGBRegressor/XGBRFRegressor models
- `"identity"` — 6 HurdleModel models (the gate pins Hurdle/Shurf to `identity`)

Each change is a clean one-line addition, byte-identical to the corresponding file on `development`.

## Verification

Checked main against the **union of both published contracts** — pipeline-core 2.3.0 `CoreConfigSniffer` mandatory keys (`name, algorithm, level, creator, steps, time_steps, rolling_origin_stride, deployment_status, prediction_format`) + target/metric rules, and stepshifter 1.3.0 gate (`CORE_GENOME` + per-algorithm `parameter_keys`/`config_keys`). Across all 19 members, `target_transform` is the **only** missing required key. Per-algorithm parameter keys (`n_estimators`/`n_jobs`, `clf`/`reg`) are all present. `log1p` and `identity` are both valid in stepshifter 1.3.0's `TRANSFORMS` registry.

## Scope

Targeted **main hotfix** to keep the released stack runnable. Full reconciliation with `development` (which tracks the further-ahead, unreleased stack) is a separate effort.

🤖 Generated with [Claude Code](https://claude.com/claude-code)