### PR TITLE
fix(liveness): Appwrite server-side ordering — pagination bug gave a false idle verdict

### DIFF
--- a/tests/test_liveness_appwrite_store.py
+++ b/tests/test_liveness_appwrite_store.py
@@ -6,7 +6,10 @@ TDD suite written BEFORE the implementation. Ground truth captured live
     database  id='file_metadata'          name='File Metadata'
     collection id='production_forecasts'  name='Production Forecasts'
     collection id='unfao'                 name='UNFAO File Metadata'
-    bucket 'production_forecasts': 318 files, newest 2025-11-27 (~34KB stubs)
+    bucket 'production_forecasts': 318 files. NOTE: an early forensic pass
+    claimed 'newest 2025-11-27' — that was the PAGINATION BUG (Appwrite's
+    25-per-page default, unsorted); the true newest was 2026-06-29. The
+    check now orders server-side; the regression test below pins it.
 
 The June 2026 live failure used collection ID 'forecasts_metadata' — which
 does not exist and never did (register C-100's founding incident). This
@@ -142,6 +145,26 @@ def test_empty_bucket_is_idle_with_no_newest():
     report = AppwriteStoreCheck(credentials=CREDS, fetch=fetch).run(now=NOW)
     assert report.verdict == "STORE_IDLE"
     assert report.newest_file_name is None
+
+
+
+
+# ── the pagination-bug regression (2026-07-19) ────────────────────────
+# Appwrite returns 25 files/page by default; sorting one page of a 318-file
+# bucket produced a FALSE "newest = 2025-11-27" (truth: 2026-06-29). The
+# storage request must order server-side.
+
+def test_storage_request_orders_server_side():
+    captured = []
+    def recording_fetch(url, headers):
+        captured.append(url)
+        if "/storage/" in url:
+            return FILES_DOC
+        return COLLECTIONS_DOC
+    AppwriteStoreCheck(credentials=CREDS, fetch=recording_fetch).run(now=NOW)
+    storage_urls = [u for u in captured if "/storage/" in u]
+    assert storage_urls and "orderDesc" in storage_urls[0]
+    assert "createdAt" in storage_urls[0]
 
 
 # ── collection discovery facts ────────────────────────────────────────

--- a/tests/test_liveness_unfao_delivery.py
+++ b/tests/test_liveness_unfao_delivery.py
@@ -32,29 +32,34 @@ NOW = datetime(2026, 7, 19, 12, 0, 0, tzinfo=timezone.utc)
 SENTINEL_KEY = "SECRET-KEY-NEVER-RENDER"
 CREDS = AppwriteCredentials("https://fra.cloud.appwrite.io/v1", "proj", SENTINEL_KEY)
 
-REAL_LISTING = {
-    "total": 18,
-    "files": [
-        {"$id": "h1", "$createdAt": "2026-03-30T09:48:45.000+00:00",
-         "name": "historical_dataset_20260330_114835.parquet", "sizeOriginal": 20_500_000},
-        {"$id": "f1", "$createdAt": "2026-03-10T10:47:48.000+00:00",
-         "name": "forecast_dataset_20260310_114703.parquet", "sizeOriginal": 191_400_000},
-        {"$id": "f2", "$createdAt": "2026-02-04T07:33:52.000+00:00",
-         "name": "forecast_dataset_20260204_083338.parquet", "sizeOriginal": 191_300_000},
-        {"$id": "x1", "$createdAt": "2026-01-01T00:00:00.000+00:00",
-         "name": "readme.txt", "sizeOriginal": 100},
-    ],
+REAL_FORECAST_DOC = {
+    "total": 9,
+    "files": [{"$id": "f1", "$createdAt": "2026-03-10T10:47:48.000+00:00",
+               "name": "forecast_dataset_20260310_114703.parquet", "sizeOriginal": 191_400_000}],
 }
-FRESH_LISTING = {
-    "total": 2,
-    "files": [
-        {"$id": "f", "$createdAt": "2026-07-10T08:00:00.000+00:00",
-         "name": "forecast_dataset_20260710_100000.parquet", "sizeOriginal": 190_000_000},
-        {"$id": "h", "$createdAt": "2026-07-11T08:00:00.000+00:00",
-         "name": "historical_dataset_20260711_100000.parquet", "sizeOriginal": 20_000_000},
-    ],
+REAL_HISTORICAL_DOC = {
+    "total": 8,
+    "files": [{"$id": "h1", "$createdAt": "2026-03-30T09:48:45.000+00:00",
+               "name": "historical_dataset_20260330_114835.parquet", "sizeOriginal": 20_500_000}],
 }
+REAL_OVERALL_DOC = {"total": 18, "files": []}
 
+FRESH_FORECAST_DOC = {
+    "total": 1,
+    "files": [{"$id": "f", "$createdAt": "2026-07-10T08:00:00.000+00:00",
+               "name": "forecast_dataset_20260710_100000.parquet", "sizeOriginal": 190_000_000}],
+}
+FRESH_HISTORICAL_DOC = {
+    "total": 1,
+    "files": [{"$id": "h", "$createdAt": "2026-07-11T08:00:00.000+00:00",
+               "name": "historical_dataset_20260711_100000.parquet", "sizeOriginal": 20_000_000}],
+}
+FRESH_OVERALL_DOC = {"total": 2, "files": []}
+
+def _responses(forecast, historical, overall):
+    # order matters: stream keys first, catch-all base last
+    return {"forecast_dataset_": forecast, "historical_dataset_": historical,
+            "unfao_bucket/files": overall}
 
 def _fake_fetch(responses):
     def fetch(url, headers):
@@ -71,7 +76,7 @@ def _fake_fetch(responses):
 # ── verdicts on the real capture ──────────────────────────────────────
 
 def test_both_streams_stalled_on_real_capture():
-    fetch = _fake_fetch({UNFAO_BUCKET_ID: REAL_LISTING})
+    fetch = _fake_fetch(_responses(REAL_FORECAST_DOC, REAL_HISTORICAL_DOC, REAL_OVERALL_DOC))
     report = UnfaoDeliveryCheck(credentials=CREDS, fetch=fetch).run(now=NOW)
     assert report.verdict == "DELIVERY_STALLED"
     assert report.forecast_verdict == "STALLED"
@@ -83,36 +88,28 @@ def test_both_streams_stalled_on_real_capture():
     assert report.other_files == 1  # readme.txt matches neither stream
 
 def test_delivering_when_both_streams_recent():
-    fetch = _fake_fetch({UNFAO_BUCKET_ID: FRESH_LISTING})
+    fetch = _fake_fetch(_responses(FRESH_FORECAST_DOC, FRESH_HISTORICAL_DOC, FRESH_OVERALL_DOC))
     report = UnfaoDeliveryCheck(credentials=CREDS, fetch=fetch).run(now=NOW)
     assert report.verdict == "DELIVERING"
     assert report.forecast_verdict == "DELIVERING"
     assert report.historical_verdict == "DELIVERING"
 
 def test_mixed_streams_yield_overall_stalled():
-    mixed = {"total": 2, "files": [
-        {"$id": "f", "$createdAt": "2026-07-10T08:00:00.000+00:00",
-         "name": "forecast_dataset_x.parquet", "sizeOriginal": 1},
-        {"$id": "h", "$createdAt": "2026-03-30T09:48:45.000+00:00",
-         "name": "historical_dataset_y.parquet", "sizeOriginal": 1},
-    ]}
-    report = UnfaoDeliveryCheck(credentials=CREDS, fetch=_fake_fetch({UNFAO_BUCKET_ID: mixed})).run(now=NOW)
+    fetch = _fake_fetch(_responses(FRESH_FORECAST_DOC, REAL_HISTORICAL_DOC, {"total": 2, "files": []}))
+    report = UnfaoDeliveryCheck(credentials=CREDS, fetch=fetch).run(now=NOW)
     assert report.forecast_verdict == "DELIVERING"
     assert report.historical_verdict == "STALLED"
     assert report.verdict == "DELIVERY_STALLED"
 
 def test_missing_stream_reported_as_never_delivered():
-    only_hist = {"total": 1, "files": [
-        {"$id": "h", "$createdAt": "2026-07-11T08:00:00.000+00:00",
-         "name": "historical_dataset_z.parquet", "sizeOriginal": 1},
-    ]}
-    report = UnfaoDeliveryCheck(credentials=CREDS, fetch=_fake_fetch({UNFAO_BUCKET_ID: only_hist})).run(now=NOW)
+    fetch = _fake_fetch(_responses({"total": 0, "files": []}, FRESH_HISTORICAL_DOC, {"total": 1, "files": []}))
+    report = UnfaoDeliveryCheck(credentials=CREDS, fetch=fetch).run(now=NOW)
     assert report.forecast_verdict == "NEVER_DELIVERED"
     assert report.verdict == "DELIVERY_STALLED"
 
 def test_unreachable_when_fetch_fails():
     report = UnfaoDeliveryCheck(credentials=CREDS,
-                                fetch=_fake_fetch({UNFAO_BUCKET_ID: OSError("dns fail")})).run(now=NOW)
+                                fetch=_fake_fetch({"unfao_bucket/files": OSError("dns fail")})).run(now=NOW)
     assert report.verdict == "UNREACHABLE"
     assert "dns fail" in (report.error or "")
 
@@ -124,7 +121,7 @@ def test_skip_when_no_credentials():
 # ── raw facts + redaction ─────────────────────────────────────────────
 
 def test_render_facts_and_redaction():
-    fetch = _fake_fetch({UNFAO_BUCKET_ID: REAL_LISTING})
+    fetch = _fake_fetch(_responses(REAL_FORECAST_DOC, REAL_HISTORICAL_DOC, REAL_OVERALL_DOC))
     text = render(UnfaoDeliveryCheck(credentials=CREDS, fetch=fetch).run(now=NOW))
     lines = text.strip().splitlines()
     assert all(":" in line for line in lines)
@@ -136,18 +133,18 @@ def test_render_facts_and_redaction():
 # ── exit codes ────────────────────────────────────────────────────────
 
 def test_exit_zero_delivering(capsys):
-    fetch = _fake_fetch({UNFAO_BUCKET_ID: FRESH_LISTING})
+    fetch = _fake_fetch(_responses(FRESH_FORECAST_DOC, FRESH_HISTORICAL_DOC, FRESH_OVERALL_DOC))
     assert main(check=UnfaoDeliveryCheck(credentials=CREDS, fetch=fetch), now=NOW) == 0
 
 def test_exit_zero_skip(capsys):
     assert main(check=UnfaoDeliveryCheck(credentials=None, fetch=_fake_fetch({})), now=NOW) == 0
 
 def test_exit_one_stalled(capsys):
-    fetch = _fake_fetch({UNFAO_BUCKET_ID: REAL_LISTING})
+    fetch = _fake_fetch(_responses(REAL_FORECAST_DOC, REAL_HISTORICAL_DOC, REAL_OVERALL_DOC))
     assert main(check=UnfaoDeliveryCheck(credentials=CREDS, fetch=fetch), now=NOW) == 1
 
 def test_exit_two_unreachable(capsys):
-    fetch = _fake_fetch({UNFAO_BUCKET_ID: OSError("boom")})
+    fetch = _fake_fetch({"unfao_bucket/files": OSError("boom")})
     assert main(check=UnfaoDeliveryCheck(credentials=CREDS, fetch=fetch), now=NOW) == 2
 
 

--- a/tools/liveness/appwrite_store.py
+++ b/tools/liveness/appwrite_store.py
@@ -63,6 +63,23 @@ _ENV_LINE = re.compile(
 FetchJson = Callable[[str, Dict[str, str]], object]
 
 
+def newest_first_query(limit: int = 5) -> str:
+    """Appwrite query string: order by $createdAt descending, capped.
+
+    Encoded once so every bucket listing in this package is immune to the
+    25-per-page default that produced the 2026-07-19 false-idle verdict.
+    """
+    import json as _json
+    from urllib.parse import quote as _quote
+
+    queries = (
+        {"method": "orderDesc", "attribute": "$createdAt"},
+        {"method": "limit", "values": [limit]},
+    )
+    return "&".join("queries[]=" + _quote(_json.dumps(q)) for q in queries)
+
+
+
 @dataclass(frozen=True)
 class AppwriteCredentials:
     endpoint: str
@@ -179,8 +196,14 @@ class AppwriteStoreCheck:
         }
 
         try:
+            # Server-side newest-first + limit: Appwrite returns 25/page by
+            # default, and an unsorted first page of a large bucket made this
+            # check report a FALSE newest (the 2026-07-19 pagination bug —
+            # pinned by test_storage_request_orders_server_side).
             listing = self._fetch(
-                f"{creds.endpoint}/storage/buckets/{APPWRITE_BUCKET_ID}/files", headers
+                f"{creds.endpoint}/storage/buckets/{APPWRITE_BUCKET_ID}/files"
+                f"?{newest_first_query()}",
+                headers,
             )
             files = list(listing.get("files", []))  # type: ignore[union-attr]
             total = int(listing.get("total", len(files)))  # type: ignore[union-attr]

--- a/tools/liveness/unfao_delivery.py
+++ b/tools/liveness/unfao_delivery.py
@@ -26,6 +26,7 @@ from typing import Callable, Dict, Optional, Tuple
 
 from tools.liveness.appwrite_store import (
     AppwriteCredentials,
+    newest_first_query,
     resolve_credentials,
 )
 
@@ -40,6 +41,20 @@ DELIVERING_WITHIN_DAYS = 45
 _FETCH_TIMEOUT_SECONDS = 25
 
 FetchJson = Callable[[str, Dict[str, str]], object]
+
+
+def stream_newest_query(prefix: str) -> str:
+    """Appwrite query string: newest file whose name starts with ``prefix``."""
+    import json as _json
+    from urllib.parse import quote as _quote
+
+    queries = (
+        {"method": "startsWith", "attribute": "name", "values": [prefix]},
+        {"method": "orderDesc", "attribute": "$createdAt"},
+        {"method": "limit", "values": [1]},
+    )
+    return "&".join("queries[]=" + _quote(_json.dumps(q)) for q in queries)
+
 
 
 @dataclass(frozen=True)
@@ -119,12 +134,19 @@ class UnfaoDeliveryCheck:
             "X-Appwrite-Key": creds.api_key,
         }
 
+        base = f"{creds.endpoint}/storage/buckets/{UNFAO_BUCKET_ID}/files"
         try:
-            listing = self._fetch(
-                f"{creds.endpoint}/storage/buckets/{UNFAO_BUCKET_ID}/files", headers
+            # Per-stream server-side newest (startsWith + orderDesc + limit):
+            # immune to Appwrite's 25-per-page default (the 2026-07-19
+            # pagination bug found in the sibling check).
+            overall = self._fetch(f"{base}?{newest_first_query(limit=1)}", headers)
+            total = int(overall.get("total", 0))  # type: ignore[union-attr]
+            forecast_doc = self._fetch(
+                f"{base}?{stream_newest_query(FORECAST_PREFIX)}", headers
             )
-            files = list(listing.get("files", []))  # type: ignore[union-attr]
-            total = int(listing.get("total", len(files)))  # type: ignore[union-attr]
+            historical_doc = self._fetch(
+                f"{base}?{stream_newest_query(HISTORICAL_PREFIX)}", headers
+            )
         except Exception as exc:  # noqa: BLE001 — any storage failure is the fact
             return CheckReport(
                 verdict="UNREACHABLE",
@@ -132,9 +154,11 @@ class UnfaoDeliveryCheck:
                 error=f"{type(exc).__name__}: {exc}",
             )
 
-        forecast_files = [f for f in files if str(f.get("name", "")).startswith(FORECAST_PREFIX)]
-        historical_files = [f for f in files if str(f.get("name", "")).startswith(HISTORICAL_PREFIX)]
-        other = len(files) - len(forecast_files) - len(historical_files)
+        forecast_files = list(forecast_doc.get("files", []))  # type: ignore[union-attr]
+        historical_files = list(historical_doc.get("files", []))  # type: ignore[union-attr]
+        forecast_total = int(forecast_doc.get("total", 0))  # type: ignore[union-attr]
+        historical_total = int(historical_doc.get("total", 0))  # type: ignore[union-attr]
+        other = total - forecast_total - historical_total
 
         f_verdict, f_facts = self._stream_verdict(forecast_files, now)
         h_verdict, h_facts = self._stream_verdict(historical_files, now)


### PR DESCRIPTION
Follow-up fix to S3/S4 (#241, #242, epic #238). Investigating the maintainer's routing question exposed that my forensic 'shelf idle since November' — and the shipped S3 check's live verdict — were artifacts of **Appwrite's 25-per-page default** (one unsorted page of 318 files). Truth, server-sorted: **newest = 2026-06-29** — the June monthlies DID upload to the shelf. Both checks now order server-side (regression-tested); S4 gains per-stream server-side newest + totals.

**Corrected live verdicts:** `production_forecasts` → **STORE_ACTIVE** (19 days; and the **July 15 runs did not upload** — real finding). `unfao_bucket` → DELIVERY_STALLED unchanged (131/111 days).

The instrument caught its own class of error within hours of shipping — which is the whole point of having it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)