### PR TITLE
feat(liveness): S2 — datafactory input check (coverage vs partition windows) (#240)

### DIFF
--- a/tests/test_liveness_datafactory_input.py
+++ b/tests/test_liveness_datafactory_input.py
@@ -1,0 +1,134 @@
+"""Liveness S2: the datafactory input store (remote zarr) — issue #240, epic #238.
+
+TDD suite written BEFORE the implementation. The check answers: does the
+datafactory's observed-data coverage (`last_valid_month_id`, read live from
+the store's .zattrs) reach what this repo's canonical partitions require
+(`meta/partitions.json` — max test-window end)? This automates the register
+C-96 tripwire, which re-arms at every partition bump.
+
+Ground truth used below (verified live 2026-07-06/19): the store's
+last_valid_month_id was 558; meta/partitions.json currently requires 552.
+
+Unit tests are offline (injected reader + fixed requirements); the single
+live test is @pytest.mark.red and skips truthfully.
+"""
+
+import json
+from pathlib import Path
+
+import pytest
+
+from tools.liveness.datafactory_input import (
+    CheckReport,
+    DatafactoryInputCheck,
+    main,
+    render,
+    required_month_id_from_partitions,
+)
+from tools.partitions.domain import month_id_to_date
+
+pytestmark = pytest.mark.green
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+
+# ── requirement derivation (never hardcoded) ──────────────────────────
+
+def test_required_month_derives_from_canonical_partitions_file():
+    canonical = json.loads((REPO_ROOT / "meta" / "partitions.json").read_text())
+    expected = max(
+        canonical["calibration"]["test"][1], canonical["validation"]["test"][1]
+    )
+    assert required_month_id_from_partitions(REPO_ROOT) == expected
+
+def test_required_month_from_synthetic_partitions(tmp_path):
+    (tmp_path / "meta").mkdir()
+    (tmp_path / "meta" / "partitions.json").write_text(json.dumps({
+        "calibration": {"train": [1, 2], "test": [3, 400]},
+        "validation": {"train": [1, 4], "test": [5, 390]},
+        "steps_default": 36,
+    }))
+    assert required_month_id_from_partitions(tmp_path) == 400
+
+
+# ── verdicts (injected reader; deterministic) ─────────────────────────
+
+def _check(last_valid, netrc_present=True, required=552):
+    def read_last_valid():
+        if isinstance(last_valid, Exception):
+            raise last_valid
+        return last_valid
+    return DatafactoryInputCheck(
+        read_last_valid_month_id=read_last_valid,
+        netrc_probe=lambda: netrc_present,
+        required_month_id=required,
+    )
+
+def test_fresh_when_coverage_reaches_requirement():
+    report = _check(558).run()
+    assert report.verdict == "INPUT_FRESH"
+    assert report.last_valid_month_id == 558
+    assert report.required_month_id == 552
+    assert report.margin_months == 6
+
+def test_fresh_at_exact_boundary():
+    assert _check(552).run().verdict == "INPUT_FRESH"
+
+def test_stale_when_coverage_short_of_requirement():
+    report = _check(540).run()
+    assert report.verdict == "INPUT_STALE"
+    assert report.margin_months == -12
+
+def test_unreachable_when_reader_fails():
+    report = _check(OSError("connection timed out")).run()
+    assert report.verdict == "UNREACHABLE"
+    assert "connection timed out" in (report.error or "")
+
+def test_missing_netrc_is_reported_as_fact():
+    report = _check(558, netrc_present=False).run()
+    assert report.netrc_present is False
+    assert report.verdict == "INPUT_FRESH"  # reachable store trumps the hint
+
+
+# ── the report is raw facts ───────────────────────────────────────────
+
+def test_report_dates_rendered_from_month_ids():
+    report = _check(558).run()
+    assert report.last_valid_date == month_id_to_date(558) == "2026-06"
+    assert report.required_date == month_id_to_date(552) == "2025-12"
+
+def test_render_is_one_fact_per_line():
+    text = render(_check(558).run())
+    lines = text.strip().splitlines()
+    assert all(":" in line for line in lines)
+    assert any("INPUT_FRESH" in line for line in lines)
+    assert any("558" in line for line in lines)
+    assert any("552" in line for line in lines)
+
+
+# ── exit codes ────────────────────────────────────────────────────────
+
+def test_exit_zero_when_fresh(capsys):
+    assert main(check=_check(558)) == 0
+    assert "INPUT_FRESH" in capsys.readouterr().out
+
+def test_exit_one_when_stale(capsys):
+    assert main(check=_check(500)) == 1
+
+def test_exit_two_when_unreachable(capsys):
+    assert main(check=_check(OSError("no route"))) == 2
+
+
+# ── live integration (network + datafactory install; skips truthfully) ─
+
+@pytest.mark.red
+def test_live_datafactory_input_invariants():
+    try:
+        report = DatafactoryInputCheck().run()
+    except Exception as e:  # noqa: BLE001 — any env problem skips, never false-red
+        pytest.skip(f"datafactory input unreachable: {type(e).__name__}: {e}")
+    if report.verdict == "UNREACHABLE":
+        pytest.skip(f"datafactory input unreachable: {report.error}")
+    assert report.last_valid_month_id is not None
+    assert report.last_valid_month_id > 500  # sanity: post-2021 coverage
+    assert report.required_month_id == required_month_id_from_partitions(REPO_ROOT)

--- a/tests/test_liveness_old_api.py
+++ b/tests/test_liveness_old_api.py
@@ -136,6 +136,11 @@ def test_parses_canonical_run_name():
 def test_parses_second_tag_sequence():
     assert parse_run_name("fatalities002_2023_09_t02") == (2, 2023, 9, 2)
 
+def test_rejects_legacy_month_zero_names():
+    # fatalities001_2022_00_t01 is real in the listing; month 00 must not
+    # reach the month math (S1 review finding).
+    assert parse_run_name("fatalities001_2022_00_t01") is None
+
 @pytest.mark.parametrize("name", ["escwa_2021_02_01", "d_2021_02_01", "r_2021_12_01",
                                   "escwa_features_2021_05_01", "f_2021_06_01", ""])
 def test_rejects_non_fatalities_names(name):

--- a/tools/liveness/datafactory_input.py
+++ b/tools/liveness/datafactory_input.py
@@ -1,0 +1,163 @@
+"""Liveness check for the datafactory input store (the remote zarr).
+
+Answers, with raw facts: is the input store reachable, how far does its
+OBSERVED data coverage reach (`last_valid_month_id`, read from the live
+store's .zattrs), and does that cover what this repo's canonical partitions
+require (`meta/partitions.json`, max test-window end)?
+
+Usage:
+    python -m tools.liveness.datafactory_input   # exit 0 fresh / 1 stale / 2 unreachable
+
+This automates the register C-96 tripwire: partition windows that outrun
+observed coverage mean models are evaluated against zero-fill, warned about
+only in run logs. The requirement is DERIVED from meta/partitions.json at
+run time — never hardcoded — so every partition bump re-arms the check
+automatically (ADR-013 spirit).
+
+Context receipts: live value 558 (2026-07-06/19); current requirement 552;
+store host carries HTTP basic auth via ~/.netrc (presence reported as a
+fact, value never read).
+
+Design (house rules, mirrors tools/liveness/old_api.py): injected reader
+callables (DIP), lazy datafactory import inside the default reader only,
+no import-time side effects (C-93), month math reused from
+tools.partitions.domain, zero new dependencies.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Callable, Optional
+
+from tools.partitions.domain import month_id_to_date
+
+_DEFAULT_REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+
+
+def required_month_id_from_partitions(repo_root: Path = _DEFAULT_REPO_ROOT) -> int:
+    """Max test-window end across the canonical partitions (the coverage bar)."""
+    canonical = json.loads((repo_root / "meta" / "partitions.json").read_text())
+    return max(
+        canonical["calibration"]["test"][1],
+        canonical["validation"]["test"][1],
+    )
+
+
+@dataclass(frozen=True)
+class CheckReport:
+    """Raw facts about the datafactory input store — no narration."""
+
+    verdict: str  # INPUT_FRESH | INPUT_STALE | UNREACHABLE
+    netrc_present: Optional[bool] = None
+    last_valid_month_id: Optional[int] = None
+    last_valid_date: Optional[str] = None
+    required_month_id: Optional[int] = None
+    required_date: Optional[str] = None
+    margin_months: Optional[int] = None
+    error: Optional[str] = None
+
+
+def render(report: CheckReport) -> str:
+    """One fact per line, ``key: value``."""
+    facts = [
+        ("surface", "datafactory_input"),
+        ("verdict", report.verdict),
+        ("netrc_present", report.netrc_present),
+        ("last_valid_month_id", report.last_valid_month_id),
+        ("last_valid_date", report.last_valid_date),
+        ("required_month_id", report.required_month_id),
+        ("required_date", report.required_date),
+        ("margin_months", report.margin_months),
+        ("error", report.error),
+    ]
+    return "\n".join(f"{key}: {value}" for key, value in facts if value is not None)
+
+
+class DatafactoryInputCheck:
+    """Coverage-vs-requirement check for the input store (DIP seams throughout)."""
+
+    def __init__(
+        self,
+        read_last_valid_month_id: Optional[Callable[[], int]] = None,
+        netrc_probe: Optional[Callable[[], bool]] = None,
+        required_month_id: Optional[int] = None,
+    ) -> None:
+        self._read_last_valid = read_last_valid_month_id or self._read_live_last_valid
+        self._netrc_probe = netrc_probe or self._netrc_has_store_host
+        self._required_month_id = required_month_id
+
+    def run(self) -> CheckReport:
+        required = (
+            self._required_month_id
+            if self._required_month_id is not None
+            else required_month_id_from_partitions()
+        )
+        netrc_present = self._safe_netrc_probe()
+
+        try:
+            last_valid = int(self._read_last_valid())
+        except Exception as exc:  # noqa: BLE001 — any failure is the UNREACHABLE fact
+            return CheckReport(
+                verdict="UNREACHABLE",
+                netrc_present=netrc_present,
+                required_month_id=required,
+                required_date=month_id_to_date(required),
+                error=f"{type(exc).__name__}: {exc}",
+            )
+
+        margin = last_valid - required
+        verdict = "INPUT_FRESH" if margin >= 0 else "INPUT_STALE"
+        return CheckReport(
+            verdict=verdict,
+            netrc_present=netrc_present,
+            last_valid_month_id=last_valid,
+            last_valid_date=month_id_to_date(last_valid),
+            required_month_id=required,
+            required_date=month_id_to_date(required),
+            margin_months=margin,
+        )
+
+    def _safe_netrc_probe(self) -> Optional[bool]:
+        try:
+            return bool(self._netrc_probe())
+        except Exception:  # noqa: BLE001 — the hint must never sink the check
+            return None
+
+    @staticmethod
+    def _read_live_last_valid() -> int:
+        """Default reader: the datafactory's own live .zattrs accessor."""
+        from datafactory_query.defaults import get_last_valid_month_id
+
+        return int(get_last_valid_month_id())
+
+    @staticmethod
+    def _netrc_has_store_host() -> bool:
+        """Does ~/.netrc mention the store host? (presence only; never values)."""
+        import netrc
+        from urllib.parse import urlparse
+
+        from datafactory_query.defaults import DEFAULT_REMOTE
+
+        host = urlparse(DEFAULT_REMOTE.zarr_url).hostname
+        credentials = netrc.netrc()
+        return host is not None and credentials.authenticators(host) is not None
+
+
+_EXIT_CODE_BY_VERDICT = {
+    "INPUT_FRESH": 0,
+    "INPUT_STALE": 1,
+    "UNREACHABLE": 2,
+}
+
+
+def main(check: Optional[DatafactoryInputCheck] = None) -> int:
+    """Run the check, print raw facts, return the exit code."""
+    report = (check or DatafactoryInputCheck()).run()
+    print(render(report))
+    return _EXIT_CODE_BY_VERDICT[report.verdict]
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/liveness/old_api.py
+++ b/tools/liveness/old_api.py
@@ -63,6 +63,11 @@ def parse_run_name(name: str) -> Optional[RunId]:
     if match is None:
         return None
     generation, year, month, seq = (int(g) for g in match.groups())
+    if not 1 <= month <= 12:
+        # Legacy quirk: names like fatalities001_2022_00_t01 exist in the
+        # listing; month 00 is not a calendar month and must not enter the
+        # month math (review finding, S2 remediation).
+        return None
     return (generation, year, month, seq)
 
 


### PR DESCRIPTION
Story S2 of **epic #238** (tracking #247). Closes #240.

`python -m tools.liveness.datafactory_input` — input-side freshness: live `last_valid_month_id` vs the requirement **derived from `meta/partitions.json`** (never hardcoded; every partition bump re-arms the check — this is register **C-96**'s tripwire, automated). TDD: 14 tests first, injected seams, offline-deterministic; live test skips truthfully. Zero new deps.

Includes the S1 review-finding fix: month-`00` legacy names rejected in `parse_run_name` (pinned test).

**First live run (2026-07-19):**
```
verdict: INPUT_FRESH
last_valid: 558 (2026-06)   required: 552 (2025-12)   margin: 6 months
netrc_present: True
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)