### PR TITLE
docs(partitions): de-stale config_partitions docstrings -> point to meta/partitions.json (C-57)

### DIFF
--- a/models/blazing_meteor/configs/config_partitions.py
+++ b/models/blazing_meteor/configs/config_partitions.py
@@ -4,9 +4,9 @@ Defines temporal boundaries for each run type. These are identical
 to all other VIEWS pgm models — the partitions are a platform
 convention, not model-specific.
 
-    calibration:  train 121-444, test 445-492  (Jan 1990 – Dec 2020)
-    validation:   train 121-492, test 493-540  (Jan 1990 – Dec 2024)
-    forecasting:  train 121-now,  test now+1 to now+steps  (dynamic)
+    See ``meta/partitions.json`` for the canonical calibration/validation
+    train/test ranges (rewritten across all models by the partition bump
+    tool); forecasting is dynamic from the current month.
 
 Month IDs use VIEWS encoding: month_id = (year - 1980) * 12 + month.
 """

--- a/models/bold_comet/configs/config_partitions.py
+++ b/models/bold_comet/configs/config_partitions.py
@@ -4,9 +4,9 @@ Defines temporal boundaries for each run type. These are identical
 to all other VIEWS pgm models — the partitions are a platform
 convention, not model-specific.
 
-    calibration:  train 121-444, test 445-492  (Jan 1990 – Dec 2020)
-    validation:   train 121-492, test 493-540  (Jan 1990 – Dec 2024)
-    forecasting:  train 121-now,  test now+1 to now+steps  (dynamic)
+    See ``meta/partitions.json`` for the canonical calibration/validation
+    train/test ranges (rewritten across all models by the partition bump
+    tool); forecasting is dynamic from the current month.
 
 Month IDs use VIEWS encoding: month_id = (year - 1980) * 12 + month.
 """

--- a/models/bright_starship/configs/config_partitions.py
+++ b/models/bright_starship/configs/config_partitions.py
@@ -4,9 +4,9 @@ Defines temporal boundaries for each run type. These are identical
 to all other VIEWS pgm models — the partitions are a platform
 convention, not model-specific.
 
-    calibration:  train 121-444, test 445-492  (Jan 1990 – Dec 2020)
-    validation:   train 121-492, test 493-540  (Jan 1990 – Dec 2024)
-    forecasting:  train 121-now,  test now+1 to now+steps  (dynamic)
+    See ``meta/partitions.json`` for the canonical calibration/validation
+    train/test ranges (rewritten across all models by the partition bump
+    tool); forecasting is dynamic from the current month.
 
 Month IDs use VIEWS encoding: month_id = (year - 1980) * 12 + month.
 """

--- a/models/heavy_freighter/configs/config_partitions.py
+++ b/models/heavy_freighter/configs/config_partitions.py
@@ -4,9 +4,9 @@ Defines temporal boundaries for each run type. These are identical
 to all other VIEWS pgm models — the partitions are a platform
 convention, not model-specific.
 
-    calibration:  train 121-444, test 445-492  (Jan 1990 – Dec 2020)
-    validation:   train 121-492, test 493-540  (Jan 1990 – Dec 2024)
-    forecasting:  train 121-now,  test now+1 to now+steps  (dynamic)
+    See ``meta/partitions.json`` for the canonical calibration/validation
+    train/test ranges (rewritten across all models by the partition bump
+    tool); forecasting is dynamic from the current month.
 
 Month IDs use VIEWS encoding: month_id = (year - 1980) * 12 + month.
 """

--- a/models/heavy_strider/configs/config_partitions.py
+++ b/models/heavy_strider/configs/config_partitions.py
@@ -4,9 +4,9 @@ Defines temporal boundaries for each run type. These are identical
 to all other VIEWS pgm models — the partitions are a platform
 convention, not model-specific.
 
