### PR TITLE
feat(liveness): S4 — FAO unfao_bucket delivery check (per-stream freshness) (#242)

### DIFF
--- a/tests/test_liveness_unfao_delivery.py
+++ b/tests/test_liveness_unfao_delivery.py
@@ -1,0 +1,168 @@
+"""Liveness S4: the FAO delivery bucket (unfao_bucket) — issue #242, epic #238.
+
+TDD suite written BEFORE the implementation. Ground truth captured live
+2026-07-19: bucket `unfao_bucket`, 18 files, two delivery streams —
+``forecast_dataset_*.parquet`` (newest 2026-03-10, ~191MB) and
+``historical_dataset_*.parquet`` (newest 2026-03-30, ~20MB). Real monthly
+deliveries ran Jan–Mar 2026, then stalled; nobody noticed (register C-99
+class). This check makes "when did FAO last receive anything?" a machine
+answer with per-stream verdicts.
+
+Unit tests are offline (fake fetch, fake credentials, injected clock).
+Credentials resolution is REUSED from tools.liveness.appwrite_store (same
+project, same .env — S7 will home it in a shared credentials module).
+"""
+
+from datetime import datetime, timezone
+
+import pytest
+
+from tools.liveness.appwrite_store import AppwriteCredentials
+from tools.liveness.unfao_delivery import (
+    UNFAO_BUCKET_ID,
+    CheckReport,
+    UnfaoDeliveryCheck,
+    main,
+    render,
+)
+
+pytestmark = pytest.mark.green
+
+NOW = datetime(2026, 7, 19, 12, 0, 0, tzinfo=timezone.utc)
+SENTINEL_KEY = "SECRET-KEY-NEVER-RENDER"
+CREDS = AppwriteCredentials("https://fra.cloud.appwrite.io/v1", "proj", SENTINEL_KEY)
+
+REAL_LISTING = {
+    "total": 18,
+    "files": [
+        {"$id": "h1", "$createdAt": "2026-03-30T09:48:45.000+00:00",
+         "name": "historical_dataset_20260330_114835.parquet", "sizeOriginal": 20_500_000},
+        {"$id": "f1", "$createdAt": "2026-03-10T10:47:48.000+00:00",
+         "name": "forecast_dataset_20260310_114703.parquet", "sizeOriginal": 191_400_000},
+        {"$id": "f2", "$createdAt": "2026-02-04T07:33:52.000+00:00",
+         "name": "forecast_dataset_20260204_083338.parquet", "sizeOriginal": 191_300_000},
+        {"$id": "x1", "$createdAt": "2026-01-01T00:00:00.000+00:00",
+         "name": "readme.txt", "sizeOriginal": 100},
+    ],
+}
+FRESH_LISTING = {
+    "total": 2,
+    "files": [
+        {"$id": "f", "$createdAt": "2026-07-10T08:00:00.000+00:00",
+         "name": "forecast_dataset_20260710_100000.parquet", "sizeOriginal": 190_000_000},
+        {"$id": "h", "$createdAt": "2026-07-11T08:00:00.000+00:00",
+         "name": "historical_dataset_20260711_100000.parquet", "sizeOriginal": 20_000_000},
+    ],
+}
+
+
+def _fake_fetch(responses):
+    def fetch(url, headers):
+        assert headers["X-Appwrite-Key"] == SENTINEL_KEY
+        for key, value in responses.items():
+            if key in url:
+                if isinstance(value, Exception):
+                    raise value
+                return value
+        raise AssertionError(f"unexpected url: {url}")
+    return fetch
+
+
+# ── verdicts on the real capture ──────────────────────────────────────
+
+def test_both_streams_stalled_on_real_capture():
+    fetch = _fake_fetch({UNFAO_BUCKET_ID: REAL_LISTING})
+    report = UnfaoDeliveryCheck(credentials=CREDS, fetch=fetch).run(now=NOW)
+    assert report.verdict == "DELIVERY_STALLED"
+    assert report.forecast_verdict == "STALLED"
+    assert report.historical_verdict == "STALLED"
+    assert report.forecast_newest_name == "forecast_dataset_20260310_114703.parquet"
+    assert report.forecast_days_since == 131
+    assert report.historical_newest_name == "historical_dataset_20260330_114835.parquet"
+    assert report.historical_days_since == 111
+    assert report.other_files == 1  # readme.txt matches neither stream
+
+def test_delivering_when_both_streams_recent():
+    fetch = _fake_fetch({UNFAO_BUCKET_ID: FRESH_LISTING})
+    report = UnfaoDeliveryCheck(credentials=CREDS, fetch=fetch).run(now=NOW)
+    assert report.verdict == "DELIVERING"
+    assert report.forecast_verdict == "DELIVERING"
+    assert report.historical_verdict == "DELIVERING"
+
+def test_mixed_streams_yield_overall_stalled():
+    mixed = {"total": 2, "files": [
+        {"$id": "f", "$createdAt": "2026-07-10T08:00:00.000+00:00",
+         "name": "forecast_dataset_x.parquet", "sizeOriginal": 1},
+        {"$id": "h", "$createdAt": "2026-03-30T09:48:45.000+00:00",
+         "name": "historical_dataset_y.parquet", "sizeOriginal": 1},
+    ]}
+    report = UnfaoDeliveryCheck(credentials=CREDS, fetch=_fake_fetch({UNFAO_BUCKET_ID: mixed})).run(now=NOW)
+    assert report.forecast_verdict == "DELIVERING"
+    assert report.historical_verdict == "STALLED"
+    assert report.verdict == "DELIVERY_STALLED"
+
+def test_missing_stream_reported_as_never_delivered():
+    only_hist = {"total": 1, "files": [
+        {"$id": "h", "$createdAt": "2026-07-11T08:00:00.000+00:00",
+         "name": "historical_dataset_z.parquet", "sizeOriginal": 1},
+    ]}
+    report = UnfaoDeliveryCheck(credentials=CREDS, fetch=_fake_fetch({UNFAO_BUCKET_ID: only_hist})).run(now=NOW)
+    assert report.forecast_verdict == "NEVER_DELIVERED"
+    assert report.verdict == "DELIVERY_STALLED"
+
+def test_unreachable_when_fetch_fails():
+    report = UnfaoDeliveryCheck(credentials=CREDS,
+                                fetch=_fake_fetch({UNFAO_BUCKET_ID: OSError("dns fail")})).run(now=NOW)
+    assert report.verdict == "UNREACHABLE"
+    assert "dns fail" in (report.error or "")
+
+def test_skip_when_no_credentials():
+    report = UnfaoDeliveryCheck(credentials=None, fetch=_fake_fetch({})).run(now=NOW)
+    assert report.verdict == "SKIP_NO_CREDENTIALS"
+
+
+# ── raw facts + redaction ─────────────────────────────────────────────
+
+def test_render_facts_and_redaction():
+    fetch = _fake_fetch({UNFAO_BUCKET_ID: REAL_LISTING})
+    text = render(UnfaoDeliveryCheck(credentials=CREDS, fetch=fetch).run(now=NOW))
+    lines = text.strip().splitlines()
+    assert all(":" in line for line in lines)
+    assert SENTINEL_KEY not in text
+    assert any("forecast_dataset_20260310_114703.parquet" in line for line in lines)
+    assert any("DELIVERY_STALLED" in line for line in lines)
+
+
+# ── exit codes ────────────────────────────────────────────────────────
+
+def test_exit_zero_delivering(capsys):
+    fetch = _fake_fetch({UNFAO_BUCKET_ID: FRESH_LISTING})
+    assert main(check=UnfaoDeliveryCheck(credentials=CREDS, fetch=fetch), now=NOW) == 0
+
+def test_exit_zero_skip(capsys):
+    assert main(check=UnfaoDeliveryCheck(credentials=None, fetch=_fake_fetch({})), now=NOW) == 0
+
+def test_exit_one_stalled(capsys):
+    fetch = _fake_fetch({UNFAO_BUCKET_ID: REAL_LISTING})
+    assert main(check=UnfaoDeliveryCheck(credentials=CREDS, fetch=fetch), now=NOW) == 1
+
+def test_exit_two_unreachable(capsys):
+    fetch = _fake_fetch({UNFAO_BUCKET_ID: OSError("boom")})
+    assert main(check=UnfaoDeliveryCheck(credentials=CREDS, fetch=fetch), now=NOW) == 2
+
+
+# ── live integration (creds + network; skips truthfully) ──────────────
+
+@pytest.mark.red
+def test_live_unfao_delivery_invariants():
+    check = UnfaoDeliveryCheck()
+    if check.credentials is None:
+        pytest.skip("no Appwrite credentials resolvable in this environment")
+    try:
+        report = check.run()
+    except Exception as e:  # noqa: BLE001
+        pytest.skip(f"unfao bucket unreachable: {type(e).__name__}: {e}")
+    if report.verdict == "UNREACHABLE":
+        pytest.skip(f"unfao bucket unreachable: {report.error}")
+    assert report.total_files and report.total_files > 0
+    assert report.forecast_newest_name is not None

--- a/tools/liveness/unfao_delivery.py
+++ b/tools/liveness/unfao_delivery.py
@@ -1,0 +1,210 @@
+"""Liveness check for the FAO delivery bucket (unfao_bucket).
+
+Answers, with raw facts: when did FAO last actually receive anything —
+per delivery stream? The bucket carries two streams (verified live
+2026-07-19; register context: real monthly deliveries ran Jan–Mar 2026,
+then stalled unnoticed):
+
+    forecast_dataset_*.parquet    (~191MB — the forecast delivery)
+    historical_dataset_*.parquet  (~20MB  — the historical actuals delivery)
+
+Usage:
+    python -m tools.liveness.unfao_delivery   # exit 0 delivering/skip / 1 stalled / 2 unreachable
+
+Credentials are REUSED from tools.liveness.appwrite_store (same Appwrite
+project + .env; S7 will home this in a shared credentials module — noted,
+deliberate). Design mirrors the sibling checks: injected fetch/credentials/
+clock (DIP), lazy stdlib urllib, no import-time side effects (C-93),
+secrets never rendered, truthful SKIP without credentials.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Callable, Dict, Optional, Tuple
+
+from tools.liveness.appwrite_store import (
+    AppwriteCredentials,
+    resolve_credentials,
+)
+
+UNFAO_BUCKET_ID = "unfao_bucket"
+FORECAST_PREFIX = "forecast_dataset_"
+HISTORICAL_PREFIX = "historical_dataset_"
+
+# Monthly delivery cadence: a stream is "delivering" if something landed
+# within ~1.5 cycles.
+DELIVERING_WITHIN_DAYS = 45
+
+_FETCH_TIMEOUT_SECONDS = 25
+
+FetchJson = Callable[[str, Dict[str, str]], object]
+
+
+@dataclass(frozen=True)
+class CheckReport:
+    """Raw facts about the FAO delivery bucket — no narration."""
+
+    verdict: str  # DELIVERING | DELIVERY_STALLED | UNREACHABLE | SKIP_NO_CREDENTIALS
+    endpoint: Optional[str] = None
+    bucket: str = UNFAO_BUCKET_ID
+    total_files: Optional[int] = None
+    forecast_verdict: Optional[str] = None  # DELIVERING | STALLED | NEVER_DELIVERED
+    forecast_newest_name: Optional[str] = None
+    forecast_newest_created: Optional[str] = None
+    forecast_newest_bytes: Optional[int] = None
+    forecast_days_since: Optional[int] = None
+    historical_verdict: Optional[str] = None
+    historical_newest_name: Optional[str] = None
+    historical_newest_created: Optional[str] = None
+    historical_newest_bytes: Optional[int] = None
+    historical_days_since: Optional[int] = None
+    other_files: Optional[int] = None
+    error: Optional[str] = None
+
+
+def render(report: CheckReport) -> str:
+    """One fact per line, ``key: value``; key material never appears."""
+    facts = [
+        ("surface", "unfao_delivery"),
+        ("verdict", report.verdict),
+        ("endpoint", report.endpoint),
+        ("bucket", report.bucket),
+        ("total_files", report.total_files),
+        ("delivering_within_days", DELIVERING_WITHIN_DAYS),
+        ("forecast_verdict", report.forecast_verdict),
+        ("forecast_newest_name", report.forecast_newest_name),
+        ("forecast_newest_created", report.forecast_newest_created),
+        ("forecast_newest_bytes", report.forecast_newest_bytes),
+        ("forecast_days_since", report.forecast_days_since),
+        ("historical_verdict", report.historical_verdict),
+        ("historical_newest_name", report.historical_newest_name),
+        ("historical_newest_created", report.historical_newest_created),
+        ("historical_newest_bytes", report.historical_newest_bytes),
+        ("historical_days_since", report.historical_days_since),
+        ("other_files", report.other_files),
+        ("error", report.error),
+    ]
+    return "\n".join(f"{key}: {value}" for key, value in facts if value is not None)
+
+
+def _newest(files: list) -> Optional[dict]:
+    return max(files, key=lambda f: f.get("$createdAt", ""), default=None)
+
+
+class UnfaoDeliveryCheck:
+    """Per-stream freshness of the FAO delivery bucket (all seams injected)."""
+
+    def __init__(
+        self,
+        credentials: Optional[AppwriteCredentials] = "RESOLVE",  # type: ignore[assignment]
+        fetch: Optional[FetchJson] = None,
+    ) -> None:
+        self.credentials = (
+            resolve_credentials() if credentials == "RESOLVE" else credentials
+        )
+        self._fetch = fetch or self._fetch_json
+
+    def run(self, now: Optional[datetime] = None) -> CheckReport:
+        if self.credentials is None:
+            return CheckReport(
+                verdict="SKIP_NO_CREDENTIALS",
+                error="no Appwrite credentials in env or known .env files",
+            )
+        now = now or datetime.now(timezone.utc)
+        creds = self.credentials
+        headers = {
+            "X-Appwrite-Project": creds.project_id,
+            "X-Appwrite-Key": creds.api_key,
+        }
+
+        try:
+            listing = self._fetch(
+                f"{creds.endpoint}/storage/buckets/{UNFAO_BUCKET_ID}/files", headers
+            )
+            files = list(listing.get("files", []))  # type: ignore[union-attr]
+            total = int(listing.get("total", len(files)))  # type: ignore[union-attr]
+        except Exception as exc:  # noqa: BLE001 — any storage failure is the fact
+            return CheckReport(
+                verdict="UNREACHABLE",
+                endpoint=creds.endpoint,
+                error=f"{type(exc).__name__}: {exc}",
+            )
+
+        forecast_files = [f for f in files if str(f.get("name", "")).startswith(FORECAST_PREFIX)]
+        historical_files = [f for f in files if str(f.get("name", "")).startswith(HISTORICAL_PREFIX)]
+        other = len(files) - len(forecast_files) - len(historical_files)
+
+        f_verdict, f_facts = self._stream_verdict(forecast_files, now)
+        h_verdict, h_facts = self._stream_verdict(historical_files, now)
+
+        overall = (
+            "DELIVERING"
+            if f_verdict == "DELIVERING" and h_verdict == "DELIVERING"
+            else "DELIVERY_STALLED"
+        )
+
+        return CheckReport(
+            verdict=overall,
+            endpoint=creds.endpoint,
+            total_files=total,
+            forecast_verdict=f_verdict,
+            forecast_newest_name=f_facts[0],
+            forecast_newest_created=f_facts[1],
+            forecast_newest_bytes=f_facts[2],
+            forecast_days_since=f_facts[3],
+            historical_verdict=h_verdict,
+            historical_newest_name=h_facts[0],
+            historical_newest_created=h_facts[1],
+            historical_newest_bytes=h_facts[2],
+            historical_days_since=h_facts[3],
+            other_files=other,
+        )
+
+    @staticmethod
+    def _stream_verdict(
+        files: list, now: datetime
+    ) -> Tuple[str, Tuple[Optional[str], Optional[str], Optional[int], Optional[int]]]:
+        newest = _newest(files)
+        if newest is None:
+            return "NEVER_DELIVERED", (None, None, None, None)
+        created_text = str(newest["$createdAt"])
+        created = datetime.fromisoformat(created_text.replace("Z", "+00:00"))
+        days = (now - created).days
+        verdict = "DELIVERING" if days <= DELIVERING_WITHIN_DAYS else "STALLED"
+        return verdict, (
+            str(newest.get("name")),
+            created_text[:19],
+            newest.get("sizeOriginal"),
+            days,
+        )
+
+    @staticmethod
+    def _fetch_json(url: str, headers: Dict[str, str]) -> object:
+        """Default fetch: stdlib urllib, lazy import, explicit timeout."""
+        import json
+        import urllib.request
+
+        request = urllib.request.Request(url, headers=headers)
+        with urllib.request.urlopen(request, timeout=_FETCH_TIMEOUT_SECONDS) as response:
+            return json.load(response)
+
+
+_EXIT_CODE_BY_VERDICT = {
+    "DELIVERING": 0,
+    "SKIP_NO_CREDENTIALS": 0,
+    "DELIVERY_STALLED": 1,
+    "UNREACHABLE": 2,
+}
+
+
+def main(check: Optional[UnfaoDeliveryCheck] = None, now: Optional[datetime] = None) -> int:
+    """Run the check, print raw facts, return the exit code."""
+    report = (check or UnfaoDeliveryCheck()).run(now=now)
+    print(render(report))
+    return _EXIT_CODE_BY_VERDICT[report.verdict]
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Story S4 of **epic #238** (tracking #247). Closes #242.

`python -m tools.liveness.unfao_delivery` — per-stream FAO delivery freshness. TDD 12 tests (fixtures = the real listing; day-counts hand-verified after the S3 off-by-one lesson). Creds reused from S3's resolver (S7 extracts to a shared module — flagged in-code).

**First live run (2026-07-19):**
```
verdict: DELIVERY_STALLED   (exit 1 — true finding)
forecast:   STALLED, newest 2026-03-10 (131 days, 191MB)
historical: STALLED, newest 2026-03-30 (111 days, 20MB)
```
The Jan–Mar delivery run and its silent 4-month stall are now facts a machine reports, not chat-transcript archaeology.

🤖 Generated with [Claude Code](https://claude.com/claude-code)