### PR TITLE
feat(liveness): S3 — Appwrite production_forecasts check + real collection IDs (#241)

### DIFF
--- a/tests/test_liveness_appwrite_store.py
+++ b/tests/test_liveness_appwrite_store.py
@@ -1,0 +1,212 @@
+"""Liveness S3: the Appwrite production_forecasts store — issue #241, epic #238.
+
+TDD suite written BEFORE the implementation. Ground truth captured live
+2026-07-19 with the datastore key:
+
+    database  id='file_metadata'          name='File Metadata'
+    collection id='production_forecasts'  name='Production Forecasts'
+    collection id='unfao'                 name='UNFAO File Metadata'
+    bucket 'production_forecasts': 318 files, newest 2025-11-27 (~34KB stubs)
+
+The June 2026 live failure used collection ID 'forecasts_metadata' — which
+does not exist and never did (register C-100's founding incident). This
+check encodes the REAL IDs and reports drift.
+
+Unit tests are offline (fake fetch, fake credentials, injected clock);
+secrets never appear in any rendered output (pinned test). The live test is
+@pytest.mark.red and skips truthfully.
+"""
+
+from datetime import datetime, timezone
+
+import pytest
+
+from tools.liveness.appwrite_store import (
+    HISTORICAL_WRONG_COLLECTION_ID,
+    REAL_METADATA_DATABASE_ID,
+    REAL_PROD_FORECASTS_COLLECTION_ID,
+    AppwriteCredentials,
+    AppwriteStoreCheck,
+    CheckReport,
+    load_credentials_from_env_file,
+    main,
+    render,
+)
+
+pytestmark = pytest.mark.green
+
+NOW = datetime(2026, 7, 19, 12, 0, 0, tzinfo=timezone.utc)
+SENTINEL_KEY = "SECRET-API-KEY-MUST-NEVER-RENDER"
+
+CREDS = AppwriteCredentials(
+    endpoint="https://fra.cloud.appwrite.io/v1",
+    project_id="proj123",
+    api_key=SENTINEL_KEY,
+)
+
+FILES_DOC = {
+    "total": 318,
+    "files": [
+        {"$id": "a", "$createdAt": "2025-11-26T12:07:40.000+00:00",
+         "name": "predictions_forecasting_20251126_125446.parquet", "sizeOriginal": 42843},
+        {"$id": "b", "$createdAt": "2025-11-27T12:12:56.000+00:00",
+         "name": "predictions_forecasting_20251127_125227.parquet", "sizeOriginal": 33721},
+    ],
+}
+COLLECTIONS_DOC = {
+    "total": 2,
+    "collections": [
+        {"$id": "production_forecasts", "name": "Production Forecasts"},
+        {"$id": "unfao", "name": "UNFAO File Metadata"},
+    ],
+}
+FRESH_FILES_DOC = {
+    "total": 5,
+    "files": [
+        {"$id": "c", "$createdAt": "2026-07-10T09:00:00.000+00:00",
+         "name": "predictions_forecasting_20260710.parquet", "sizeOriginal": 5_000_000},
+    ],
+}
+
+
+def _fake_fetch(responses):
+    def fetch(url, headers):
+        assert headers["X-Appwrite-Key"] == SENTINEL_KEY  # creds reach the wire
+        for key, value in responses.items():
+            if key in url:
+                if isinstance(value, Exception):
+                    raise value
+                return value
+        raise AssertionError(f"unexpected url: {url}")
+    return fetch
+
+
+# ── encoded ground truth ──────────────────────────────────────────────
+
+def test_real_ids_are_encoded():
+    assert REAL_METADATA_DATABASE_ID == "file_metadata"
+    assert REAL_PROD_FORECASTS_COLLECTION_ID == "production_forecasts"
+    assert HISTORICAL_WRONG_COLLECTION_ID == "forecasts_metadata"
+
+
+# ── credentials resolution (presence, never values) ───────────────────
+
+def test_credentials_parse_export_style_env_file(tmp_path):
+    env = tmp_path / ".env"
+    env.write_text(
+        'export APPWRITE_ENDPOINT="https://x.example/v1"\n'
+        "export APPWRITE_DATASTORE_PROJECT_ID=p1\n"
+        "export APPWRITE_DATASTORE_API_KEY='k1'\n"
+        "export OTHER=ignored\n"
+    )
+    creds = load_credentials_from_env_file(env)
+    assert creds == AppwriteCredentials("https://x.example/v1", "p1", "k1")
+
+def test_credentials_none_when_file_missing(tmp_path):
+    assert load_credentials_from_env_file(tmp_path / "absent.env") is None
+
+def test_credentials_none_when_keys_incomplete(tmp_path):
+    env = tmp_path / ".env"
+    env.write_text("export APPWRITE_ENDPOINT=https://x\n")
+    assert load_credentials_from_env_file(env) is None
+
+
+# ── verdicts ──────────────────────────────────────────────────────────
+
+def test_skip_when_no_credentials():
+    report = AppwriteStoreCheck(credentials=None, fetch=_fake_fetch({})).run(now=NOW)
+    assert report.verdict == "SKIP_NO_CREDENTIALS"
+
+def test_idle_when_newest_file_old():
+    fetch = _fake_fetch({"/storage/": FILES_DOC, "/databases/": COLLECTIONS_DOC})
+    report = AppwriteStoreCheck(credentials=CREDS, fetch=fetch).run(now=NOW)
+    assert report.verdict == "STORE_IDLE"
+    assert report.newest_file_name == "predictions_forecasting_20251127_125227.parquet"
+    assert report.days_since_newest == 233  # 23h47m short of day 234
+
+def test_active_when_newest_file_recent():
+    fetch = _fake_fetch({"/storage/": FRESH_FILES_DOC, "/databases/": COLLECTIONS_DOC})
+    report = AppwriteStoreCheck(credentials=CREDS, fetch=fetch).run(now=NOW)
+    assert report.verdict == "STORE_ACTIVE"
+    assert report.days_since_newest == 9
+
+def test_unreachable_when_fetch_fails():
+    fetch = _fake_fetch({"/storage/": OSError("tls handshake failed")})
+    report = AppwriteStoreCheck(credentials=CREDS, fetch=fetch).run(now=NOW)
+    assert report.verdict == "UNREACHABLE"
+    assert "tls handshake" in (report.error or "")
+
+def test_empty_bucket_is_idle_with_no_newest():
+    fetch = _fake_fetch({"/storage/": {"total": 0, "files": []},
+                         "/databases/": COLLECTIONS_DOC})
+    report = AppwriteStoreCheck(credentials=CREDS, fetch=fetch).run(now=NOW)
+    assert report.verdict == "STORE_IDLE"
+    assert report.newest_file_name is None
+
+
+# ── collection discovery facts ────────────────────────────────────────
+
+def test_real_collection_confirmed_and_wrong_id_absent():
+    fetch = _fake_fetch({"/storage/": FILES_DOC, "/databases/": COLLECTIONS_DOC})
+    report = AppwriteStoreCheck(credentials=CREDS, fetch=fetch).run(now=NOW)
+    assert report.real_collection_present is True
+    assert "production_forecasts" in report.collections_found
+    assert HISTORICAL_WRONG_COLLECTION_ID not in report.collections_found
+
+def test_collection_listing_failure_is_a_fact_not_a_crash():
+    fetch = _fake_fetch({"/storage/": FILES_DOC, "/databases/": OSError("403")})
+    report = AppwriteStoreCheck(credentials=CREDS, fetch=fetch).run(now=NOW)
+    assert report.verdict == "STORE_IDLE"           # storage verdict unaffected
+    assert report.real_collection_present is None    # unknown, honestly
+
+
+# ── secrets never render ──────────────────────────────────────────────
+
+def test_render_never_contains_key_material():
+    fetch = _fake_fetch({"/storage/": FILES_DOC, "/databases/": COLLECTIONS_DOC})
+    report = AppwriteStoreCheck(credentials=CREDS, fetch=fetch).run(now=NOW)
+    text = render(report)
+    assert SENTINEL_KEY not in text
+    assert "api_key_chars: " in text  # presence signalled by length only
+
+def test_render_is_one_fact_per_line():
+    fetch = _fake_fetch({"/storage/": FILES_DOC, "/databases/": COLLECTIONS_DOC})
+    text = render(AppwriteStoreCheck(credentials=CREDS, fetch=fetch).run(now=NOW))
+    assert all(":" in line for line in text.strip().splitlines())
+    assert any("STORE_IDLE" in line for line in text.splitlines())
+
+
+# ── exit codes ────────────────────────────────────────────────────────
+
+def test_exit_zero_active(capsys):
+    fetch = _fake_fetch({"/storage/": FRESH_FILES_DOC, "/databases/": COLLECTIONS_DOC})
+    assert main(check=AppwriteStoreCheck(credentials=CREDS, fetch=fetch), now=NOW) == 0
+
+def test_exit_zero_skip_no_creds(capsys):
+    assert main(check=AppwriteStoreCheck(credentials=None, fetch=_fake_fetch({})), now=NOW) == 0
+    assert "SKIP_NO_CREDENTIALS" in capsys.readouterr().out
+
+def test_exit_one_idle(capsys):
+    fetch = _fake_fetch({"/storage/": FILES_DOC, "/databases/": COLLECTIONS_DOC})
+    assert main(check=AppwriteStoreCheck(credentials=CREDS, fetch=fetch), now=NOW) == 1
+
+def test_exit_two_unreachable(capsys):
+    fetch = _fake_fetch({"/storage/": OSError("boom")})
+    assert main(check=AppwriteStoreCheck(credentials=CREDS, fetch=fetch), now=NOW) == 2
+
+
+# ── live integration (creds + network; skips truthfully) ──────────────
+
+@pytest.mark.red
+def test_live_appwrite_store_invariants():
+    check = AppwriteStoreCheck()
+    if check.credentials is None:
+        pytest.skip("no Appwrite credentials resolvable in this environment")
+    try:
+        report = check.run()
+    except Exception as e:  # noqa: BLE001
+        pytest.skip(f"appwrite unreachable: {type(e).__name__}: {e}")
+    if report.verdict == "UNREACHABLE":
+        pytest.skip(f"appwrite unreachable: {report.error}")
+    assert report.total_files and report.total_files > 0
+    assert report.real_collection_present is True

--- a/tools/liveness/appwrite_store.py
+++ b/tools/liveness/appwrite_store.py
@@ -1,0 +1,268 @@
+"""Liveness check for the Appwrite production_forecasts store (the "new shelf").
+
+Answers, with raw facts: is the store reachable with resolvable credentials,
+when did the newest forecast file land, and do the REAL metadata IDs match
+what we encode?
+
+Usage:
+    python -m tools.liveness.appwrite_store   # exit 0 active/skip / 1 idle / 2 unreachable
+
+THE REAL IDs (discovered live 2026-07-19 via the datastore key; register
+C-100's founding incident was a config naming a collection that never
+existed):
+
+    database   'file_metadata'          ("File Metadata")
+    collection 'production_forecasts'   ("Production Forecasts")  <- the real one
+    collection 'unfao'                  ("UNFAO File Metadata")
+
+    HISTORICAL WRONG VALUE: 'forecasts_metadata' — used by the June 2026
+    un_fao run config; does not exist; killed the run at store lookup.
+
+Credentials resolution (encoded once, values never rendered): process env
+vars first, else the known platform .env (views-faoapi/.env, export-style).
+Reports presence via character counts only.
+
+Design (house rules, mirrors the S1/S2 checks): injected fetch + credentials
++ clock (DIP), lazy stdlib urllib in the default fetch, no import-time side
+effects (C-93), zero new dependencies, truthful SKIP without credentials.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Callable, Dict, List, Optional
+
+APPWRITE_BUCKET_ID = "production_forecasts"
+REAL_METADATA_DATABASE_ID = "file_metadata"
+REAL_PROD_FORECASTS_COLLECTION_ID = "production_forecasts"
+HISTORICAL_WRONG_COLLECTION_ID = "forecasts_metadata"
+
+# A monthly-cadence store is "active" if something landed within ~1.5 cycles.
+ACTIVE_WITHIN_DAYS = 45
+
+_FETCH_TIMEOUT_SECONDS = 25
+
+def _known_env_files():
+    """Candidate platform .env files, discovered by walking ancestors — robust
+    to running from the main checkout AND from a git worktree under
+    .claude/worktrees/ (where fixed parent-counting breaks)."""
+    return tuple(
+        ancestor / "views-faoapi" / ".env"
+        for ancestor in Path(__file__).resolve().parents
+        if (ancestor / "views-faoapi" / ".env").exists()
+    )
+
+_ENV_LINE = re.compile(
+    r"^export\s+(APPWRITE_ENDPOINT|APPWRITE_DATASTORE_PROJECT_ID|"
+    r"APPWRITE_DATASTORE_API_KEY)\s*=\s*(.+?)\s*$"
+)
+
+FetchJson = Callable[[str, Dict[str, str]], object]
+
+
+@dataclass(frozen=True)
+class AppwriteCredentials:
+    endpoint: str
+    project_id: str
+    api_key: str
+
+
+def load_credentials_from_env_file(path: Path) -> Optional[AppwriteCredentials]:
+    """Parse an export-style .env; None unless all three keys are present."""
+    try:
+        text = path.read_text()
+    except OSError:
+        return None
+    found: Dict[str, str] = {}
+    for line in text.splitlines():
+        match = _ENV_LINE.match(line.strip())
+        if match:
+            found[match.group(1)] = match.group(2).strip("\"'")
+    try:
+        return AppwriteCredentials(
+            endpoint=found["APPWRITE_ENDPOINT"],
+            project_id=found["APPWRITE_DATASTORE_PROJECT_ID"],
+            api_key=found["APPWRITE_DATASTORE_API_KEY"],
+        )
+    except KeyError:
+        return None
+
+
+def resolve_credentials() -> Optional[AppwriteCredentials]:
+    """Env vars first, then the known platform .env files."""
+    import os
+
+    env = {k: os.environ.get(k) for k in (
+        "APPWRITE_ENDPOINT", "APPWRITE_DATASTORE_PROJECT_ID", "APPWRITE_DATASTORE_API_KEY",
+    )}
+    if all(env.values()):
+        return AppwriteCredentials(
+            env["APPWRITE_ENDPOINT"],            # type: ignore[arg-type]
+            env["APPWRITE_DATASTORE_PROJECT_ID"],  # type: ignore[arg-type]
+            env["APPWRITE_DATASTORE_API_KEY"],   # type: ignore[arg-type]
+        )
+    for candidate in _known_env_files():
+        credentials = load_credentials_from_env_file(candidate)
+        if credentials is not None:
+            return credentials
+    return None
+
+
+@dataclass(frozen=True)
+class CheckReport:
+    """Raw facts about the production_forecasts store — no narration."""
+
+    verdict: str  # STORE_ACTIVE | STORE_IDLE | UNREACHABLE | SKIP_NO_CREDENTIALS
+    endpoint: Optional[str] = None
+    bucket: str = APPWRITE_BUCKET_ID
+    api_key_chars: Optional[int] = None
+    total_files: Optional[int] = None
+    newest_file_name: Optional[str] = None
+    newest_file_created: Optional[str] = None
+    newest_file_bytes: Optional[int] = None
+    days_since_newest: Optional[int] = None
+    collections_found: Optional[List[str]] = None
+    real_collection_present: Optional[bool] = None
+    error: Optional[str] = None
+
+
+def render(report: CheckReport) -> str:
+    """One fact per line, ``key: value``; key material never appears."""
+    facts = [
+        ("surface", "appwrite_store"),
+        ("verdict", report.verdict),
+        ("endpoint", report.endpoint),
+        ("bucket", report.bucket),
+        ("api_key_chars", report.api_key_chars),
+        ("total_files", report.total_files),
+        ("newest_file_name", report.newest_file_name),
+        ("newest_file_created", report.newest_file_created),
+        ("newest_file_bytes", report.newest_file_bytes),
+        ("days_since_newest", report.days_since_newest),
+        ("active_within_days", ACTIVE_WITHIN_DAYS),
+        ("metadata_database", REAL_METADATA_DATABASE_ID),
+        ("collections_found", report.collections_found),
+        ("real_collection_present", report.real_collection_present),
+        ("historical_wrong_collection_id", HISTORICAL_WRONG_COLLECTION_ID),
+        ("error", report.error),
+    ]
+    return "\n".join(f"{key}: {value}" for key, value in facts if value is not None)
+
+
+class AppwriteStoreCheck:
+    """Freshness + schema-truth check for the new shelf (all seams injected)."""
+
+    def __init__(
+        self,
+        credentials: Optional[AppwriteCredentials] = "RESOLVE",  # type: ignore[assignment]
+        fetch: Optional[FetchJson] = None,
+    ) -> None:
+        self.credentials = (
+            resolve_credentials() if credentials == "RESOLVE" else credentials
+        )
+        self._fetch = fetch or self._fetch_json
+
+    def run(self, now: Optional[datetime] = None) -> CheckReport:
+        if self.credentials is None:
+            return CheckReport(
+                verdict="SKIP_NO_CREDENTIALS",
+                error="no Appwrite credentials in env or known .env files",
+            )
+        now = now or datetime.now(timezone.utc)
+        creds = self.credentials
+        headers = {
+            "X-Appwrite-Project": creds.project_id,
+            "X-Appwrite-Key": creds.api_key,
+        }
+
+        try:
+            listing = self._fetch(
+                f"{creds.endpoint}/storage/buckets/{APPWRITE_BUCKET_ID}/files", headers
+            )
+            files = list(listing.get("files", []))  # type: ignore[union-attr]
+            total = int(listing.get("total", len(files)))  # type: ignore[union-attr]
+        except Exception as exc:  # noqa: BLE001 — any storage failure is the fact
+            return CheckReport(
+                verdict="UNREACHABLE",
+                endpoint=creds.endpoint,
+                api_key_chars=len(creds.api_key),
+                error=f"{type(exc).__name__}: {exc}",
+            )
+
+        collections, real_present = self._discover_collections(creds, headers)
+
+        newest = max(files, key=lambda f: f.get("$createdAt", ""), default=None)
+        if newest is None:
+            return CheckReport(
+                verdict="STORE_IDLE",
+                endpoint=creds.endpoint,
+                api_key_chars=len(creds.api_key),
+                total_files=total,
+                collections_found=collections,
+                real_collection_present=real_present,
+                error="bucket contains no files",
+            )
+
+        created_text = str(newest["$createdAt"])
+        created = datetime.fromisoformat(created_text.replace("Z", "+00:00"))
+        days = (now - created).days
+        verdict = "STORE_ACTIVE" if days <= ACTIVE_WITHIN_DAYS else "STORE_IDLE"
+
+        return CheckReport(
+            verdict=verdict,
+            endpoint=creds.endpoint,
+            api_key_chars=len(creds.api_key),
+            total_files=total,
+            newest_file_name=str(newest.get("name")),
+            newest_file_created=created_text[:19],
+            newest_file_bytes=newest.get("sizeOriginal"),
+            days_since_newest=days,
+            collections_found=collections,
+            real_collection_present=real_present,
+        )
+
+    def _discover_collections(
+        self, creds: AppwriteCredentials, headers: Dict[str, str]
+    ) -> tuple:
+        """List the metadata database's collections; failure is unknown, not fatal."""
+        try:
+            doc = self._fetch(
+                f"{creds.endpoint}/databases/{REAL_METADATA_DATABASE_ID}/collections",
+                headers,
+            )
+            ids = [c["$id"] for c in doc.get("collections", [])]  # type: ignore[union-attr]
+            return ids, REAL_PROD_FORECASTS_COLLECTION_ID in ids
+        except Exception:  # noqa: BLE001 — discovery is auxiliary; unknown, honestly
+            return None, None
+
+    @staticmethod
+    def _fetch_json(url: str, headers: Dict[str, str]) -> object:
+        """Default fetch: stdlib urllib, lazy import, explicit timeout."""
+        import json
+        import urllib.request
+
+        request = urllib.request.Request(url, headers=headers)
+        with urllib.request.urlopen(request, timeout=_FETCH_TIMEOUT_SECONDS) as response:
+            return json.load(response)
+
+
+_EXIT_CODE_BY_VERDICT = {
+    "STORE_ACTIVE": 0,
+    "SKIP_NO_CREDENTIALS": 0,
+    "STORE_IDLE": 1,
+    "UNREACHABLE": 2,
+}
+
+
+def main(check: Optional[AppwriteStoreCheck] = None, now: Optional[datetime] = None) -> int:
+    """Run the check, print raw facts, return the exit code."""
+    report = (check or AppwriteStoreCheck()).run(now=now)
+    print(render(report))
+    return _EXIT_CODE_BY_VERDICT[report.verdict]
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Story S3 of **epic #238** (tracking #247). Closes #241.

`python -m tools.liveness.appwrite_store` — the new shelf's freshness + schema truth. **The forecasts_metadata mystery is closed:** live discovery found the real structure (db `file_metadata`, collections `production_forecasts` + `unfao`); the June failure's collection ID never existed. Real IDs now encoded with receipts; drift is a reported fact.

TDD 19 tests (injected fetch/creds/clock; secrets provably never rendered; truthful SKIP without creds). Worktree-safe .env discovery (ancestor walk — fixed a real bug the live run caught).

**First live run (2026-07-19):**
```
verdict: STORE_IDLE   (exit 1 — a true finding, not a bug)
newest_file: predictions_forecasting_20251127_125227.parquet (2025-11-27, 234 days)
total_files: 318   collections_found: ['production_forecasts', 'unfao']
real_collection_present: True
```
The shelf being idle is register **C-98**'s reality — now machine-visible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)