### PR TITLE
fix(configs): add target_transform to skinny_love stepshifter models

### DIFF
--- a/models/bad_blood/configs/config_hyperparameters.py
+++ b/models/bad_blood/configs/config_hyperparameters.py
@@ -9,6 +9,7 @@ def get_hp_config():
     """
     
     hyperparameters = {
+        "target_transform": "identity",
         'steps': [*range(1, 36 + 1, 1)],
         "time_steps": 36,
         'parameters': {

--- a/models/blank_space/configs/config_hyperparameters.py
+++ b/models/blank_space/configs/config_hyperparameters.py
@@ -1,5 +1,6 @@
 def get_hp_config(): 
     hp_config = {
+        "target_transform": "identity",
         "steps": [*range(1, 36 + 1, 1)],
         "time_steps": 36,
         "parameters": {

--- a/models/caring_fish/configs/config_hyperparameters.py
+++ b/models/caring_fish/configs/config_hyperparameters.py
@@ -9,6 +9,7 @@ def get_hp_config():
     """
     
     hyperparameters = {
+        "target_transform": "identity",
         'steps': [*range(1, 36 + 1, 1)],
         "time_steps": 36,
         'parameters': {

--- a/models/chunky_cat/configs/config_hyperparameters.py
+++ b/models/chunky_cat/configs/config_hyperparameters.py
@@ -9,6 +9,7 @@ def get_hp_config():
     """
     
     hyperparameters = {
+        "target_transform": "identity",
         'steps': [*range(1, 36 + 1, 1)],
         "time_steps": 36,
         'parameters': {

--- a/models/dark_paradise/configs/config_hyperparameters.py
+++ b/models/dark_paradise/configs/config_hyperparameters.py
@@ -9,6 +9,7 @@ def get_hp_config():
     """
     
     hyperparameters = {
+        "target_transform": "identity",
         "steps": [*range(1, 36 + 1, 1)],
         "time_steps": 36,
         "parameters": {

--- a/models/invisible_string/configs/config_hyperparameters.py
+++ b/models/invisible_string/configs/config_hyperparameters.py
@@ -9,6 +9,7 @@ def get_hp_config():
     """
     
     hyperparameters = {
+        "target_transform": "identity",
         'steps': [*range(1, 36 + 1, 1)],
         "time_steps": 36,
         'parameters': {

--- a/models/lavender_haze/configs/config_hyperparameters.py
+++ b/models/lavender_haze/configs/config_hyperparameters.py
@@ -1,5 +1,6 @@
 def get_hp_config(): 
     hp_config = {
+        "target_transform": "identity",
         "steps": [*range(1, 36 + 1, 1)],
         "time_steps": 36,
         "parameters": {

--- a/models/midnight_rain/configs/config_hyperparameters.py
+++ b/models/midnight_rain/configs/config_hyperparameters.py
@@ -9,6 +9,7 @@ def get_hp_config():
     """
     
     hyperparameters = {
+        "target_transform": "identity",
         'steps': [*range(1, 36 + 1, 1)],
         "time_steps": 36,
          'parameters': {

--- a/models/old_money/configs/config_hyperparameters.py
+++ b/models/old_money/configs/config_hyperparameters.py
@@ -1,5 +1,6 @@
 def get_hp_config(): 
     hp_config = {
+        "target_transform": "identity",
         "steps": [*range(1, 36 + 1, 1)],
         "time_steps": 36,
         "parameters": {

--- a/models/orange_pasta/configs/config_hyperparameters.py
+++ b/models/orange_pasta/configs/config_hyperparameters.py
@@ -1,5 +1,6 @@
 def get_hp_config(): 
     hp_config = {
+        "target_transform": "identity",
         "steps": [*range(1, 36 + 1, 1)],
         "time_steps": 36,
         "parameters": {

--- a/models/wildest_dream/configs/config_hyperparameters.py
+++ b/models/wildest_dream/configs/config_hyperparameters.py
@@ -1,5 +1,6 @@
 def get_hp_config(): 
     hp_config = {
+        "target_transform": "identity",
         "steps": [*range(1, 36 + 1, 1)],
         "time_steps": 36,
         "parameters": {

--- a/models/yellow_pikachu/configs/config_hyperparameters.py
+++ b/models/yellow_pikachu/configs/config_hyperparameters.py
@@ -1,5 +1,6 @@
 def get_hp_config(): 
     hp_config = {
+        "target_transform": "identity",
         "steps": [*range(1, 36 + 1, 1)],
         "time_steps": 36,
         "parameters": {


### PR DESCRIPTION
Adds the `target_transform` core parameter (pulled verbatim from `development`) to the 12 skinny_love ensemble members so they satisfy the stepshifter ReproducibilityGate contract on `main`. Same fix as #205, applied to the skinny_love members.

🤖 Generated with [Claude Code](https://claude.com/claude-code)