### PR TITLE
feat(liveness): S1 — old-API liveness check (raw facts, freshness + serving verdicts) (#239)

### DIFF
--- a/tests/test_liveness_old_api.py
+++ b/tests/test_liveness_old_api.py
@@ -1,0 +1,271 @@
+"""Liveness S1: the old public API (api.viewsforecasting.org) — issue #239, epic #238.
+
+TDD suite written BEFORE the implementation. All expectations derive from the
+REAL API response captured live on 2026-07-19 (CAPTURED_RUNS below, verbatim,
+88 entries) and from the run-naming convention evidenced that day:
+
+    fatalities{generation}_{yyyy}_{mm}_t{seq}, where {yyyy}_{mm} is the
+    DATA-CUTOFF month — publication happens ~1 month later. Evidence: the
+    wandb run of 2026-06-29 trained to month_id 557 (May 2026) and was
+    published as fatalities003_2026_05_t01.
+
+Unit tests are offline (fake fetch, injected clock). The single live test is
+@pytest.mark.red and skips truthfully on any network problem (house pattern:
+tests/test_reconciliation_viewser_provider.py).
+"""
+
+import pytest
+
+from tools.liveness.old_api import (
+    BASE_URL,
+    FRESHNESS_BUDGET_MONTHS,
+    OldApiCheck,
+    latest_fatalities_run,
+    main,
+    parse_run_name,
+    render,
+)
+from tools.partitions.domain import date_to_month_id, month_id_to_date
+
+pytestmark = pytest.mark.green
+
+
+# ── the real response, frozen (2026-07-19) ────────────────────────────
+CAPTURED_RUNS = [
+    'd_2021_02_01',
+    'escwa_2021_02_01',
+    'escwa_2021_03_01',
+    'escwa_2021_04_01',
+    'escwa_2021_05_01',
+    'escwa_2021_06_01',
+    'escwa_2021_07_01',
+    'escwa_2021_08_01',
+    'escwa_2021_09_01',
+    'escwa_2021_10_01',
+    'escwa_2021_11_01',
+    'escwa_2021_12_01',
+    'escwa_data_2021_10_01',
+    'escwa_features_2021_05_01',
+    'f_2021_06_01',
+    'fatalities001_2021_12_t01',
+    'fatalities001_2022_00_t01',
+    'fatalities001_2022_01_t01',
+    'fatalities001_2022_02_t01',
+    'fatalities001_2022_03_t01',
+    'fatalities001_2022_04_t01',
+    'fatalities001_2022_05_t01',
+    'fatalities001_2022_06_t01',
+    'fatalities001_2022_07_t01',
+    'fatalities001_2022_08_t01',
+    'fatalities001_2022_09_t01',
+    'fatalities001_2022_10_t01',
+    'fatalities001_2022_11_t01',
+    'fatalities001_2022_12_t01',
+    'fatalities001_2023_00_t01',
+    'fatalities001_2023_01_t01',
+    'fatalities001_2023_02_t01',
+    'fatalities001_2023_03_t01',
+    'fatalities002_2023_04_t01',
+    'fatalities002_2023_05_t01',
+    'fatalities002_2023_06_t01',
+    'fatalities002_2023_07_t01',
+    'fatalities002_2023_08_t01',
+    'fatalities002_2023_09_t01',
+    'fatalities002_2023_09_t02',
+    'fatalities002_2023_10_t01',
+    'fatalities002_2023_10_t02',
+    'fatalities002_2023_11_t01',
+    'fatalities002_2023_12_t01',
+    'fatalities002_2024_01_t01',
+    'fatalities002_2024_02_t01',
+    'fatalities002_2024_03_t01',
+    'fatalities002_2024_04_t01',
+    'fatalities002_2024_05_t01',
+    'fatalities002_2024_06_t01',
+    'fatalities002_2024_07_t01',
+    'fatalities002_2024_08_t01',
+    'fatalities002_2024_09_t01',
+    'fatalities002_2024_10_t01',
+    'fatalities002_2024_11_t01',
+    'fatalities002_2024_12_t01',
+    'fatalities002_2025_01_t01',
+    'fatalities002_2025_02_t01',
+    'fatalities002_2025_03_t01',
+    'fatalities002_2025_04_t01',
+    'fatalities002_2025_05_t01',
+    'fatalities002_2025_06_t01',
+    'fatalities002_2025_07_t01',
+    'fatalities002_2025_08_t01',
+    'fatalities002_2025_09_t01',
+    'fatalities002_2025_10_t01',
+    'fatalities003_2025_10_t01',
+    'fatalities003_2025_11_t01',
+    'fatalities003_2025_12_t01',
+    'fatalities003_2026_01_t01',
+    'fatalities003_2026_02_t01',
+    'fatalities003_2026_03_t01',
+    'fatalities003_2026_04_t01',
+    'fatalities003_2026_05_t01',
+    'predictors_fatalities002_2025_12',
+    'predictors_fatalities003_0000_00',
+    'r_2021_01_01',
+    'r_2021_02_01',
+    'r_2021_03_01',
+    'r_2021_04_01',
+    'r_2021_05_01',
+    'r_2021_06_01',
+    'r_2021_07_01',
+    'r_2021_08_01',
+    'r_2021_09_01',
+    'r_2021_10_01',
+    'r_2021_11_01',
+    'r_2021_12_01',
+]
+
+
+# The month the capture was made (July 2026) — used as the injected "now"
+# so verdict tests are deterministic forever.
+CAPTURE_NOW = date_to_month_id(2026, 7)  # 559
+
+
+# ── parse_run_name ────────────────────────────────────────────────────
+
+def test_parses_canonical_run_name():
+    assert parse_run_name("fatalities003_2026_05_t01") == (3, 2026, 5, 1)
+
+def test_parses_second_tag_sequence():
+    assert parse_run_name("fatalities002_2023_09_t02") == (2, 2023, 9, 2)
+
+@pytest.mark.parametrize("name", ["escwa_2021_02_01", "d_2021_02_01", "r_2021_12_01",
+                                  "escwa_features_2021_05_01", "f_2021_06_01", ""])
+def test_rejects_non_fatalities_names(name):
+    assert parse_run_name(name) is None
+
+
+# ── latest run selection: THE pinned bug ──────────────────────────────
+# The API's list is NOT chronologically sorted; its alphabetical tail is
+# r_2021_12_01. Naive "take the last element" reports a 2021 run. This test
+# pins the chronological selection against the full real capture.
+
+def test_latest_run_on_real_capture_is_2026_05():
+    assert CAPTURED_RUNS[-1] == "r_2021_12_01"  # the trap, preserved
+    assert latest_fatalities_run(CAPTURED_RUNS) == "fatalities003_2026_05_t01"
+
+def test_latest_run_empty_list_is_none():
+    assert latest_fatalities_run([]) is None
+    assert latest_fatalities_run(["escwa_2021_02_01"]) is None
+
+
+# ── month math (reused from tools.partitions.domain) ──────────────────
+
+def test_data_cutoff_month_id_of_latest_capture():
+    assert date_to_month_id(2026, 5) == 557
+    assert month_id_to_date(557) == "2026-05"
+
+
+# ── verdicts (fake fetch, injected now) ───────────────────────────────
+
+def _fake_fetch(responses):
+    """Dict-driven fetch: url -> parsed JSON, or a raise-marker Exception."""
+    def fetch(url):
+        for key, value in responses.items():
+            if key in url:
+                if isinstance(value, Exception):
+                    raise value
+                return value
+        raise AssertionError(f"unexpected url fetched: {url}")
+    return fetch
+
+def _runs_doc(names):
+    return {"runs": list(names)}
+
+SERVING_ROWS = {"data": [{"country_id": 1, "month_id": 558}, {"country_id": 2, "month_id": 558}]}
+EMPTY_ROWS = {"data": []}
+
+
+def test_fresh_when_cutoff_within_budget():
+    # cutoff May (557), now July (559): 2 months behind == budget -> FRESH
+    fetch = _fake_fetch({"?month=": SERVING_ROWS, BASE_URL: _runs_doc(CAPTURED_RUNS)})
+    report = OldApiCheck(fetch=fetch).run(now_month_id=CAPTURE_NOW)
+    assert report.verdict == "LIVE_FRESH"
+    assert report.months_behind == FRESHNESS_BUDGET_MONTHS == 2
+    assert report.latest_run == "fatalities003_2026_05_t01"
+
+def test_stale_when_cutoff_beyond_budget():
+    fetch = _fake_fetch({"?month=": SERVING_ROWS, BASE_URL: _runs_doc(CAPTURED_RUNS)})
+    report = OldApiCheck(fetch=fetch).run(now_month_id=CAPTURE_NOW + 1)  # Aug: 3 behind
+    assert report.verdict == "LIVE_STALE"
+    assert report.months_behind == 3
+
+def test_unreachable_when_list_fetch_fails():
+    fetch = _fake_fetch({BASE_URL: OSError("connection refused")})
+    report = OldApiCheck(fetch=fetch).run(now_month_id=CAPTURE_NOW)
+    assert report.verdict == "UNREACHABLE"
+    assert "connection refused" in (report.error or "")
+
+def test_not_serving_when_latest_run_returns_no_rows():
+    fetch = _fake_fetch({"?month=": EMPTY_ROWS, BASE_URL: _runs_doc(CAPTURED_RUNS)})
+    report = OldApiCheck(fetch=fetch).run(now_month_id=CAPTURE_NOW)
+    assert report.verdict == "LIVE_NOT_SERVING"
+
+def test_not_serving_when_no_fatalities_runs_listed():
+    fetch = _fake_fetch({BASE_URL: _runs_doc(["escwa_2021_02_01"])})
+    report = OldApiCheck(fetch=fetch).run(now_month_id=CAPTURE_NOW)
+    assert report.verdict == "LIVE_NOT_SERVING"
+
+
+# ── the report is raw facts ───────────────────────────────────────────
+
+def test_report_contains_literal_url_and_run_name():
+    fetch = _fake_fetch({"?month=": SERVING_ROWS, BASE_URL: _runs_doc(CAPTURED_RUNS)})
+    report = OldApiCheck(fetch=fetch).run(now_month_id=CAPTURE_NOW)
+    assert report.url == BASE_URL
+    assert report.run_count == len(CAPTURED_RUNS)
+    assert report.data_cutoff_month_id == 557
+    assert report.data_cutoff_date == "2026-05"
+    assert report.serving_rows_sampled == 2
+
+def test_render_is_one_fact_per_line():
+    fetch = _fake_fetch({"?month=": SERVING_ROWS, BASE_URL: _runs_doc(CAPTURED_RUNS)})
+    report = OldApiCheck(fetch=fetch).run(now_month_id=CAPTURE_NOW)
+    text = render(report)
+    lines = text.strip().splitlines()
+    assert all(":" in line for line in lines)          # fact per line
+    assert any(BASE_URL in line for line in lines)      # literal url
+    assert any("fatalities003_2026_05_t01" in line for line in lines)
+    assert any("LIVE_FRESH" in line for line in lines)
+
+
+# ── exit codes ────────────────────────────────────────────────────────
+
+def test_exit_zero_when_fresh(capsys):
+    fetch = _fake_fetch({"?month=": SERVING_ROWS, BASE_URL: _runs_doc(CAPTURED_RUNS)})
+    assert main(fetch=fetch, now_month_id=CAPTURE_NOW) == 0
+    assert "LIVE_FRESH" in capsys.readouterr().out
+
+def test_exit_one_when_stale(capsys):
+    fetch = _fake_fetch({"?month=": SERVING_ROWS, BASE_URL: _runs_doc(CAPTURED_RUNS)})
+    assert main(fetch=fetch, now_month_id=CAPTURE_NOW + 6) == 1
+
+def test_exit_one_when_not_serving(capsys):
+    fetch = _fake_fetch({"?month=": EMPTY_ROWS, BASE_URL: _runs_doc(CAPTURED_RUNS)})
+    assert main(fetch=fetch, now_month_id=CAPTURE_NOW) == 1
+
+def test_exit_two_when_unreachable(capsys):
+    fetch = _fake_fetch({BASE_URL: OSError("no route")})
+    assert main(fetch=fetch, now_month_id=CAPTURE_NOW) == 2
+
+
+# ── live integration (network; skips truthfully) ──────────────────────
+
+@pytest.mark.red
+def test_live_old_api_invariants():
+    try:
+        report = OldApiCheck().run()
+    except Exception as e:  # noqa: BLE001 — any network/env problem skips, never false-red
+        pytest.skip(f"old API unreachable from this environment: {type(e).__name__}: {e}")
+    if report.verdict == "UNREACHABLE":
+        pytest.skip(f"old API unreachable: {report.error}")
+    assert report.run_count and report.run_count > 0
+    assert report.latest_run is not None
+    assert parse_run_name(report.latest_run) is not None

--- a/tools/liveness/__init__.py
+++ b/tools/liveness/__init__.py
@@ -1,0 +1,15 @@
+"""Liveness checks: is each forecast surface live, fresh, and serving?
+
+One module per external surface, each answering with RAW FACTS (URL hit,
+value found, date derived) and a verdict — never narration. Run a single
+surface as ``python -m tools.liveness.<surface>``; the aggregate runner
+arrives with epic #238 story S7.
+
+Surfaces (epic #238): old_api (S1, here) · datafactory input (S2) ·
+Appwrite production_forecasts (S3) · FAO unfao_bucket (S4) · wandb
+execution (S5) · VPN store gjoll (S6).
+
+House rules: zero import-time side effects (C-93); injected fetch for
+testability (DIP, mirroring reconciliation/viewser_country_mapping_provider);
+zero new dependencies; live tests skip truthfully (C-75).
+"""

--- a/tools/liveness/old_api.py
+++ b/tools/liveness/old_api.py
@@ -1,0 +1,225 @@
+"""Liveness check for the old public API (api.viewsforecasting.org).
+
+Answers, with raw facts: is the API reachable, what is the newest published
+fatalities run, how fresh is it, and does it actually serve rows?
+
+Usage:
+    python -m tools.liveness.old_api      # exit 0 fresh / 1 stale-or-not-serving / 2 unreachable
+
+THE NAMING CONVENTION (encoded once, colleague-confirmable — issue #239):
+    Runs are named ``fatalities{generation}_{yyyy}_{mm}_t{seq}`` where
+    ``{yyyy}_{mm}`` is the DATA-CUTOFF month, not the execution month;
+    execution/publication happens ~1 month after the cutoff.
+    Evidence (2026-07-19 forensics): the wandb pink_ponyclub run executed
+    2026-06-29 trained on data through month_id 557 (May 2026) and was
+    published as ``fatalities003_2026_05_t01``. Misreading this convention
+    as execution-month produced a false "production stalled" alarm; this
+    module exists so that mistake can never be repeated.
+
+API facts (captured live 2026-07-19):
+    GET /                      -> {"runs": [...]}  (NOT chronologically sorted)
+    GET /{run}/cm?month={id}&pagesize=N -> {"data": [rows...]}
+    unknown run                -> HTTP 422
+
+Design: injected fetch callable (DIP; mirrors
+reconciliation/viewser_country_mapping_provider.py), pure parsing functions,
+no import-time side effects (C-93). Month math is reused from
+tools.partitions.domain — not reimplemented.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from datetime import date
+from typing import Callable, List, Optional, Tuple
+
+from tools.partitions.domain import date_to_month_id, month_id_to_date
+
+BASE_URL = "https://api.viewsforecasting.org"
+
+# Freshness budget: cadence is one run per data-month, published ~1 month
+# after cutoff (PUBLICATION_LAG_MONTHS) + 1 month of in-flight grace.
+PUBLICATION_LAG_MONTHS = 1
+GRACE_MONTHS = 1
+FRESHNESS_BUDGET_MONTHS = PUBLICATION_LAG_MONTHS + GRACE_MONTHS
+
+_FETCH_TIMEOUT_SECONDS = 20
+_SERVING_SAMPLE_PAGESIZE = 2
+
+_RUN_NAME_PATTERN = re.compile(r"^fatalities(\d+)_(\d{4})_(\d{2})_t(\d+)$")
+
+# (generation, year, month, sequence)
+RunId = Tuple[int, int, int, int]
+
+FetchJson = Callable[[str], object]
+
+
+def parse_run_name(name: str) -> Optional[RunId]:
+    """Parse a fatalities run name; None for any other run family."""
+    match = _RUN_NAME_PATTERN.match(name)
+    if match is None:
+        return None
+    generation, year, month, seq = (int(g) for g in match.groups())
+    return (generation, year, month, seq)
+
+
+def latest_fatalities_run(run_names: List[str]) -> Optional[str]:
+    """Chronologically newest fatalities run (by cutoff, then generation/seq).
+
+    The API's list is NOT sorted chronologically — its alphabetical tail is
+    ``r_2021_12_01`` — so naive last-element selection is wrong (the pinned
+    bug from the 2026-07-19 forensics).
+    """
+    best: Optional[Tuple[Tuple[int, int, int, int], str]] = None
+    for name in run_names:
+        parsed = parse_run_name(name)
+        if parsed is None:
+            continue
+        generation, year, month, seq = parsed
+        sort_key = (year, month, generation, seq)
+        if best is None or sort_key > best[0]:
+            best = (sort_key, name)
+    return None if best is None else best[1]
+
+
+@dataclass(frozen=True)
+class CheckReport:
+    """Raw facts about the old API — no narration."""
+
+    url: str
+    verdict: str  # LIVE_FRESH | LIVE_STALE | LIVE_NOT_SERVING | UNREACHABLE
+    run_count: Optional[int] = None
+    latest_run: Optional[str] = None
+    data_cutoff_month_id: Optional[int] = None
+    data_cutoff_date: Optional[str] = None
+    now_month_id: Optional[int] = None
+    months_behind: Optional[int] = None
+    serving_rows_sampled: Optional[int] = None
+    error: Optional[str] = None
+
+
+def render(report: CheckReport) -> str:
+    """One fact per line, ``key: value`` — machine- and human-scannable."""
+    facts = [
+        ("surface", "old_api"),
+        ("url", report.url),
+        ("verdict", report.verdict),
+        ("run_count", report.run_count),
+        ("latest_run", report.latest_run),
+        ("data_cutoff_month_id", report.data_cutoff_month_id),
+        ("data_cutoff_date", report.data_cutoff_date),
+        ("now_month_id", report.now_month_id),
+        ("months_behind", report.months_behind),
+        ("freshness_budget_months", FRESHNESS_BUDGET_MONTHS),
+        ("serving_rows_sampled", report.serving_rows_sampled),
+        ("error", report.error),
+    ]
+    return "\n".join(f"{key}: {value}" for key, value in facts if value is not None)
+
+
+class OldApiCheck:
+    """Liveness check for the old public API (DIP: fetch is injectable)."""
+
+    def __init__(self, fetch: Optional[FetchJson] = None) -> None:
+        self._fetch = fetch or self._fetch_json
+
+    def run(self, now_month_id: Optional[int] = None) -> CheckReport:
+        """Fetch the run list, pick the newest fatalities run, judge freshness,
+        and confirm the run serves rows. ``now_month_id`` is injectable for
+        deterministic tests; defaults to the current calendar month."""
+        if now_month_id is None:
+            today = date.today()
+            now_month_id = date_to_month_id(today.year, today.month)
+
+        try:
+            listing = self._fetch(f"{BASE_URL}/")
+            run_names = list(listing["runs"])  # type: ignore[index]
+        except Exception as exc:  # noqa: BLE001 — any failure is the UNREACHABLE fact
+            return CheckReport(
+                url=BASE_URL,
+                verdict="UNREACHABLE",
+                now_month_id=now_month_id,
+                error=f"{type(exc).__name__}: {exc}",
+            )
+
+        latest = latest_fatalities_run(run_names)
+        if latest is None:
+            return CheckReport(
+                url=BASE_URL,
+                verdict="LIVE_NOT_SERVING",
+                run_count=len(run_names),
+                now_month_id=now_month_id,
+                error="no fatalities runs in listing",
+            )
+
+        _, year, month, _ = parse_run_name(latest)  # type: ignore[misc]
+        cutoff_id = date_to_month_id(year, month)
+        months_behind = now_month_id - cutoff_id
+
+        rows_sampled, serving_error = self._sample_serving_rows(latest, cutoff_id)
+
+        if rows_sampled == 0:
+            verdict = "LIVE_NOT_SERVING"
+        elif months_behind <= FRESHNESS_BUDGET_MONTHS:
+            verdict = "LIVE_FRESH"
+        else:
+            verdict = "LIVE_STALE"
+
+        return CheckReport(
+            url=BASE_URL,
+            verdict=verdict,
+            run_count=len(run_names),
+            latest_run=latest,
+            data_cutoff_month_id=cutoff_id,
+            data_cutoff_date=month_id_to_date(cutoff_id),
+            now_month_id=now_month_id,
+            months_behind=months_behind,
+            serving_rows_sampled=rows_sampled,
+            error=serving_error,
+        )
+
+    def _sample_serving_rows(
+        self, run_name: str, cutoff_id: int
+    ) -> Tuple[int, Optional[str]]:
+        """Sample rows from the run's first forecast month (cutoff + 1)."""
+        url = (
+            f"{BASE_URL}/{run_name}/cm"
+            f"?month={cutoff_id + 1}&pagesize={_SERVING_SAMPLE_PAGESIZE}"
+        )
+        try:
+            payload = self._fetch(url)
+            rows = payload.get("data", [])  # type: ignore[union-attr]
+            return len(rows), None
+        except Exception as exc:  # noqa: BLE001 — a serving failure is a fact, not a crash
+            return 0, f"{type(exc).__name__}: {exc}"
+
+    @staticmethod
+    def _fetch_json(url: str) -> object:
+        """Default fetch: stdlib urllib, lazy import, explicit timeout."""
+        import json
+        import urllib.request
+
+        with urllib.request.urlopen(url, timeout=_FETCH_TIMEOUT_SECONDS) as response:
+            return json.load(response)
+
+
+_EXIT_CODE_BY_VERDICT = {
+    "LIVE_FRESH": 0,
+    "LIVE_STALE": 1,
+    "LIVE_NOT_SERVING": 1,
+    "UNREACHABLE": 2,
+}
+
+
+def main(
+    fetch: Optional[FetchJson] = None, now_month_id: Optional[int] = None
+) -> int:
+    """Run the check, print raw facts, return the exit code."""
+    report = OldApiCheck(fetch=fetch).run(now_month_id=now_month_id)
+    print(render(report))
+    return _EXIT_CODE_BY_VERDICT[report.verdict]
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Story S1 of **epic #238** (tracking #247). Closes #239.

`python -m tools.liveness.old_api` — the repo's first self-answer to *are our forecasts live?*. TDD: 23 tests written first, fixtures = the real 88-run API response captured 2026-07-19; the chronological-selection trap is a pinned test. DIP injected fetch, stdlib-only, zero new deps, CI-green tests.

**⚠ One human confirmation requested (the encoded assumption):** run names `fatalities{gen}_{yyyy}_{mm}_t{seq}` use `{yyyy}_{mm}` as the **data-cutoff month** (publication ~1 month later; evidence in the module docstring). Please confirm or correct — this constant is the single source of the 2026-07-19 false alarm.

**First live run output (2026-07-19):**
```
verdict: LIVE_FRESH
run_count: 88
latest_run: fatalities003_2026_05_t01
data_cutoff_date: 2026-05
months_behind: 2 (budget: 2 — July cycle in-flight)
serving_rows_sampled: 2
```

Full suite: 7046 passed; 9 failures pre-existing from the WIP dwarf/violet snapshot (#236), untouched by this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)