-    calibration:  train 121-444, test 445-492  (Jan 1990 – Dec 2020)
-    validation:   train 121-492, test 493-540  (Jan 1990 – Dec 2024)
-    forecasting:  train 121-now,  test now+1 to now+steps  (dynamic)
+    See ``meta/partitions.json`` for the canonical calibration/validation
+    train/test ranges (rewritten across all models by the partition bump
+    tool); forecasting is dynamic from the current month.
 
 Month IDs use VIEWS encoding: month_id = (year - 1980) * 12 + month.
 """

--- a/models/light_strider/configs/config_partitions.py
+++ b/models/light_strider/configs/config_partitions.py
@@ -4,9 +4,9 @@ Defines temporal boundaries for each run type. These are identical
 to all other VIEWS pgm models — the partitions are a platform
 convention, not model-specific.
 
-    calibration:  train 121-444, test 445-492  (Jan 1990 – Dec 2020)
-    validation:   train 121-492, test 493-540  (Jan 1990 – Dec 2024)
-    forecasting:  train 121-now,  test now+1 to now+steps  (dynamic)
+    See ``meta/partitions.json`` for the canonical calibration/validation
+    train/test ranges (rewritten across all models by the partition bump
+    tool); forecasting is dynamic from the current month.
 
 Month IDs use VIEWS encoding: month_id = (year - 1980) * 12 + month.
 """

--- a/models/shining_codex/configs/config_partitions.py
+++ b/models/shining_codex/configs/config_partitions.py
@@ -4,9 +4,9 @@ Defines temporal boundaries for each run type. These are identical
 to all other VIEWS cm models — the partitions are a platform
 convention, not model-specific.
 
-    calibration:  train 121-444, test 445-492  (Jan 1990 – Dec 2020)
-    validation:   train 121-492, test 493-540  (Jan 1990 – Dec 2024)
-    forecasting:  train 121-now,  test now+1 to now+steps  (dynamic)
+    See ``meta/partitions.json`` for the canonical calibration/validation
+    train/test ranges (rewritten across all models by the partition bump
+    tool); forecasting is dynamic from the current month.
 
 Month IDs use VIEWS encoding: month_id = (year - 1980) * 12 + month.
 """

--- a/models/temporary_bison/configs/config_partitions.py
+++ b/models/temporary_bison/configs/config_partitions.py
@@ -4,9 +4,9 @@ Defines temporal boundaries for each run type. These are identical
 to all other VIEWS pgm models — the partitions are a platform
 convention, not model-specific.
 
-    calibration:  train 121-444, test 445-492  (Jan 1990 – Dec 2020)
-    validation:   train 121-492, test 493-540  (Jan 1990 – Dec 2024)
-    forecasting:  train 121-now,  test now+1 to now+steps  (dynamic)
+    See ``meta/partitions.json`` for the canonical calibration/validation
+    train/test ranges (rewritten across all models by the partition bump
+    tool); forecasting is dynamic from the current month.
 
 Month IDs use VIEWS encoding: month_id = (year - 1980) * 12 + month.
 """

--- a/models/temporary_crane/configs/config_partitions.py
+++ b/models/temporary_crane/configs/config_partitions.py
@@ -4,9 +4,9 @@ Defines temporal boundaries for each run type. These are identical
 to all other VIEWS pgm models — the partitions are a platform
 convention, not model-specific.
 
-    calibration:  train 121-444, test 445-492  (Jan 1990 – Dec 2020)
-    validation:   train 121-492, test 493-540  (Jan 1990 – Dec 2024)
-    forecasting:  train 121-now,  test now+1 to now+steps  (dynamic)
+    See ``meta/partitions.json`` for the canonical calibration/validation
+    train/test ranges (rewritten across all models by the partition bump
+    tool); forecasting is dynamic from the current month.
 
 Month IDs use VIEWS encoding: month_id = (year - 1980) * 12 + month.
 """

--- a/models/temporary_finch/configs/config_partitions.py
+++ b/models/temporary_finch/configs/config_partitions.py
@@ -4,9 +4,9 @@ Defines temporal boundaries for each run type. These are identical
 to all other VIEWS pgm models — the partitions are a platform
 convention, not model-specific.
 
-    calibration:  train 121-444, test 445-492  (Jan 1990 – Dec 2020)
-    validation:   train 121-492, test 493-540  (Jan 1990 – Dec 2024)
-    forecasting:  train 121-now,  test now+1 to now+steps  (dynamic)
+    See ``meta/partitions.json`` for the canonical calibration/validation
+    train/test ranges (rewritten across all models by the partition bump
+    tool); forecasting is dynamic from the current month.
 
 Month IDs use VIEWS encoding: month_id = (year - 1980) * 12 + month.
 """

--- a/models/temporary_fox/configs/config_partitions.py
+++ b/models/temporary_fox/configs/config_partitions.py
@@ -4,9 +4,9 @@ Defines temporal boundaries for each run type. These are identical
 to all other VIEWS pgm models — the partitions are a platform
 convention, not model-specific.
 
