### PR TITLE
fix(partitions): advance calibration/validation windows +12 months

### DIFF
--- a/ensembles/cruel_summer/configs/config_partitions.py
+++ b/ensembles/cruel_summer/configs/config_partitions.py
@@ -30,12 +30,12 @@ def generate(steps: int = 36) -> dict:
 
     return {
         "calibration": {
-            "train": (121, 444),
-            "test": (445, 492),
+            "train": (121, 456),
+            "test": (457, 504),
         },
         "validation": {
-            "train": (121, 492),
-            "test": (493, 540),
+            "train": (121, 504),
+            "test": (505, 552),
         },
         "forecasting": {
             "train": forecasting_train_range(),

--- a/ensembles/first_love/configs/config_partitions.py
+++ b/ensembles/first_love/configs/config_partitions.py
@@ -30,12 +30,12 @@ def generate(steps: int = 36) -> dict:
 
     return {
         "calibration": {
-            "train": (121, 444),
-            "test": (445, 492),
+            "train": (121, 456),
+            "test": (457, 504),
         },
         "validation": {
-            "train": (121, 492),
-            "test": (493, 540),
+            "train": (121, 504),
+            "test": (505, 552),
         },
         "forecasting": {
             "train": forecasting_train_range(),

--- a/ensembles/pink_ponyclub/configs/config_partitions.py
+++ b/ensembles/pink_ponyclub/configs/config_partitions.py
@@ -30,12 +30,12 @@ def generate(steps: int = 36) -> dict:
 
     return {
         "calibration": {
-            "train": (121, 444),
-            "test": (445, 492),
+            "train": (121, 456),
+            "test": (457, 504),
         },
         "validation": {
-            "train": (121, 492),
-            "test": (493, 540),
+            "train": (121, 504),
+            "test": (505, 552),
         },
         "forecasting": {
             "train": forecasting_train_range(),

--- a/ensembles/rude_boy/configs/config_partitions.py
+++ b/ensembles/rude_boy/configs/config_partitions.py
@@ -30,12 +30,12 @@ def generate(steps: int = 36) -> dict:
 
     return {
         "calibration": {
-            "train": (121, 444),
-            "test": (445, 492),
+            "train": (121, 456),
+            "test": (457, 504),
         },
         "validation": {
-            "train": (121, 492),
-            "test": (493, 540),
+            "train": (121, 504),
+            "test": (505, 552),
         },
         "forecasting": {
             "train": forecasting_train_range(),

--- a/ensembles/skinny_love/configs/config_partitions.py
+++ b/ensembles/skinny_love/configs/config_partitions.py
@@ -30,12 +30,12 @@ def generate(steps: int = 36) -> dict:
 
     return {
         "calibration": {
-            "train": (121, 444),
-            "test": (445, 492),
+            "train": (121, 456),
+            "test": (457, 504),
         },
         "validation": {
-            "train": (121, 492),
-            "test": (493, 540),
+            "train": (121, 504),
+            "test": (505, 552),
         },
         "forecasting": {
             "train": forecasting_train_range(),

--- a/ensembles/white_mustang/configs/config_partitions.py
+++ b/ensembles/white_mustang/configs/config_partitions.py
@@ -30,12 +30,12 @@ def generate(steps: int = 36) -> dict:
 
     return {
         "calibration": {
-            "train": (121, 444),
-            "test": (445, 492),
+            "train": (121, 456),
+            "test": (457, 504),
         },
         "validation": {
-            "train": (121, 492),
-            "test": (493, 540),
+            "train": (121, 504),
+            "test": (505, 552),
         },
         "forecasting": {
             "train": forecasting_train_range(),

--- a/extractors/ucdp_extractor/configs/config_partitions.py
+++ b/extractors/ucdp_extractor/configs/config_partitions.py
@@ -31,12 +31,12 @@ def generate(steps: int = 36) -> dict:
 
     return {
         "calibration": {
-            "train": (121, 444),
-            "test": (445, 492),
+            "train": (121, 456),
+            "test": (457, 504),
         },
         "validation": {
-            "train": (121, 492),
-            "test": (493, 540),
+            "train": (121, 504),
+            "test": (505, 552),
         },
         "forecasting": {
             "train": forecasting_train_range(),

--- a/models/adolecent_slob/configs/config_partitions.py
+++ b/models/adolecent_slob/configs/config_partitions.py
@@ -32,12 +32,12 @@ def generate(steps: int = 36) -> dict:
 
     return {
         "calibration": {
-            "train": (121, 444),
-            "test": (445, 492),
+            "train": (121, 456),
+            "test": (457, 504),
         },
         "validation": {
-            "train": (121, 492),
-            "test": (493, 540),
+            "train": (121, 504),
+            "test": (505, 552),
         },
         "forecasting": {
             "train": forecasting_train_range(),

--- a/models/average_cmbaseline/configs/config_partitions.py
+++ b/models/average_cmbaseline/configs/config_partitions.py
@@ -30,12 +30,12 @@ def generate(steps: int = 36) -> dict:
 
     return {
         "calibration": {
-            "train": (121, 444),
-            "test": (445, 492),
+            "train": (121, 456),
+            "test": (457, 504),
         },
         "validation": {
-            "train": (121, 492),
-            "test": (493, 540),
+            "train": (121, 504),
+            "test": (505, 552),
         },
         "forecasting": {
             "train": forecasting_train_range(),

--- a/models/average_pgmbaseline/configs/config_partitions.py
+++ b/models/average_pgmbaseline/configs/config_partitions.py
@@ -29,12 +29,12 @@ def generate(steps: int = 36) -> dict:
 
     return {
         "calibration": {
-            "train": (121, 444),
-            "test": (445, 492),
+            "train": (121, 456),
+            "test": (457, 504),
         },
         "validation": {
-            "train": (121, 492),
-            "test": (493, 540),
+            "train": (121, 504),
+            "test": (505, 552),
         },
         "forecasting": {
             "train": forecasting_train_range(),

--- a/models/bad_blood/configs/config_partitions.py
+++ b/models/bad_blood/configs/config_partitions.py
@@ -30,12 +30,12 @@ def generate(steps: int = 36) -> dict:
 
     return {
         "calibration": {
-            "train": (121, 444),
-            "test": (445, 492),
+            "train": (121, 456),
+            "test": (457, 504),
         },
         "validation": {
-            "train": (121, 492),
-            "test": (493, 540),
+            "train": (121, 504),
+            "test": (505, 552),
         },
         "forecasting": {
             "train": forecasting_train_range(),

--- a/models/bad_romance/configs/config_partitions.py
+++ b/models/bad_romance/configs/config_partitions.py
@@ -30,12 +30,12 @@ def generate(steps: int = 36) -> dict:
 
     return {
         "calibration": {
-            "train": (121, 444),
-            "test": (445, 492),
+            "train": (121, 456),
+            "test": (457, 504),
         },
         "validation": {
-            "train": (121, 492),
-            "test": (493, 540),
+            "train": (121, 504),
+            "test": (505, 552),
         },
         "forecasting": {
             "train": forecasting_train_range(),

--- a/models/bittersweet_symphony/configs/config_partitions.py
+++ b/models/bittersweet_symphony/configs/config_partitions.py
@@ -30,12 +30,12 @@ def generate(steps: int = 36) -> dict:
 
     return {
         "calibration": {
-            "train": (121, 444),
-            "test": (445, 492),
+            "train": (121, 456),
+            "test": (457, 504),
         },
         "validation": {
-            "train": (121, 492),
-            "test": (493, 540),
+            "train": (121, 504),
+            "test": (505, 552),
         },
         "forecasting": {
             "train": forecasting_train_range(),

--- a/models/black_ranger/configs/config_partitions.py
+++ b/models/black_ranger/configs/config_partitions.py
@@ -30,12 +30,12 @@ def generate(steps: int = 36) -> dict:
 
     return {
         "calibration": {
-            "train": (121, 444),
-            "test": (445, 492),
+            "train": (121, 456),
+            "test": (457, 504),
         },
         "validation": {
-            "train": (121, 492),
-            "test": (493, 540),
+            "train": (121, 504),
+            "test": (505, 552),
         },
         "forecasting": {
             "train": forecasting_train_range(),

--- a/models/blank_space/configs/config_partitions.py
+++ b/models/blank_space/configs/config_partitions.py
@@ -30,12 +30,12 @@ def generate(steps: int = 36) -> dict:
 
     return {
         "calibration": {
-            "train": (121, 444),
-            "test": (445, 492),
+            "train": (121, 456),
+            "test": (457, 504),
         },
         "validation": {
-            "train": (121, 492),
-            "test": (493, 540),
+            "train": (121, 504),
+            "test": (505, 552),
         },
         "forecasting": {
             "train": forecasting_train_range(),

--- a/models/blue_ranger/configs/config_partitions.py
+++ b/models/blue_ranger/configs/config_partitions.py
@@ -30,12 +30,12 @@ def generate(steps: int = 36) -> dict:
 
     return {
         "calibration": {
-            "train": (121, 444),
-            "test": (445, 492),
+            "train": (121, 456),
+            "test": (457, 504),
         },
         "validation": {
-            "train": (121, 492),
-            "test": (493, 540),
+            "train": (121, 504),
+            "test": (505, 552),
         },
         "forecasting": {
             "train": forecasting_train_range(),

--- a/models/blue_stranger/configs/config_partitions.py
+++ b/models/blue_stranger/configs/config_partitions.py
@@ -30,12 +30,12 @@ def generate(steps: int = 36) -> dict:
 
     return {
         "calibration": {
-            "train": (121, 444),
-            "test": (445, 492),
+            "train": (121, 456),
+            "test": (457, 504),
         },
         "validation": {
-            "train": (121, 492),
-            "test": (493, 540),
+            "train": (121, 504),
+            "test": (505, 552),
         },
         "forecasting": {
             "train": forecasting_train_range(),

--- a/models/bouncy_organ/configs/config_partitions.py
+++ b/models/bouncy_organ/configs/config_partitions.py
@@ -30,12 +30,12 @@ def generate(steps: int = 36) -> dict:
 
     return {
         "calibration": {
-            "train": (121, 444),
-            "test": (445, 492),
+            "train": (121, 456),
+            "test": (457, 504),
         },
         "validation": {
-            "train": (121, 492),
-            "test": (493, 540),
+            "train": (121, 504),
+            "test": (505, 552),
         },
         "forecasting": {
             "train": forecasting_train_range(),

--- a/models/bright_starship/configs/config_partitions.py
+++ b/models/bright_starship/configs/config_partitions.py
@@ -41,12 +41,12 @@ def generate(steps: int = 36) -> dict:
 
     return {
         "calibration": {
-            "train": (121, 444),
-            "test": (445, 492),
+            "train": (121, 456),
+            "test": (457, 504),
         },
         "validation": {
-            "train": (121, 492),
-            "test": (493, 540),
+            "train": (121, 504),
+            "test": (505, 552),
         },
         "forecasting": {
             "train": forecasting_train_range(),

--- a/models/brown_cheese/configs/config_partitions.py
+++ b/models/brown_cheese/configs/config_partitions.py
@@ -30,12 +30,12 @@ def generate(steps: int = 36) -> dict:
 
     return {
         "calibration": {
-            "train": (121, 444),
-            "test": (445, 492),
+            "train": (121, 456),
+            "test": (457, 504),
         },
         "validation": {
-            "train": (121, 492),
-            "test": (493, 540),
+            "train": (121, 504),
+            "test": (505, 552),
         },
         "forecasting": {
             "train": forecasting_train_range(),

--- a/models/car_radio/configs/config_partitions.py
+++ b/models/car_radio/configs/config_partitions.py
@@ -30,12 +30,12 @@ def generate(steps: int = 36) -> dict:
 
     return {
         "calibration": {
-            "train": (121, 444),
-            "test": (445, 492),
+            "train": (121, 456),
+            "test": (457, 504),
         },
         "validation": {
-            "train": (121, 492),
-            "test": (493, 540),
+            "train": (121, 504),
+            "test": (505, 552),
         },
         "forecasting": {
             "train": forecasting_train_range(),

--- a/models/caring_fish/configs/config_partitions.py
+++ b/models/caring_fish/configs/config_partitions.py
@@ -30,12 +30,12 @@ def generate(steps: int = 36) -> dict:
 
     return {
         "calibration": {
-            "train": (121, 444),
-            "test": (445, 492),
+            "train": (121, 456),
+            "test": (457, 504),
         },
         "validation": {
-            "train": (121, 492),
-            "test": (493, 540),
+            "train": (121, 504),
+            "test": (505, 552),
         },
         "forecasting": {
             "train": forecasting_train_range(),

--- a/models/cheap_thrills/configs/config_partitions.py
+++ b/models/cheap_thrills/configs/config_partitions.py
@@ -30,12 +30,12 @@ def generate(steps: int = 36) -> dict:
 
     return {
         "calibration": {
-            "train": (121, 444),
-            "test": (445, 492),
+            "train": (121, 456),
+            "test": (457, 504),
         },
         "validation": {
-            "train": (121, 492),
-            "test": (493, 540),
+            "train": (121, 504),
+            "test": (505, 552),
         },
         "forecasting": {
             "train": forecasting_train_range(),

--- a/models/chunky_cat/configs/config_partitions.py
+++ b/models/chunky_cat/configs/config_partitions.py
@@ -30,12 +30,12 @@ def generate(steps: int = 36) -> dict:
 
     return {
         "calibration": {
-            "train": (121, 444),
-            "test": (445, 492),
+            "train": (121, 456),
+            "test": (457, 504),
         },
         "validation": {
-            "train": (121, 492),
-            "test": (493, 540),
+            "train": (121, 504),
+            "test": (505, 552),
         },
         "forecasting": {
             "train": forecasting_train_range(),

--- a/models/cold_heart/configs/config_partitions.py
+++ b/models/cold_heart/configs/config_partitions.py
@@ -30,12 +30,12 @@ def generate(steps: int = 36) -> dict:
 
     return {
         "calibration": {
-            "train": (121, 444),
-            "test": (445, 492),
+            "train": (121, 456),
+            "test": (457, 504),
         },
         "validation": {
-            "train": (121, 492),
-            "test": (493, 540),
+            "train": (121, 504),
+            "test": (505, 552),
         },
         "forecasting": {
             "train": forecasting_train_range(),

--- a/models/counting_stars/configs/config_partitions.py
+++ b/models/counting_stars/configs/config_partitions.py
@@ -30,12 +30,12 @@ def generate(steps: int = 36) -> dict:
 
     return {
         "calibration": {
-            "train": (121, 444),
-            "test": (445, 492),
+            "train": (121, 456),
+            "test": (457, 504),
         },
         "validation": {
-            "train": (121, 492),
-            "test": (493, 540),
+            "train": (121, 504),
+            "test": (505, 552),
         },
         "forecasting": {
             "train": forecasting_train_range(),

--- a/models/dancing_queen/configs/config_partitions.py
+++ b/models/dancing_queen/configs/config_partitions.py
@@ -30,12 +30,12 @@ def generate(steps: int = 36) -> dict:
 
     return {
         "calibration": {
-            "train": (121, 444),
-            "test": (445, 492),
+            "train": (121, 456),
+            "test": (457, 504),
         },
         "validation": {
-            "train": (121, 492),
-            "test": (493, 540),
+            "train": (121, 504),
+            "test": (505, 552),
         },
         "forecasting": {
             "train": forecasting_train_range(),

--- a/models/dark_paradise/configs/config_partitions.py
+++ b/models/dark_paradise/configs/config_partitions.py
@@ -30,12 +30,12 @@ def generate(steps: int = 36) -> dict:
 
     return {
         "calibration": {
-            "train": (121, 444),
-            "test": (445, 492),
+            "train": (121, 456),
+            "test": (457, 504),
         },
         "validation": {
-            "train": (121, 492),
-            "test": (493, 540),
+            "train": (121, 504),
+            "test": (505, 552),
         },
         "forecasting": {
             "train": forecasting_train_range(),

--- a/models/demon_days/configs/config_partitions.py
+++ b/models/demon_days/configs/config_partitions.py
@@ -30,12 +30,12 @@ def generate(steps: int = 36) -> dict:
 
     return {
         "calibration": {
-            "train": (121, 444),
-            "test": (445, 492),
+            "train": (121, 456),
+            "test": (457, 504),
         },
         "validation": {
-            "train": (121, 492),
-            "test": (493, 540),
+            "train": (121, 504),
+            "test": (505, 552),
         },
         "forecasting": {
             "train": forecasting_train_range(),

--- a/models/elastic_heart/configs/config_partitions.py
+++ b/models/elastic_heart/configs/config_partitions.py
@@ -30,12 +30,12 @@ def generate(steps: int = 36) -> dict:
 
     return {
         "calibration": {
-            "train": (121, 444),
-            "test": (445, 492),
+            "train": (121, 456),
+            "test": (457, 504),
         },
         "validation": {
-            "train": (121, 492),
-            "test": (493, 540),
+            "train": (121, 504),
+            "test": (505, 552),
         },
         "forecasting": {
             "train": forecasting_train_range(),

--- a/models/electric_relaxation/configs/config_partitions.py
+++ b/models/electric_relaxation/configs/config_partitions.py
@@ -30,12 +30,12 @@ def generate(steps: int = 36) -> dict:
 
     return {
         "calibration": {
-            "train": (121, 444),
-            "test": (445, 492),
+            "train": (121, 456),
+            "test": (457, 504),
         },
         "validation": {
-            "train": (121, 492),
-            "test": (493, 540),
+            "train": (121, 504),
+            "test": (505, 552),
         },
         "forecasting": {
             "train": forecasting_train_range(),

--- a/models/emerging_principles/configs/config_partitions.py
+++ b/models/emerging_principles/configs/config_partitions.py
@@ -30,12 +30,12 @@ def generate(steps: int = 36) -> dict:
 
     return {
         "calibration": {
-            "train": (121, 444),
-            "test": (445, 492),
+            "train": (121, 456),
+            "test": (457, 504),
         },
         "validation": {
-            "train": (121, 492),
-            "test": (493, 540),
+            "train": (121, 504),
+            "test": (505, 552),
         },
         "forecasting": {
             "train": forecasting_train_range(),

--- a/models/fake_model/configs/config_partitions.py
+++ b/models/fake_model/configs/config_partitions.py
@@ -29,12 +29,12 @@ def generate(steps: int = 36) -> dict:
 
     return {
         "calibration": {
-            "train": (121, 444),
-            "test": (445, 492),
+            "train": (121, 456),
+            "test": (457, 504),
         },
         "validation": {
-            "train": (121, 492),
-            "test": (493, 540),
+            "train": (121, 504),
+            "test": (505, 552),
         },
         "forecasting": {
             "train": forecasting_train_range(),

--- a/models/fancy_feline/configs/config_partitions.py
+++ b/models/fancy_feline/configs/config_partitions.py
@@ -30,12 +30,12 @@ def generate(steps: int = 36) -> dict:
 
     return {
         "calibration": {
-            "train": (121, 444),
-            "test": (445, 492),
+            "train": (121, 456),
+            "test": (457, 504),
         },
         "validation": {
-            "train": (121, 492),
-            "test": (493, 540),
+            "train": (121, 504),
+            "test": (505, 552),
         },
         "forecasting": {
             "train": forecasting_train_range(),

--- a/models/fast_car/configs/config_partitions.py
+++ b/models/fast_car/configs/config_partitions.py
@@ -30,12 +30,12 @@ def generate(steps: int = 36) -> dict:
 
     return {
         "calibration": {
-            "train": (121, 444),
-            "test": (445, 492),
+            "train": (121, 456),
+            "test": (457, 504),
         },
         "validation": {
-            "train": (121, 492),
-            "test": (493, 540),
+            "train": (121, 504),
+            "test": (505, 552),
         },
         "forecasting": {
             "train": forecasting_train_range(),

--- a/models/fluorescent_adolescent/configs/config_partitions.py
+++ b/models/fluorescent_adolescent/configs/config_partitions.py
@@ -30,12 +30,12 @@ def generate(steps: int = 36) -> dict:
 
     return {
         "calibration": {
-            "train": (121, 444),
-            "test": (445, 492),
+            "train": (121, 456),
+            "test": (457, 504),
         },
         "validation": {
-            "train": (121, 492),
-            "test": (493, 540),
+            "train": (121, 504),
+            "test": (505, 552),
         },
         "forecasting": {
             "train": forecasting_train_range(),

--- a/models/fourtieth_symphony/configs/config_partitions.py
+++ b/models/fourtieth_symphony/configs/config_partitions.py
@@ -30,12 +30,12 @@ def generate(steps: int = 36) -> dict:
 
     return {
         "calibration": {
-            "train": (121, 444),
-            "test": (445, 492),
+            "train": (121, 456),
+            "test": (457, 504),
         },
         "validation": {
-            "train": (121, 492),
-            "test": (493, 540),
+            "train": (121, 504),
+            "test": (505, 552),
         },
         "forecasting": {
             "train": forecasting_train_range(),

--- a/models/free_fallin/configs/config_partitions.py
+++ b/models/free_fallin/configs/config_partitions.py
@@ -30,12 +30,12 @@ def generate(steps: int = 36) -> dict:
 
     return {
         "calibration": {
-            "train": (121, 444),
-            "test": (445, 492),
+            "train": (121, 456),
+            "test": (457, 504),
         },
         "validation": {
-            "train": (121, 492),
-            "test": (493, 540),
+            "train": (121, 504),
+            "test": (505, 552),
         },
         "forecasting": {
             "train": forecasting_train_range(),

--- a/models/good_life/configs/config_partitions.py
+++ b/models/good_life/configs/config_partitions.py
@@ -30,12 +30,12 @@ def generate(steps: int = 36) -> dict:
 
     return {
         "calibration": {
-            "train": (121, 444),
-            "test": (445, 492),
+            "train": (121, 456),
+            "test": (457, 504),
         },
         "validation": {
-            "train": (121, 492),
-            "test": (493, 540),
+            "train": (121, 504),
+            "test": (505, 552),
         },
         "forecasting": {
             "train": forecasting_train_range(),

--- a/models/good_riddance/configs/config_partitions.py
+++ b/models/good_riddance/configs/config_partitions.py
@@ -30,12 +30,12 @@ def generate(steps: int = 36) -> dict:
 
     return {
         "calibration": {
-            "train": (121, 444),
-            "test": (445, 492),
+            "train": (121, 456),
+            "test": (457, 504),
         },
         "validation": {
-            "train": (121, 492),
-            "test": (493, 540),
+            "train": (121, 504),
+            "test": (505, 552),
         },
         "forecasting": {
             "train": forecasting_train_range(),

--- a/models/green_ranger/configs/config_partitions.py
+++ b/models/green_ranger/configs/config_partitions.py
@@ -30,12 +30,12 @@ def generate(steps: int = 36) -> dict:
 
     return {
         "calibration": {
-            "train": (121, 444),
-            "test": (445, 492),
+            "train": (121, 456),
+            "test": (457, 504),
         },
         "validation": {
-            "train": (121, 492),
-            "test": (493, 540),
+            "train": (121, 504),
+            "test": (505, 552),
         },
         "forecasting": {
             "train": forecasting_train_range(),

--- a/models/green_squirrel/configs/config_partitions.py
+++ b/models/green_squirrel/configs/config_partitions.py
@@ -30,12 +30,12 @@ def generate(steps: int = 36) -> dict:
 
     return {
         "calibration": {
-            "train": (121, 444),
-            "test": (445, 492),
+            "train": (121, 456),
+            "test": (457, 504),
         },
         "validation": {
-            "train": (121, 492),
-            "test": (493, 540),
+            "train": (121, 504),
+            "test": (505, 552),
         },
         "forecasting": {
             "train": forecasting_train_range(),

--- a/models/heat_waves/configs/config_partitions.py
+++ b/models/heat_waves/configs/config_partitions.py
@@ -30,12 +30,12 @@ def generate(steps: int = 36) -> dict:
 
     return {
         "calibration": {
-            "train": (121, 444),
-            "test": (445, 492),
+            "train": (121, 456),
+            "test": (457, 504),
         },
         "validation": {
-            "train": (121, 492),
-            "test": (493, 540),
+            "train": (121, 504),
+            "test": (505, 552),
         },
         "forecasting": {
             "train": forecasting_train_range(),

--- a/models/heavy_freighter/configs/config_partitions.py
+++ b/models/heavy_freighter/configs/config_partitions.py
@@ -41,12 +41,12 @@ def generate(steps: int = 36) -> dict:
 
     return {
         "calibration": {
-            "train": (121, 444),
-            "test": (445, 492),
+            "train": (121, 456),
+            "test": (457, 504),
         },
         "validation": {
-            "train": (121, 492),
-            "test": (493, 540),
+            "train": (121, 504),
+            "test": (505, 552),
         },
         "forecasting": {
             "train": forecasting_train_range(),

--- a/models/heavy_rotation/configs/config_partitions.py
+++ b/models/heavy_rotation/configs/config_partitions.py
@@ -30,12 +30,12 @@ def generate(steps: int = 36) -> dict:
 
     return {
         "calibration": {
-            "train": (121, 444),
-            "test": (445, 492),
+            "train": (121, 456),
+            "test": (457, 504),
         },
         "validation": {
-            "train": (121, 492),
-            "test": (493, 540),
+            "train": (121, 504),
+            "test": (505, 552),
         },
         "forecasting": {
             "train": forecasting_train_range(),

--- a/models/heavy_strider/configs/config_partitions.py
+++ b/models/heavy_strider/configs/config_partitions.py
@@ -41,12 +41,12 @@ def generate(steps: int = 36) -> dict:
 
     return {
         "calibration": {
-            "train": (121, 444),
-            "test": (445, 492),
+            "train": (121, 456),
+            "test": (457, 504),
         },
         "validation": {
-            "train": (121, 492),
-            "test": (493, 540),
+            "train": (121, 504),
+            "test": (505, 552),
         },
         "forecasting": {
             "train": forecasting_train_range(),

--- a/models/high_hopes/configs/config_partitions.py
+++ b/models/high_hopes/configs/config_partitions.py
@@ -30,12 +30,12 @@ def generate(steps: int = 36) -> dict:
 
     return {
         "calibration": {
-            "train": (121, 444),
-            "test": (445, 492),
+            "train": (121, 456),
+            "test": (457, 504),
         },
         "validation": {
-            "train": (121, 492),
-            "test": (493, 540),
+            "train": (121, 504),
+            "test": (505, 552),
         },
         "forecasting": {
             "train": forecasting_train_range(),

--- a/models/hot_stream/configs/config_partitions.py
+++ b/models/hot_stream/configs/config_partitions.py
@@ -30,12 +30,12 @@ def generate(steps: int = 36) -> dict:
 
     return {
         "calibration": {
-            "train": (121, 444),
-            "test": (445, 492),
+            "train": (121, 456),
+            "test": (457, 504),
         },
         "validation": {
-            "train": (121, 492),
-            "test": (493, 540),
+            "train": (121, 504),
+            "test": (505, 552),
         },
         "forecasting": {
             "train": forecasting_train_range(),

--- a/models/invisible_string/configs/config_partitions.py
+++ b/models/invisible_string/configs/config_partitions.py
@@ -30,12 +30,12 @@ def generate(steps: int = 36) -> dict:
 
     return {
         "calibration": {
-            "train": (121, 444),
-            "test": (445, 492),
+            "train": (121, 456),
+            "test": (457, 504),
         },
         "validation": {
-            "train": (121, 492),
-            "test": (493, 540),
+            "train": (121, 504),
+            "test": (505, 552),
         },
         "forecasting": {
             "train": forecasting_train_range(),

--- a/models/lavender_haze/configs/config_partitions.py
+++ b/models/lavender_haze/configs/config_partitions.py
@@ -30,12 +30,12 @@ def generate(steps: int = 36) -> dict:
 
     return {
         "calibration": {
-            "train": (121, 444),
-            "test": (445, 492),
+            "train": (121, 456),
+            "test": (457, 504),
         },
         "validation": {
-            "train": (121, 492),
-            "test": (493, 540),
+            "train": (121, 504),
+            "test": (505, 552),
         },
         "forecasting": {
             "train": forecasting_train_range(),

--- a/models/light_strider/configs/config_partitions.py
+++ b/models/light_strider/configs/config_partitions.py
@@ -41,12 +41,12 @@ def generate(steps: int = 36) -> dict:
 
     return {
         "calibration": {
-            "train": (121, 444),
-            "test": (445, 492),
+            "train": (121, 456),
+            "test": (457, 504),
         },
         "validation": {
-            "train": (121, 492),
-            "test": (493, 540),
+            "train": (121, 504),
+            "test": (505, 552),
         },
         "forecasting": {
             "train": forecasting_train_range(),

--- a/models/little_lies/configs/config_partitions.py
+++ b/models/little_lies/configs/config_partitions.py
@@ -30,12 +30,12 @@ def generate(steps: int = 36) -> dict:
 
     return {
         "calibration": {
-            "train": (121, 444),
-            "test": (445, 492),
+            "train": (121, 456),
+            "test": (457, 504),
         },
         "validation": {
-            "train": (121, 492),
-            "test": (493, 540),
+            "train": (121, 504),
+            "test": (505, 552),
         },
         "forecasting": {
             "train": forecasting_train_range(),

--- a/models/locf_cmbaseline/configs/config_partitions.py
+++ b/models/locf_cmbaseline/configs/config_partitions.py
@@ -30,12 +30,12 @@ def generate(steps: int = 36) -> dict:
 
     return {
         "calibration": {
-            "train": (121, 444),
-            "test": (445, 492),
+            "train": (121, 456),
+            "test": (457, 504),
         },
         "validation": {
-            "train": (121, 492),
-            "test": (493, 540),
+            "train": (121, 504),
+            "test": (505, 552),
         },
         "forecasting": {
             "train": forecasting_train_range(),

--- a/models/locf_pgmbaseline/configs/config_partitions.py
+++ b/models/locf_pgmbaseline/configs/config_partitions.py
@@ -29,12 +29,12 @@ def generate(steps: int = 36) -> dict:
 
     return {
         "calibration": {
-            "train": (121, 444),
-            "test": (445, 492),
+            "train": (121, 456),
+            "test": (457, 504),
         },
         "validation": {
-            "train": (121, 492),
-            "test": (493, 540),
+            "train": (121, 504),
+            "test": (505, 552),
         },
         "forecasting": {
             "train": forecasting_train_range(),

--- a/models/lovely_creature/configs/config_partitions.py
+++ b/models/lovely_creature/configs/config_partitions.py
@@ -30,12 +30,12 @@ def generate(steps: int = 36) -> dict:
 
     return {
         "calibration": {
-            "train": (121, 444),
-            "test": (445, 492),
+            "train": (121, 456),
+            "test": (457, 504),
         },
         "validation": {
-            "train": (121, 492),
-            "test": (493, 540),
+            "train": (121, 504),
+            "test": (505, 552),
         },
         "forecasting": {
             "train": forecasting_train_range(),

--- a/models/midnight_rain/configs/config_partitions.py
+++ b/models/midnight_rain/configs/config_partitions.py
@@ -30,12 +30,12 @@ def generate(steps: int = 36) -> dict:
 
     return {
         "calibration": {
-            "train": (121, 444),
-            "test": (445, 492),
+            "train": (121, 456),
+            "test": (457, 504),
         },
         "validation": {
-            "train": (121, 492),
-            "test": (493, 540),
+            "train": (121, 504),
+            "test": (505, 552),
         },
         "forecasting": {
             "train": forecasting_train_range(),

--- a/models/national_anthem/configs/config_partitions.py
+++ b/models/national_anthem/configs/config_partitions.py
@@ -30,12 +30,12 @@ def generate(steps: int = 36) -> dict:
 
     return {
         "calibration": {
-            "train": (121, 444),
-            "test": (445, 492),
+            "train": (121, 456),
+            "test": (457, 504),
         },
         "validation": {
-            "train": (121, 492),
-            "test": (493, 540),
+            "train": (121, 504),
+            "test": (505, 552),
         },
         "forecasting": {
             "train": forecasting_train_range(),

--- a/models/new_rules/configs/config_partitions.py
+++ b/models/new_rules/configs/config_partitions.py
@@ -30,12 +30,12 @@ def generate(steps: int = 36) -> dict:
 
     return {
         "calibration": {
-            "train": (121, 444),
-            "test": (445, 492),
+            "train": (121, 456),
+            "test": (457, 504),
         },
         "validation": {
-            "train": (121, 492),
-            "test": (493, 540),
+            "train": (121, 504),
+            "test": (505, 552),
         },
         "forecasting": {
             "train": forecasting_train_range(),

--- a/models/novel_heuristics/configs/config_partitions.py
+++ b/models/novel_heuristics/configs/config_partitions.py
@@ -30,12 +30,12 @@ def generate(steps: int = 36) -> dict:
 
     return {
         "calibration": {
-            "train": (121, 444),
-            "test": (445, 492),
+            "train": (121, 456),
+            "test": (457, 504),
         },
         "validation": {
-            "train": (121, 492),
-            "test": (493, 540),
+            "train": (121, 504),
+            "test": (505, 552),
         },
         "forecasting": {
             "train": forecasting_train_range(),

--- a/models/old_money/configs/config_partitions.py
+++ b/models/old_money/configs/config_partitions.py
@@ -30,12 +30,12 @@ def generate(steps: int = 36) -> dict:
 
     return {
         "calibration": {
-            "train": (121, 444),
-            "test": (445, 492),
+            "train": (121, 456),
+            "test": (457, 504),
         },
         "validation": {
-            "train": (121, 492),
-            "test": (493, 540),
+            "train": (121, 504),
+            "test": (505, 552),
         },
         "forecasting": {
             "train": forecasting_train_range(),

--- a/models/ominous_ox/configs/config_partitions.py
+++ b/models/ominous_ox/configs/config_partitions.py
@@ -30,12 +30,12 @@ def generate(steps: int = 36) -> dict:
 
     return {
         "calibration": {
-            "train": (121, 444),
-            "test": (445, 492),
+            "train": (121, 456),
+            "test": (457, 504),
         },
         "validation": {
-            "train": (121, 492),
-            "test": (493, 540),
+            "train": (121, 504),
+            "test": (505, 552),
         },
         "forecasting": {
             "train": forecasting_train_range(),

--- a/models/orange_pasta/configs/config_partitions.py
+++ b/models/orange_pasta/configs/config_partitions.py
@@ -30,12 +30,12 @@ def generate(steps: int = 36) -> dict:
 
     return {
         "calibration": {
-            "train": (121, 444),
-            "test": (445, 492),
+            "train": (121, 456),
+            "test": (457, 504),
         },
         "validation": {
-            "train": (121, 492),
-            "test": (493, 540),
+            "train": (121, 504),
+            "test": (505, 552),
         },
         "forecasting": {
             "train": forecasting_train_range(),

--- a/models/party_princess/configs/config_partitions.py
+++ b/models/party_princess/configs/config_partitions.py
@@ -30,12 +30,12 @@ def generate(steps: int = 36) -> dict:
 
     return {
         "calibration": {
-            "train": (121, 444),
-            "test": (445, 492),
+            "train": (121, 456),
+            "test": (457, 504),
         },
         "validation": {
-            "train": (121, 492),
-            "test": (493, 540),
+            "train": (121, 504),
+            "test": (505, 552),
         },
         "forecasting": {
             "train": forecasting_train_range(),

--- a/models/pink_ranger/configs/config_partitions.py
+++ b/models/pink_ranger/configs/config_partitions.py
@@ -30,12 +30,12 @@ def generate(steps: int = 36) -> dict:
 
     return {
         "calibration": {
-            "train": (121, 444),
-            "test": (445, 492),
+            "train": (121, 456),
+            "test": (457, 504),
         },
         "validation": {
-            "train": (121, 492),
-            "test": (493, 540),
+            "train": (121, 504),
+            "test": (505, 552),
         },
         "forecasting": {
             "train": forecasting_train_range(),

--- a/models/plastic_beach/configs/config_partitions.py
+++ b/models/plastic_beach/configs/config_partitions.py
@@ -30,12 +30,12 @@ def generate(steps: int = 36) -> dict:
 
     return {
         "calibration": {
-            "train": (121, 444),
-            "test": (445, 492),
+            "train": (121, 456),
+            "test": (457, 504),
         },
         "validation": {
-            "train": (121, 492),
-            "test": (493, 540),
+            "train": (121, 504),
+            "test": (505, 552),
         },
         "forecasting": {
             "train": forecasting_train_range(),

--- a/models/popular_monster/configs/config_partitions.py
+++ b/models/popular_monster/configs/config_partitions.py
@@ -30,12 +30,12 @@ def generate(steps: int = 36) -> dict:
 
     return {
         "calibration": {
-            "train": (121, 444),
-            "test": (445, 492),
+            "train": (121, 456),
+            "test": (457, 504),
         },
         "validation": {
-            "train": (121, 492),
-            "test": (493, 540),
+            "train": (121, 504),
+            "test": (505, 552),
         },
         "forecasting": {
             "train": forecasting_train_range(),

--- a/models/preliminary_directives/configs/config_partitions.py
+++ b/models/preliminary_directives/configs/config_partitions.py
@@ -30,12 +30,12 @@ def generate(steps: int = 36) -> dict:
 
     return {
         "calibration": {
-            "train": (121, 444),
-            "test": (445, 492),
+            "train": (121, 456),
+            "test": (457, 504),
         },
         "validation": {
-            "train": (121, 492),
-            "test": (493, 540),
+            "train": (121, 504),
+            "test": (505, 552),
         },
         "forecasting": {
             "train": forecasting_train_range(),

--- a/models/purple_alien/configs/config_partitions.py
+++ b/models/purple_alien/configs/config_partitions.py
@@ -30,12 +30,12 @@ def generate(steps: int = 36) -> dict:
 
     return {
         "calibration": {
-            "train": (121, 444),
-            "test": (445, 492),
+            "train": (121, 456),
+            "test": (457, 504),
         },
         "validation": {
-            "train": (121, 492),
-            "test": (493, 540),
+            "train": (121, 504),
+            "test": (505, 552),
         },
         "forecasting": {
             "train": forecasting_train_range(),

--- a/models/purple_haze/configs/config_partitions.py
+++ b/models/purple_haze/configs/config_partitions.py
@@ -30,12 +30,12 @@ def generate(steps: int = 36) -> dict:
 
     return {
         "calibration": {
-            "train": (121, 444),
-            "test": (445, 492),
+            "train": (121, 456),
+            "test": (457, 504),
         },
         "validation": {
-            "train": (121, 492),
-            "test": (493, 540),
+            "train": (121, 504),
+            "test": (505, 552),
         },
         "forecasting": {
             "train": forecasting_train_range(),

--- a/models/red_ranger/configs/config_partitions.py
+++ b/models/red_ranger/configs/config_partitions.py
@@ -30,12 +30,12 @@ def generate(steps: int = 36) -> dict:
 
     return {
         "calibration": {
-            "train": (121, 444),
-            "test": (445, 492),
+            "train": (121, 456),
+            "test": (457, 504),
         },
         "validation": {
-            "train": (121, 492),
-            "test": (493, 540),
+            "train": (121, 504),
+            "test": (505, 552),
         },
         "forecasting": {
             "train": forecasting_train_range(),

--- a/models/revolving_door/configs/config_partitions.py
+++ b/models/revolving_door/configs/config_partitions.py
@@ -30,12 +30,12 @@ def generate(steps: int = 36) -> dict:
 
     return {
         "calibration": {
-            "train": (121, 444),
-            "test": (445, 492),
+            "train": (121, 456),
+            "test": (457, 504),
         },
         "validation": {
-            "train": (121, 492),
-            "test": (493, 540),
+            "train": (121, 504),
+            "test": (505, 552),
         },
         "forecasting": {
             "train": forecasting_train_range(),

--- a/models/shining_codex/configs/config_partitions.py
+++ b/models/shining_codex/configs/config_partitions.py
@@ -41,12 +41,12 @@ def generate(steps: int = 36) -> dict:
 
     return {
         "calibration": {
-            "train": (121, 444),
-            "test": (445, 492),
+            "train": (121, 456),
+            "test": (457, 504),
         },
         "validation": {
-            "train": (121, 492),
-            "test": (493, 540),
+            "train": (121, 504),
+            "test": (505, 552),
         },
         "forecasting": {
             "train": forecasting_train_range(),

--- a/models/smol_cat/configs/config_partitions.py
+++ b/models/smol_cat/configs/config_partitions.py
@@ -30,12 +30,12 @@ def generate(steps: int = 36) -> dict:
 
     return {
         "calibration": {
-            "train": (121, 444),
-            "test": (445, 492),
+            "train": (121, 456),
+            "test": (457, 504),
         },
         "validation": {
-            "train": (121, 492),
-            "test": (493, 540),
+            "train": (121, 504),
+            "test": (505, 552),
         },
         "forecasting": {
             "train": forecasting_train_range(),

--- a/models/teen_spirit/configs/config_partitions.py
+++ b/models/teen_spirit/configs/config_partitions.py
@@ -30,12 +30,12 @@ def generate(steps: int = 36) -> dict:
 
     return {
         "calibration": {
-            "train": (121, 444),
-            "test": (445, 492),
+            "train": (121, 456),
+            "test": (457, 504),
         },
         "validation": {
-            "train": (121, 492),
-            "test": (493, 540),
+            "train": (121, 504),
+            "test": (505, 552),
         },
         "forecasting": {
             "train": forecasting_train_range(),

--- a/models/twin_flame/configs/config_partitions.py
+++ b/models/twin_flame/configs/config_partitions.py
@@ -30,12 +30,12 @@ def generate(steps: int = 36) -> dict:
 
     return {
         "calibration": {
-            "train": (121, 444),
-            "test": (445, 492),
+            "train": (121, 456),
+            "test": (457, 504),
         },
         "validation": {
-            "train": (121, 492),
-            "test": (493, 540),
+            "train": (121, 504),
+            "test": (505, 552),
         },
         "forecasting": {
             "train": forecasting_train_range(),

--- a/models/violet_visitor/configs/config_partitions.py
+++ b/models/violet_visitor/configs/config_partitions.py
@@ -30,12 +30,12 @@ def generate(steps: int = 36) -> dict:
 
     return {
         "calibration": {
-            "train": (121, 444),
-            "test": (445, 492),
+            "train": (121, 456),
+            "test": (457, 504),
         },
         "validation": {
-            "train": (121, 492),
-            "test": (493, 540),
+            "train": (121, 504),
+            "test": (505, 552),
         },
         "forecasting": {
             "train": forecasting_train_range(),

--- a/models/white_ranger/configs/config_partitions.py
+++ b/models/white_ranger/configs/config_partitions.py
@@ -30,12 +30,12 @@ def generate(steps: int = 36) -> dict:
 
     return {
         "calibration": {
-            "train": (121, 444),
-            "test": (445, 492),
+            "train": (121, 456),
+            "test": (457, 504),
         },
         "validation": {
-            "train": (121, 492),
-            "test": (493, 540),
+            "train": (121, 504),
+            "test": (505, 552),
         },
         "forecasting": {
             "train": forecasting_train_range(),

--- a/models/wild_rose/configs/config_partitions.py
+++ b/models/wild_rose/configs/config_partitions.py
@@ -30,12 +30,12 @@ def generate(steps: int = 36) -> dict:
 
     return {
         "calibration": {
-            "train": (121, 444),
-            "test": (445, 492),
+            "train": (121, 456),
+            "test": (457, 504),
         },
         "validation": {
-            "train": (121, 492),
-            "test": (493, 540),
+            "train": (121, 504),
+            "test": (505, 552),
         },
         "forecasting": {
             "train": forecasting_train_range(),

--- a/models/wildest_dream/configs/config_partitions.py
+++ b/models/wildest_dream/configs/config_partitions.py
@@ -30,12 +30,12 @@ def generate(steps: int = 36) -> dict:
 
     return {
         "calibration": {
-            "train": (121, 444),
-            "test": (445, 492),
+            "train": (121, 456),
+            "test": (457, 504),
         },
         "validation": {
-            "train": (121, 492),
-            "test": (493, 540),
+            "train": (121, 504),
+            "test": (505, 552),
         },
         "forecasting": {
             "train": forecasting_train_range(),

--- a/models/wuthering_heights/configs/config_partitions.py
+++ b/models/wuthering_heights/configs/config_partitions.py
@@ -30,12 +30,12 @@ def generate(steps: int = 36) -> dict:
 
     return {
         "calibration": {
-            "train": (121, 444),
-            "test": (445, 492),
+            "train": (121, 456),
+            "test": (457, 504),
         },
         "validation": {
-            "train": (121, 492),
-            "test": (493, 540),
+            "train": (121, 504),
+            "test": (505, 552),
         },
         "forecasting": {
             "train": forecasting_train_range(),

--- a/models/yellow_pikachu/configs/config_partitions.py
+++ b/models/yellow_pikachu/configs/config_partitions.py
@@ -30,12 +30,12 @@ def generate(steps: int = 36) -> dict:
 
     return {
         "calibration": {
-            "train": (121, 444),
-            "test": (445, 492),
+            "train": (121, 456),
+            "test": (457, 504),
         },
         "validation": {
-            "train": (121, 492),
-            "test": (493, 540),
+            "train": (121, 504),
+            "test": (505, 552),
         },
         "forecasting": {
             "train": forecasting_train_range(),

--- a/models/yellow_ranger/configs/config_partitions.py
+++ b/models/yellow_ranger/configs/config_partitions.py
@@ -30,12 +30,12 @@ def generate(steps: int = 36) -> dict:
 
     return {
         "calibration": {
-            "train": (121, 444),
-            "test": (445, 492),
+            "train": (121, 456),
+            "test": (457, 504),
         },
         "validation": {
-            "train": (121, 492),
-            "test": (493, 540),
+            "train": (121, 504),
+            "test": (505, 552),
         },
         "forecasting": {
             "train": forecasting_train_range(),

--- a/models/yellow_submarine/configs/config_partitions.py
+++ b/models/yellow_submarine/configs/config_partitions.py
@@ -30,12 +30,12 @@ def generate(steps: int = 36) -> dict:
 
     return {
         "calibration": {
-            "train": (121, 444),
-            "test": (445, 492),
+            "train": (121, 456),
+            "test": (457, 504),
         },
         "validation": {
-            "train": (121, 492),
-            "test": (493, 540),
+            "train": (121, 504),
+            "test": (505, 552),
         },
         "forecasting": {
             "train": forecasting_train_range(),

--- a/models/zero_cmbaseline/configs/config_partitions.py
+++ b/models/zero_cmbaseline/configs/config_partitions.py
@@ -30,12 +30,12 @@ def generate(steps: int = 36) -> dict:
 
     return {
         "calibration": {
-            "train": (121, 444),
-            "test": (445, 492),
+            "train": (121, 456),
+            "test": (457, 504),
         },
         "validation": {
-            "train": (121, 492),
-            "test": (493, 540),
+            "train": (121, 504),
+            "test": (505, 552),
         },
         "forecasting": {
             "train": forecasting_train_range(),

--- a/models/zero_pgmbaseline/configs/config_partitions.py
+++ b/models/zero_pgmbaseline/configs/config_partitions.py
@@ -29,12 +29,12 @@ def generate(steps: int = 36) -> dict:
 
     return {
         "calibration": {
-            "train": (121, 444),
-            "test": (445, 492),
+            "train": (121, 456),
+            "test": (457, 504),
         },
         "validation": {
-            "train": (121, 492),
-            "test": (493, 540),
+            "train": (121, 504),
+            "test": (505, 552),
         },
         "forecasting": {
             "train": forecasting_train_range(),

--- a/postprocessors/un_fao/configs/config_partitions.py
+++ b/postprocessors/un_fao/configs/config_partitions.py
@@ -30,12 +30,12 @@ def generate(steps: int = 36) -> dict:
 
     return {
         "calibration": {
-            "train": (121, 444),
-            "test": (445, 492),
+            "train": (121, 456),
+            "test": (457, 504),
         },
         "validation": {
-            "train": (121, 492),
-            "test": (493, 540),
+            "train": (121, 504),
+            "test": (505, 552),
         },
         "forecasting": {
             "train": forecasting_train_range(),


### PR DESCRIPTION
New data published. Bumps the hardcoded calibration/validation train/test windows on all 86 partition configs by 12 months to match `development` (calibration `457/504`, validation `505/552`). Forecasting ranges are computed dynamically and are unaffected; the ingester3 import on `main` is left untouched to keep this a pure window change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)