### PR TITLE
fix(configs): satisfy stepshifter ReproducibilityGate for ShurfModels

### DIFF
--- a/models/cheap_thrills/configs/config_hyperparameters.py
+++ b/models/cheap_thrills/configs/config_hyperparameters.py
@@ -9,6 +9,7 @@ def get_hp_config():
     """
     
     hyperparameters = {
+        "target_transform": "identity",
         'steps': [*range(1, 36 + 1, 1)],
         "time_steps": 36,
         'submodels_to_train': 50,

--- a/models/fourtieth_symphony/configs/config_hyperparameters.py
+++ b/models/fourtieth_symphony/configs/config_hyperparameters.py
@@ -9,11 +9,12 @@ def get_hp_config():
     """
     
     hyperparameters = {
+        "target_transform": "identity",
         'steps': [*range(1, 36 + 1, 1)],
         "time_steps": 36,
         'submodels_to_train': 20,
         'pred_samples': 10,
-        'log_target': True,
+        'log_target': False,
         'draw_dist': 'Lognormal',
         'draw_sigma': 0.5,
         'geo_unit_samples': 1.0,

--- a/models/lovely_creature/configs/config_hyperparameters.py
+++ b/models/lovely_creature/configs/config_hyperparameters.py
@@ -9,6 +9,7 @@ def get_hp_config():
     """
     
     hyperparameters = {
+        "target_transform": "identity",
         'steps': [*range(1, 36 + 1, 1)],
         "time_steps": 36,
         'submodels_to_train': 50,

--- a/models/purple_haze/configs/config_hyperparameters.py
+++ b/models/purple_haze/configs/config_hyperparameters.py
@@ -9,6 +9,7 @@ def get_hp_config():
     """
     
     hyperparameters = {
+        "target_transform": "identity",
         'steps': [*range(1, 36 + 1, 1)],
         "time_steps": 36,
         'submodels_to_train': 50,

--- a/models/wild_rose/configs/config_hyperparameters.py
+++ b/models/wild_rose/configs/config_hyperparameters.py
@@ -9,6 +9,7 @@ def get_hp_config():
     """
     
     hyperparameters = {
+        "target_transform": "identity",
         'steps': [*range(1, 36 + 1, 1)],
         "time_steps": 36,
         'submodels_to_train': 50,

--- a/models/wuthering_heights/configs/config_hyperparameters.py
+++ b/models/wuthering_heights/configs/config_hyperparameters.py
@@ -9,6 +9,7 @@ def get_hp_config():
     """
     
     hyperparameters = {
+        "target_transform": "identity",
         'steps': [*range(1, 36 + 1, 1)],
         "time_steps": 36,
         'submodels_to_train': 50,


### PR DESCRIPTION
Adds `target_transform="identity"` to the 6 ShurfModel members and flips `fourtieth_symphony`'s `log_target` to `False` (pulled verbatim from `development`) so they satisfy the stepshifter ReproducibilityGate contract on `main`. Same class of fix as #205 / #207.

🤖 Generated with [Claude Code](https://claude.com/claude-code)