### PR TITLE
config(baselines): declare evaluation_mode=point, drop fake n_posterior_samples (#220, epic #216)

### DIFF
--- a/models/average_cmbaseline/configs/config_hyperparameters.py
+++ b/models/average_cmbaseline/configs/config_hyperparameters.py
@@ -12,7 +12,6 @@ def get_hp_config():
         'steps': [*range(1, 36 + 1, 1)],
         'time_steps': 36,
         'skip_predictions_delivery': True,
-        'n_posterior_samples': 1,
         'regression_targets': ['lr_ged_sb'],
         'window_months': 60,
     }

--- a/models/average_cmbaseline/configs/config_meta.py
+++ b/models/average_cmbaseline/configs/config_meta.py
@@ -14,6 +14,7 @@ def get_meta_config():
         "level": "cm",
         "creator": "Sonja",
         "prediction_format": "prediction_frame",
+        "evaluation_mode": "point",
         "rolling_origin_stride": 1,
         "regression_point_baselines": ["average_cmbaseline", "zero_cmbaseline", "locf_cmbaseline"],
         "regression_point_metrics": ["RMSLE", "MSE", "MSLE", "y_hat_bar", "MCR_point"],

--- a/models/average_pgmbaseline/configs/config_hyperparameters.py
+++ b/models/average_pgmbaseline/configs/config_hyperparameters.py
@@ -12,7 +12,6 @@ def get_hp_config():
         'steps': [*range(1, 36 + 1, 1)],
         'time_steps': 36,
         'skip_predictions_delivery': True,
-        'n_posterior_samples': 1,
         'regression_targets': ['lr_ged_sb'],
         'window_months': 18,
     }

--- a/models/average_pgmbaseline/configs/config_meta.py
+++ b/models/average_pgmbaseline/configs/config_meta.py
@@ -14,6 +14,7 @@ def get_meta_config():
         "level": "pgm",
         "creator": "Sonja",
         "prediction_format": "prediction_frame",
+        "evaluation_mode": "point",
         "rolling_origin_stride": 1,
         "regression_point_baselines": ["average_cmbaseline", "zero_cmbaseline", "locf_cmbaseline"],
         "regression_point_metrics": ["RMSLE", "MSE", "MSLE", "y_hat_bar"],

--- a/models/diagonal_dream/configs/config_hyperparameters.py
+++ b/models/diagonal_dream/configs/config_hyperparameters.py
@@ -3,7 +3,6 @@ def get_hp_config():
         "steps": [*range(1, 36 + 1, 1)],
         "time_steps": 36,
         "skip_predictions_delivery": True,
-        "n_posterior_samples": 1,
         "regression_targets": ["synth_target"],
     }
     return hyperparameters

--- a/models/diagonal_dream/configs/config_meta.py
+++ b/models/diagonal_dream/configs/config_meta.py
@@ -6,6 +6,7 @@ def get_meta_config():
         "level": "pgm",
         "creator": "synthetic_test",
         "prediction_format": "prediction_frame",
+        "evaluation_mode": "point",
         "rolling_origin_stride": 1,
         "regression_point_metrics": ["MSE"],
     }

--- a/models/horizontal_dream/configs/config_hyperparameters.py
+++ b/models/horizontal_dream/configs/config_hyperparameters.py
@@ -3,7 +3,6 @@ def get_hp_config():
         "steps": [*range(1, 36 + 1, 1)],
         "time_steps": 36,
         "skip_predictions_delivery": True,
-        "n_posterior_samples": 1,
         "regression_targets": ["synth_target"],
     }
     return hyperparameters

--- a/models/horizontal_dream/configs/config_meta.py
+++ b/models/horizontal_dream/configs/config_meta.py
@@ -6,6 +6,7 @@ def get_meta_config():
         "level": "pgm",
         "creator": "synthetic_test",
         "prediction_format": "prediction_frame",
+        "evaluation_mode": "point",
         "rolling_origin_stride": 1,
         "regression_point_metrics": ["MSE"],
     }

--- a/models/locf_cmbaseline/configs/config_hyperparameters.py
+++ b/models/locf_cmbaseline/configs/config_hyperparameters.py
@@ -12,7 +12,6 @@ def get_hp_config():
         'steps': [*range(1, 36 + 1, 1)],
         'time_steps': 36,
         'skip_predictions_delivery': True,
-        'n_posterior_samples': 1,
         'regression_targets': ['lr_ged_sb'],
     }
     return hyperparameters

--- a/models/locf_cmbaseline/configs/config_meta.py
+++ b/models/locf_cmbaseline/configs/config_meta.py
@@ -14,6 +14,7 @@ def get_meta_config():
         "level": "cm",
         "creator": "Sonja",
         "prediction_format": "prediction_frame",