-    calibration:  train 121-444, test 445-492  (Jan 1990 – Dec 2020)
-    validation:   train 121-492, test 493-540  (Jan 1990 – Dec 2024)
-    forecasting:  train 121-now,  test now+1 to now+steps  (dynamic)
+    See ``meta/partitions.json`` for the canonical calibration/validation
+    train/test ranges (rewritten across all models by the partition bump
+    tool); forecasting is dynamic from the current month.
 
 Month IDs use VIEWS encoding: month_id = (year - 1980) * 12 + month.
 """

--- a/models/temporary_heron/configs/config_partitions.py
+++ b/models/temporary_heron/configs/config_partitions.py
@@ -4,9 +4,9 @@ Defines temporal boundaries for each run type. These are identical
 to all other VIEWS pgm models — the partitions are a platform
 convention, not model-specific.
 
-    calibration:  train 121-444, test 445-492  (Jan 1990 – Dec 2020)
-    validation:   train 121-492, test 493-540  (Jan 1990 – Dec 2024)
-    forecasting:  train 121-now,  test now+1 to now+steps  (dynamic)
+    See ``meta/partitions.json`` for the canonical calibration/validation
+    train/test ranges (rewritten across all models by the partition bump
+    tool); forecasting is dynamic from the current month.
 
 Month IDs use VIEWS encoding: month_id = (year - 1980) * 12 + month.
 """

--- a/models/temporary_lynx/configs/config_partitions.py
+++ b/models/temporary_lynx/configs/config_partitions.py
@@ -4,9 +4,9 @@ Defines temporal boundaries for each run type. These are identical
 to all other VIEWS pgm models — the partitions are a platform
 convention, not model-specific.
 
-    calibration:  train 121-444, test 445-492  (Jan 1990 – Dec 2020)
-    validation:   train 121-492, test 493-540  (Jan 1990 – Dec 2024)
-    forecasting:  train 121-now,  test now+1 to now+steps  (dynamic)
+    See ``meta/partitions.json`` for the canonical calibration/validation
+    train/test ranges (rewritten across all models by the partition bump
+    tool); forecasting is dynamic from the current month.
 
 Month IDs use VIEWS encoding: month_id = (year - 1980) * 12 + month.
 """

--- a/models/temporary_otter/configs/config_partitions.py
+++ b/models/temporary_otter/configs/config_partitions.py
@@ -4,9 +4,9 @@ Defines temporal boundaries for each run type. These are identical
 to all other VIEWS pgm models — the partitions are a platform
 convention, not model-specific.
 
-    calibration:  train 121-444, test 445-492  (Jan 1990 – Dec 2020)
-    validation:   train 121-492, test 493-540  (Jan 1990 – Dec 2024)
-    forecasting:  train 121-now,  test now+1 to now+steps  (dynamic)
+    See ``meta/partitions.json`` for the canonical calibration/validation
+    train/test ranges (rewritten across all models by the partition bump
+    tool); forecasting is dynamic from the current month.
 
 Month IDs use VIEWS encoding: month_id = (year - 1980) * 12 + month.
 """

--- a/models/temporary_robin/configs/config_partitions.py
+++ b/models/temporary_robin/configs/config_partitions.py
@@ -4,9 +4,9 @@ Defines temporal boundaries for each run type. These are identical
 to all other VIEWS pgm models — the partitions are a platform
 convention, not model-specific.
 
-    calibration:  train 121-444, test 445-492  (Jan 1990 – Dec 2020)
-    validation:   train 121-492, test 493-540  (Jan 1990 – Dec 2024)
-    forecasting:  train 121-now,  test now+1 to now+steps  (dynamic)
+    See ``meta/partitions.json`` for the canonical calibration/validation
+    train/test ranges (rewritten across all models by the partition bump
+    tool); forecasting is dynamic from the current month.
 
 Month IDs use VIEWS encoding: month_id = (year - 1980) * 12 + month.
 """


### PR DESCRIPTION
15 datafactory-pgm-template models had config_partitions.py **docstrings** listing the old hardcoded train/test ranges; the bump tool rewrites the code dict but not the prose, so they'd gone stale (code was correct). Replaces the numbers with a pointer to `meta/partitions.json` so they can't drift again. Docstring-only — `generate()` unchanged, partition consistency test green (972 passed), ruff clean. Resolves a C-57-class comment-vs-code instance.