### PR TITLE
config(baselines): declare seed=42 in the 9 distributional baseline configs (#233)

### DIFF
--- a/models/black_ranger/configs/config_hyperparameters.py
+++ b/models/black_ranger/configs/config_hyperparameters.py
@@ -15,6 +15,7 @@ def get_hp_config():
         'lambda_mix': 0.05,
         'n_samples': 256,
         'n_posterior_samples': 256,
+        'seed': 42,
         'regression_targets': ['lr_os_best'],
         'skip_predictions_delivery': True,
     }

--- a/models/blue_ranger/configs/config_hyperparameters.py
+++ b/models/blue_ranger/configs/config_hyperparameters.py
@@ -15,6 +15,7 @@ def get_hp_config():
         'lambda_mix': 0.05,
         'n_samples': 256,
         'n_posterior_samples': 256,
+        'seed': 42,
         'regression_targets': ['lr_ged_sb'],
         'skip_predictions_delivery': True,
     }

--- a/models/green_ranger/configs/config_hyperparameters.py
+++ b/models/green_ranger/configs/config_hyperparameters.py
@@ -15,6 +15,7 @@ def get_hp_config():
         'lambda_mix': 0.05,
         'n_samples': 256,
         'n_posterior_samples': 256,
+        'seed': 42,
         'regression_targets': ['lr_ns_best'],
         'skip_predictions_delivery': True,
     }

--- a/models/lucid_dream/configs/config_hyperparameters.py
+++ b/models/lucid_dream/configs/config_hyperparameters.py
@@ -5,6 +5,7 @@ def get_hp_config():
         'window_months': 18,
         'n_samples': 64,
         'n_posterior_samples': 64,
+        'seed': 42,
         'regression_targets': ['synth_target'],
         'skip_predictions_delivery': True,
     }

--- a/models/pink_ranger/configs/config_hyperparameters.py
+++ b/models/pink_ranger/configs/config_hyperparameters.py
@@ -15,6 +15,7 @@ def get_hp_config():
         'lambda_mix': 0.05,
         'n_samples': 256,
         'n_posterior_samples': 256,
+        'seed': 42,
         'regression_targets': ['lr_ns_best'],
         'skip_predictions_delivery': True,
     }

--- a/models/red_ranger/configs/config_hyperparameters.py
+++ b/models/red_ranger/configs/config_hyperparameters.py
@@ -15,6 +15,7 @@ def get_hp_config():
         'lambda_mix': 0.05,
         'n_samples': 256,
         'n_posterior_samples': 256,
+        'seed': 42,
         'regression_targets': ['lr_ged_sb'],
         'skip_predictions_delivery': True,
     }

--- a/models/vivid_dream/configs/config_hyperparameters.py
+++ b/models/vivid_dream/configs/config_hyperparameters.py
@@ -6,6 +6,7 @@ def get_hp_config():
         'lambda_mix': 0.05,
         'n_samples': 64,
         'n_posterior_samples': 64,
+        'seed': 42,
         'regression_targets': ['synth_target'],
         'skip_predictions_delivery': True,
     }

--- a/models/waking_dream/configs/config_hyperparameters.py
+++ b/models/waking_dream/configs/config_hyperparameters.py
@@ -6,6 +6,7 @@ def get_hp_config():
         'lambda_mix': 0.10,
         'n_samples': 64,
         'n_posterior_samples': 64,
+        'seed': 42,
         'regression_targets': ['synth_target'],
         'skip_predictions_delivery': True,
     }

--- a/models/yellow_ranger/configs/config_hyperparameters.py
+++ b/models/yellow_ranger/configs/config_hyperparameters.py
@@ -15,6 +15,7 @@ def get_hp_config():
         'lambda_mix': 0.05,
         'n_samples': 256,
         'n_posterior_samples': 256,
+        'seed': 42,
         'regression_targets': ['lr_os_best'],
         'skip_predictions_delivery': True,
     }


### PR DESCRIPTION
Implements **#233** — the views-models half of a **coordinated two-repo change** with **views-baseline#31** (ADR-021 Zero-Magic: `seed` becomes required+audited and strictly forwarded, fixing views-baseline C-10 where every distributional baseline silently ran at seed=42 and sweeps were inert).

Adds `'seed': 42` to `get_hp_config()` in exactly the 9 configs that omitted it (8 MixtureBaseline: black/blue/green/pink/red/yellow_ranger + vivid/waking_dream; 1 ConflictologyModel: lucid_dream) — placed after `n_posterior_samples`, matching the heavy_strider precedent. `42` preserves current effective behavior → **output-neutral**. The 11 already-declaring Conflictology configs are untouched. Diff is exactly 9 one-line additions.

⚠️ **MERGE COORDINATION — must merge TOGETHER with views-baseline#31 (or before it). Do NOT let views-baseline#31 merge first**, or these 9 models fail `audit_manifest` with `MissingHyperparameterError` at config time. This PR merging first is safe (the key is redundant until #31 lands).

Verified locally (CI red expected: unpublished pipeline-core 3.0.0, C-132): all 9 configs load and declare `seed=42`; config-completeness + PF-readiness + regression-target suites green (1931 passed; sole failure = pre-existing golden_hour #131). ruff clean.

Closes #233.

🤖 Generated with [Claude Code](https://claude.com/claude-code)