+        "evaluation_mode": "point",
         "rolling_origin_stride": 1,
         "regression_point_baselines": ["average_cmbaseline", "zero_cmbaseline", "locf_cmbaseline"],
         "regression_point_metrics": ["RMSLE", "MSE", "MSLE", "y_hat_bar", "MCR_point"],

--- a/models/locf_pgmbaseline/configs/config_hyperparameters.py
+++ b/models/locf_pgmbaseline/configs/config_hyperparameters.py
@@ -12,7 +12,6 @@ def get_hp_config():
         'steps': [*range(1, 36 + 1, 1)],
         'time_steps': 36,
         'skip_predictions_delivery': True,
-        'n_posterior_samples': 1,
         'regression_targets': ['lr_ged_sb'],
     }
     return hyperparameters

--- a/models/locf_pgmbaseline/configs/config_meta.py
+++ b/models/locf_pgmbaseline/configs/config_meta.py
@@ -14,6 +14,7 @@ def get_meta_config():
         "level": "pgm",
         "creator": "Sonja",
         "prediction_format": "prediction_frame",
+        "evaluation_mode": "point",
         "rolling_origin_stride": 1,
         "regression_point_baselines": ["average_cmbaseline", "zero_cmbaseline", "locf_cmbaseline"],
         "regression_point_metrics": ["RMSLE", "MSE", "MSLE", "y_hat_bar"],

--- a/models/vertical_dream/configs/config_hyperparameters.py
+++ b/models/vertical_dream/configs/config_hyperparameters.py
@@ -3,7 +3,6 @@ def get_hp_config():
         "steps": [*range(1, 36 + 1, 1)],
         "time_steps": 36,
         "skip_predictions_delivery": True,
-        "n_posterior_samples": 1,
         "regression_targets": ["synth_target"],
     }
     return hyperparameters

--- a/models/vertical_dream/configs/config_meta.py
+++ b/models/vertical_dream/configs/config_meta.py
@@ -6,6 +6,7 @@ def get_meta_config():
         "level": "pgm",
         "creator": "synthetic_test",
         "prediction_format": "prediction_frame",
+        "evaluation_mode": "point",
         "rolling_origin_stride": 1,
         "regression_point_metrics": ["MSE"],
     }

--- a/models/zero_cmbaseline/configs/config_hyperparameters.py
+++ b/models/zero_cmbaseline/configs/config_hyperparameters.py
@@ -12,7 +12,6 @@ def get_hp_config():
         'steps': [*range(1, 36 + 1, 1)],
         'time_steps': 36,
         'skip_predictions_delivery': True,
-        'n_posterior_samples': 1,
         'regression_targets': ['lr_ged_sb'],
     }
     return hyperparameters

--- a/models/zero_cmbaseline/configs/config_meta.py
+++ b/models/zero_cmbaseline/configs/config_meta.py
@@ -14,6 +14,7 @@ def get_meta_config():
         "level": "cm",
         "creator": "Sonja",
         "prediction_format": "prediction_frame",
+        "evaluation_mode": "point",
         "rolling_origin_stride": 1,
         "regression_point_baselines": ["average_cmbaseline", "zero_cmbaseline", "locf_cmbaseline"],
         "regression_point_metrics": ["RMSLE", "MSE", "MSLE", "y_hat_bar", "MCR_point"],

--- a/models/zero_pgmbaseline/configs/config_hyperparameters.py
+++ b/models/zero_pgmbaseline/configs/config_hyperparameters.py
@@ -12,7 +12,6 @@ def get_hp_config():
         'steps': [*range(1, 36 + 1, 1)],
         'time_steps': 36,
         'skip_predictions_delivery': True,
-        'n_posterior_samples': 1,
         'regression_targets': ['lr_ged_sb'],
     }
     return hyperparameters

--- a/models/zero_pgmbaseline/configs/config_meta.py
+++ b/models/zero_pgmbaseline/configs/config_meta.py
@@ -14,6 +14,7 @@ def get_meta_config():
         "level": "pgm",
         "creator": "Sonja",
         "prediction_format": "prediction_frame",
+        "evaluation_mode": "point",
         "rolling_origin_stride": 1,
         "regression_point_baselines": ["average_cmbaseline", "zero_cmbaseline", "locf_cmbaseline"],
         "regression_point_metrics": ["RMSLE", "MSE", "MSLE", "y_hat_bar"],


### PR DESCRIPTION
Story **#220** of epic **#216** — the honesty payoff. Adds `"evaluation_mode": "point"` to the 9 point models' `config_meta` and removes the dishonest `n_posterior_samples: 1` from their `config_hyperparameters`. Now legal because the readiness contract is point-aware (#218 config-level, #219 output/aggregation). Suites green (3438 passed) except the pre-existing golden_hour #131/C-74 anomaly. Closes #220.

Models: zero/locf/average_{cm,pgm}baseline, {diagonal,horizontal,vertical}_dream.