### PR TITLE
docs(api): apis/ README + un_fao postprocessor README upgrade

### DIFF
--- a/apis/README.md
+++ b/apis/README.md
@@ -1,0 +1,49 @@
+# `apis/` — deployment launchers for VIEWS serving APIs
+
+This directory holds **API deployment launchers**, a run-bearing category distinct
+from `models/` and `postprocessors/`. Each `apis/<name>/` is a **thin launcher**:
+it creates a conda env, `pip install`s an external `views-*` API package from
+GitHub, and runs it via `run.sh` → `main.py`. **The real service code lives in the
+external package, not here.** A launcher follows the same config convention as a
+model (`configs/config_meta.py`, `configs/config_deployment.py`, `main.py`,
+`run.sh`, `requirements.txt`), with `config_meta.algorithm = "API"`.
+
+## What's here
+
+| Launcher | Installs + runs | What that package is |
+|---|---|---|
+| `apis/un_fao/` | `views-faoapi` (`run.sh` → `pip install git+…/views-faoapi.git`) | FastAPI REST service that serves VIEWS conflict predictions to the UN FAO (historical + probabilistic forecasts at PGM / country / GAUL levels; reads from Appwrite) |
+| `apis/seldon_api/` | `views-seldon` (`run.sh` → `pip install git+…/views-seldon.git`) | A Seldon-style serving API (wraps `seldonapi_postprocessor`) |
+
+## The distinction that matters (so you don't get lost)
+
+For `un_fao` specifically there are **three** different `un_fao`-named things across
+the platform — they are *not* duplicates, they are different roles:
+
+- **`apis/un_fao/`** (here) — the **launcher** for the FAO serving API.
+- **`postprocessors/un_fao/`** (this repo) — the **producer**: builds + uploads the
+  FAO delivery (historical actuals + forecast) to Appwrite. See its README.
+- **`views-faoapi`** (separate repo) — the **package**: the actual FastAPI service the
+  launcher installs, and the holder of the Appwrite **secrets** (`views-faoapi/.env`).
+
+## Credentials
+
+A launcher does **not** store secrets. The launched API reads its credentials from
+the external package's own `.env` (e.g. `views-faoapi/.env`). views-models stays
+secret-free. (See `postprocessors/un_fao/README.md` → "Credential topology" and
+`reports/un_fao_delivery_{prerun,postrun}_postmortem.md` for the full Appwrite map.)
+
+## Status
+
+These launchers are early. `apis/un_fao/` on `development` is a minimal stub; a
+fuller build-out (multi-worker uvicorn, endpoint docs) exists on an unmerged
+feature branch (`sweep_week_dylan`) — revive-vs-defer is a maintainer decision, but
+**do not delete** the stub (it's the intended FAO-serving entrypoint, not dead code).
+
+## Running
+
+```
+./run.sh -r <run_type>        # bootstraps envs/<pkg>, installs the package, runs main.py
+# or, if the env exists:
+python main.py <args>
+```

--- a/postprocessors/un_fao/README.md
+++ b/postprocessors/un_fao/README.md
@@ -1,15 +1,32 @@
 # un_fao postprocessor
 
-Delivers VIEWS data to the **UN FAO**. It fetches historical UCDP fatality
-**actuals** from the VIEWS **data factory** (Zarr store), enriches them with
-country/admin attribution, and uploads the result to the FAO Appwrite bucket
-(served downstream by `views-faoapi`).
+Delivers VIEWS data to the **UN FAO** (served downstream by `views-faoapi`). One
+run delivers **two things**, not one:
+
+1. **Historical actuals** — fetched from the VIEWS **data factory** (Zarr store).
+2. **The latest forecast** — downloaded from the Appwrite `production_forecasts` bucket.
+
+Both are enriched with country/admin (GAUL) attribution and **uploaded to the FAO
+Appwrite bucket**. (Earlier docs framed this as historical-only — it is not.)
 
 Created: 2025-10-17.
 
+## Where the pieces live (read this first — it is non-obvious)
+
+`un_fao` spans **four repos in three roles** plus a shared substrate. Confusing
+them is the #1 way to get lost here:
+
+| Role | Lives in | What it is |
+|---|---|---|
+| **Producer** (config + entrypoint) | `postprocessors/un_fao/` (here) | configs + a thin `main.py` that calls the vpp manager. **Zero secret code.** |
+| **Manager** (the logic) | `views-postprocessing/.../unfao/managers/unfao.py` | reads the Appwrite env vars, downloads the forecast, reads the datafactory actuals, enriches both (`GaulLookupEnricher`), uploads both |
+| **Package** (the API) | `views-faoapi` (repo) | the FastAPI service that *serves* the delivered data; holds the Appwrite **secrets** (`.env`) |
+| **Launcher** (deploy) | `apis/un_fao/` (this repo) | installs + runs `views-faoapi` (see `apis/README.md`) |
+| **Substrate** | `views-pipeline-core` | the shared Appwrite/datastore client (`modules/datastore`, `configs/prediction_store.py`) |
+
 ## What it produces
 
-Historical actuals for three UCDP fatality targets at PRIO-GRID month level:
+Three UCDP fatality targets at PRIO-GRID month level:
 
 | descriptor feature | renamed to | UCDP source |
 |---|---|---|
@@ -19,33 +36,56 @@ Historical actuals for three UCDP fatality targets at PRIO-GRID month level:
 
 Data source is the **data factory** (not viewser) — see `configs/config_queryset.py`.
 Current coverage region: **`africa_me_legacy`** (~13,110 cells). Going global to
-`land_gaul` (64,736 cells) is tracked in issue #127.
+`land_gaul` (64,736 cells) is tracked in #127 — and it also clears the handful of
+GAUL-uncovered cells (remote islands) that fail completeness validation under
+`africa_me_legacy` (see the postmortems).
 
-## Prerequisites (datafactory)
+## Credential topology
 
-The postprocessor reads the data factory's remote Zarr store, so the runtime
-environment **must** have:
+The run needs **13 `APPWRITE_*` env vars**, of which only **3 are real secrets**:
 
-1. **`views-datafactory` installed** (provides the `datafactory_query` module):
+- **Secrets (3):** `APPWRITE_ENDPOINT`, `APPWRITE_DATASTORE_PROJECT_ID`,
+  `APPWRITE_DATASTORE_API_KEY` — they live in **`views-faoapi/.env`** (the serving
+  repo). views-models stores **no secrets**.
+- **Identifiers (10):** `APPWRITE_PROD_FORECASTS_*` (the forecast-download bucket),
+  `APPWRITE_UNFAO_*` (the upload target), `APPWRITE_METADATA_DATABASE_*` — bucket/
+  collection names, not secrets.
+
+The manager reads them via ambient `os.getenv` (plus an optional
+`load_dotenv(<ensemble>/.env)` overlay — which finds nothing today, so the
+`ensemble` ref does **not** supply credentials; a known red herring). To run it,
+provide all 13 in the process env (e.g. load `views-faoapi/.env` + set the 4
+`PROD_FORECASTS_*`). The cleanest long-term home is one canonical source referenced
+by all consumers, not copied — see the postmortems.
+
+## Prerequisites
+
+**Directory structure.** The postprocessor is run through `PostprocessorPathManager`,
+which validates the full scaffold (`artifacts/`, `notebooks/`, `reports/`,
+`data/{generated,processed,raw}/`, `logs/`, `configs/`) — a missing dir crashes
+before any work. These are guarded by
+`tests/test_model_structure.py::TestPostprocessorDirectoryStructure`.
+
+**Data factory.** The runtime env **must** have:
+
+1. **`views-datafactory` installed** (the `datafactory_query` module):
    ```
    pip install 'views-datafactory @ git+https://github.com/views-platform/views-datafactory.git@development'
    ```
-   If it is missing, `configs/config_queryset.py` fails loud at config load with
-   these install instructions (it does not fall through to an opaque
+   If missing, `configs/config_queryset.py` fails loud at config load (not an opaque
    `ModuleNotFoundError`).
-2. **`~/.netrc` credentials for the Zarr host `204.168.219.108`** on the machine
-   that runs the postprocessor (see the `bright_starship` model README for the
-   `.netrc` format). Without it, the Zarr fetch fails at runtime.
+2. **`~/.netrc` for the Zarr host `204.168.219.108`** (see the `bright_starship`
+   model README for the format). Without it the Zarr fetch fails at runtime.
 
-These are the same prerequisites the datafactory models (bright_starship,
-shining_codex) need, but the postprocessor runs in its own context — verify them
-in **its** runtime, not only a model env (issue #95).
+Verify these in the postprocessor's **own** runtime, not only a model env (#95).
 
 ## The ensemble reference
 
 `configs/config_meta.py` carries an `ensemble` field. It does **not** select an
-aggregation; it locates the `.env` credentials and tags uploaded files for the
-**forecast** delivery path. It must reference a real ensemble (issue #77).
+aggregation. The manager's forecast download is **filtered by this ensemble name**
+(`{category: forecast, name: <ensemble>}`), so it must reference an ensemble that
+**has** a forecast in the `production_forecasts` bucket. It also (optionally) locates
+`.env` credentials and tags uploads. Must be a real ensemble (#77).
 
 ## Running
 
@@ -53,7 +93,16 @@ aggregation; it locates the `.env` credentials and tags uploaded files for the
 conda run -n views_pipeline python -m postprocessors.un_fao.main
 ```
 
-This runs the full pipeline including the **Appwrite upload** to the production
-forecasts bucket — do not run it casually. For a local, no-upload data check,
-exercise `configs/config_queryset.py::generate()` + the data-factory fetch
-directly (see `tests/test_un_fao_datafactory_equivalence.py`).
+This runs the full pipeline including the **Appwrite upload** to the FAO bucket —
+there is **no dry-run / skip-upload flag**, so do not run it casually. For a local,
+no-upload check of just the **enrichment** (no forecast, no Appwrite), call the
+manager's `_read_historical_data()` + `_append_metadata()` directly (the pattern used
+to verify vpp#24 — see `reports/un_fao_delivery_postrun_postmortem.md`). For a
+data-equivalence check, exercise `configs/config_queryset.py::generate()` + the
+datafactory fetch (see `tests/test_un_fao_datafactory_equivalence.py`).
+
+## Further reading
+
+- `reports/un_fao_delivery_prerun_postmortem.md` — the machinery map + credential topology.
+- `reports/un_fao_delivery_postrun_postmortem.md` — the verified-with-caveat #24 result + the forecast-path gaps.
+- `apis/README.md` — the launcher/package distinction.


### PR DESCRIPTION
Documents the inherited API surface that made the FAO-delivery work slow to navigate. **`apis/README.md`** (new): the launcher category + the launcher/producer/package three-role distinction for un_fao. **`postprocessors/un_fao/README.md`** (upgraded): the four-repo machinery map, credential topology (13 vars / 3 secrets / faoapi/.env), the combined historical+forecast delivery, the ensemble-name forecast filter, no-dry-run, and the required scaffold dirs. Docs only; sourced from the two delivery postmortems.