### PR TITLE
feat(liveness): S5 — wandb execution check (did the team compute this cycle?) (#243)

### DIFF
--- a/tests/test_liveness_wandb_execution.py
+++ b/tests/test_liveness_wandb_execution.py
@@ -1,0 +1,154 @@
+"""Liveness S5: wandb execution recency — issue #243, epic #238.
+
+TDD suite written BEFORE the implementation. The check answers: "did the
+team compute this cycle?" — the question that started the 2026-07-19 trust
+crisis, answered then by hand-probing wandb. Ground truth from that probe
+(entity views_pipeline, project naming '{name}_forecasting' per pipeline-core
+model.py:983):
+
+    pink_ponyclub_forecasting  latest finished 2026-06-29T16:56:27
+    skinny_love_forecasting    latest finished 2026-06-29T21:06:00
+    rude_boy_forecasting       latest finished 2026-07-15T15:49:03
+    first_love_forecasting     latest finished 2026-07-15T15:11:37
+
+Each run's config also records its train-window end (the data-cutoff receipt
+that resolved the run-naming ambiguity: June-29 runs trained to month 557).
+
+Unit tests are offline (injected client + clock); the live test is
+@pytest.mark.red and skips truthfully.
+"""
+
+from datetime import datetime, timezone
+
+import pytest
+
+from tools.liveness.wandb_execution import (
+    CYCLE_BUDGET_DAYS,
+    MONTHLY_ENSEMBLES,
+    CheckReport,
+    EnsembleRun,
+    WandbExecutionCheck,
+    main,
+    render,
+)
+
+pytestmark = pytest.mark.green
+
+NOW = datetime(2026, 7, 19, 12, 0, 0, tzinfo=timezone.utc)
+
+REAL_FACTS = {
+    "pink_ponyclub_forecasting": {"run_name": "vivid-flower-127", "created_at": "2026-06-29T16:56:27", "state": "finished", "train_end_month_id": 557},
+    "skinny_love_forecasting": {"run_name": "sage-shape-97", "created_at": "2026-06-29T21:06:00", "state": "finished", "train_end_month_id": 557},
+    "rude_boy_forecasting": {"run_name": "zesty-energy-67", "created_at": "2026-07-15T15:49:03", "state": "finished", "train_end_month_id": 558},
+    "first_love_forecasting": {"run_name": "brisk-cloud-7", "created_at": "2026-07-15T15:11:37", "state": "finished", "train_end_month_id": 558},
+}
+
+
+def _client(facts):
+    def latest_run(project):
+        value = facts.get(project)
+        if isinstance(value, Exception):
+            raise value
+        return value
+    return latest_run
+
+
+# ── the ensemble list is encoded, with its receipt ────────────────────
+
+def test_monthly_ensembles_mirror_the_bash_list():
+    assert MONTHLY_ENSEMBLES == ("pink_ponyclub", "skinny_love", "rude_boy", "first_love")
+
+
+# ── verdicts ──────────────────────────────────────────────────────────
+
+def test_current_when_all_recent():
+    report = WandbExecutionCheck(latest_run=_client(REAL_FACTS), netrc_probe=lambda: True).run(now=NOW)
+    assert report.verdict == "EXECUTION_CURRENT"
+    by_name = {e.ensemble: e for e in report.ensembles}
+    assert by_name["pink_ponyclub"].days_since == 19
+    assert by_name["first_love"].days_since == 3
+    assert by_name["rude_boy"].train_end_month_id == 558
+    assert all(e.verdict == "COMPUTED" for e in report.ensembles)
+
+def test_stale_when_one_ensemble_old():
+    facts = dict(REAL_FACTS)
+    facts["pink_ponyclub_forecasting"] = {"run_name": "old", "created_at": "2026-03-01T00:00:00", "state": "finished", "train_end_month_id": 553}
+    report = WandbExecutionCheck(latest_run=_client(facts), netrc_probe=lambda: True).run(now=NOW)
+    assert report.verdict == "EXECUTION_STALE"
+    by_name = {e.ensemble: e for e in report.ensembles}
+    assert by_name["pink_ponyclub"].verdict == "NOT_COMPUTED"
+    assert by_name["pink_ponyclub"].days_since == 140
+
+def test_missing_project_is_never_run():
+    facts = dict(REAL_FACTS)
+    facts["rude_boy_forecasting"] = None
+    report = WandbExecutionCheck(latest_run=_client(facts), netrc_probe=lambda: True).run(now=NOW)
+    by_name = {e.ensemble: e for e in report.ensembles}
+    assert by_name["rude_boy"].verdict == "NEVER_RUN"
+    assert report.verdict == "EXECUTION_STALE"
+
+def test_unfinished_latest_run_is_not_computed():
+    facts = dict(REAL_FACTS)
+    facts["skinny_love_forecasting"] = {"run_name": "crashed-1", "created_at": "2026-07-18T00:00:00", "state": "crashed", "train_end_month_id": None}
+    report = WandbExecutionCheck(latest_run=_client(facts), netrc_probe=lambda: True).run(now=NOW)
+    by_name = {e.ensemble: e for e in report.ensembles}
+    assert by_name["skinny_love"].verdict == "NOT_COMPUTED"
+    assert report.verdict == "EXECUTION_STALE"
+
+def test_unreachable_when_client_fails():
+    facts = {p: OSError("api down") for p in REAL_FACTS}
+    report = WandbExecutionCheck(latest_run=_client(facts), netrc_probe=lambda: True).run(now=NOW)
+    assert report.verdict == "UNREACHABLE"
+    assert "api down" in (report.error or "")
+
+def test_skip_when_no_netrc():
+    report = WandbExecutionCheck(latest_run=_client(REAL_FACTS), netrc_probe=lambda: False).run(now=NOW)
+    assert report.verdict == "SKIP_NO_CREDENTIALS"
+
+
+# ── raw facts ─────────────────────────────────────────────────────────
+
+def test_render_per_ensemble_facts():
+    text = render(WandbExecutionCheck(latest_run=_client(REAL_FACTS), netrc_probe=lambda: True).run(now=NOW))
+    lines = text.strip().splitlines()
+    assert all(":" in line for line in lines)
+    assert any("EXECUTION_CURRENT" in line for line in lines)
+    assert any("pink_ponyclub" in line and "2026-06-29" in line for line in lines)
+    assert any("train_end" in line and "558" in line for line in lines)
+
+
+# ── exit codes ────────────────────────────────────────────────────────
+
+def test_exit_zero_current(capsys):
+    check = WandbExecutionCheck(latest_run=_client(REAL_FACTS), netrc_probe=lambda: True)
+    assert main(check=check, now=NOW) == 0
+
+def test_exit_zero_skip(capsys):
+    check = WandbExecutionCheck(latest_run=_client(REAL_FACTS), netrc_probe=lambda: False)
+    assert main(check=check, now=NOW) == 0
+
+def test_exit_one_stale(capsys):
+    facts = dict(REAL_FACTS)
+    facts["first_love_forecasting"] = None
+    check = WandbExecutionCheck(latest_run=_client(facts), netrc_probe=lambda: True)
+    assert main(check=check, now=NOW) == 1
+
+def test_exit_two_unreachable(capsys):
+    facts = {p: OSError("down") for p in REAL_FACTS}
+    check = WandbExecutionCheck(latest_run=_client(facts), netrc_probe=lambda: True)
+    assert main(check=check, now=NOW) == 2
+
+
+# ── live integration (netrc + network; skips truthfully) ──────────────
+
+@pytest.mark.red
+def test_live_wandb_execution_invariants():
+    check = WandbExecutionCheck()
+    try:
+        report = check.run()
+    except Exception as e:  # noqa: BLE001
+        pytest.skip(f"wandb unreachable: {type(e).__name__}: {e}")
+    if report.verdict in ("UNREACHABLE", "SKIP_NO_CREDENTIALS"):
+        pytest.skip(f"wandb not checkable here: {report.verdict} {report.error or ''}")
+    assert len(report.ensembles) == len(MONTHLY_ENSEMBLES)
+    assert any(e.created_at is not None for e in report.ensembles)

--- a/tools/liveness/wandb_execution.py
+++ b/tools/liveness/wandb_execution.py
@@ -1,0 +1,227 @@
+"""Liveness check for monthly execution, via wandb run history.
+
+Answers, with raw facts: "did the team compute this cycle?" — per monthly
+ensemble, when did its latest finished forecasting run happen, and what
+data-cutoff month did it train to?
+
+Usage:
+    python -m tools.liveness.wandb_execution   # exit 0 current/skip / 1 stale / 2 unreachable
+
+Receipts encoded here (2026-07-19 forensics): wandb entity is
+``views_pipeline``; project naming is ``{name}_{run_type}`` (pipeline-core
+``model.py:983``) — monthly forecasting runs live in ``{name}_forecasting``.
+Each run's config records its forecasting train window; ``train[1]`` is the
+data-cutoff month_id (the receipt that resolved the run-naming ambiguity:
+the 2026-06-29 runs trained to month 557 = May, published as ``2026_05``).
+
+The monthly ensemble list mirrors ``monthly_run.sh`` — hand-encoded rather
+than parsed from bash (fragile); update BOTH when the roster changes.
+
+Design (house rules): injected latest-run client + netrc probe + clock
+(DIP), lazy wandb import inside the default client only, no import-time
+side effects (C-93), zero new dependencies (wandb is already installed),
+truthful SKIP without credentials (C-75).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Callable, Optional, Tuple
+
+WANDB_ENTITY = "views_pipeline"
+
+# Mirrors monthly_run.sh (the hand-run production list). Keep in sync by hand.
+MONTHLY_ENSEMBLES = ("pink_ponyclub", "skinny_love", "rude_boy", "first_love")
+
+# Monthly cadence + slack: an ensemble is "computed this cycle" if its latest
+# FINISHED forecasting run is at most this many days old.
+CYCLE_BUDGET_DAYS = 40
+
+# The injected client: project name -> facts dict or None (project/run absent).
+# Facts keys: run_name, created_at (ISO), state, train_end_month_id.
+LatestRunClient = Callable[[str], Optional[dict]]
+
+
+@dataclass(frozen=True)
+class EnsembleRun:
+    """Raw facts for one monthly ensemble's latest forecasting run."""
+
+    ensemble: str
+    project: str
+    verdict: str  # COMPUTED | NOT_COMPUTED | NEVER_RUN
+    run_name: Optional[str] = None
+    created_at: Optional[str] = None
+    state: Optional[str] = None
+    train_end_month_id: Optional[int] = None
+    days_since: Optional[int] = None
+
+
+@dataclass(frozen=True)
+class CheckReport:
+    """Raw facts about monthly execution — no narration."""
+
+    verdict: str  # EXECUTION_CURRENT | EXECUTION_STALE | UNREACHABLE | SKIP_NO_CREDENTIALS
+    entity: str = WANDB_ENTITY
+    netrc_present: Optional[bool] = None
+    ensembles: Tuple[EnsembleRun, ...] = ()
+    error: Optional[str] = None
+
+
+def render(report: CheckReport) -> str:
+    """One fact per line, ``key: value``; per-ensemble blocks are prefixed."""
+    lines = [
+        f"surface: wandb_execution",
+        f"verdict: {report.verdict}",
+        f"entity: {report.entity}",
+        f"cycle_budget_days: {CYCLE_BUDGET_DAYS}",
+    ]
+    if report.netrc_present is not None:
+        lines.append(f"netrc_present: {report.netrc_present}")
+    for run in report.ensembles:
+        prefix = run.ensemble
+        lines.append(f"{prefix}.verdict: {run.verdict}")
+        if run.run_name is not None:
+            lines.append(f"{prefix}.run: {run.run_name}")
+        if run.created_at is not None:
+            lines.append(f"{prefix}.created_at: {run.created_at}")
+        if run.state is not None:
+            lines.append(f"{prefix}.state: {run.state}")
+        if run.train_end_month_id is not None:
+            lines.append(f"{prefix}.train_end_month_id: {run.train_end_month_id}")
+        if run.days_since is not None:
+            lines.append(f"{prefix}.days_since: {run.days_since}")
+    if report.error is not None:
+        lines.append(f"error: {report.error}")
+    return "\n".join(lines)
+
+
+class WandbExecutionCheck:
+    """Per-ensemble execution recency via wandb (all seams injected)."""
+
+    def __init__(
+        self,
+        latest_run: Optional[LatestRunClient] = None,
+        netrc_probe: Optional[Callable[[], bool]] = None,
+    ) -> None:
+        self._latest_run = latest_run or self._latest_run_via_wandb
+        self._netrc_probe = netrc_probe or self._netrc_has_wandb_host
+
+    def run(self, now: Optional[datetime] = None) -> CheckReport:
+        netrc_present = self._safe_netrc_probe()
+        if netrc_present is False:
+            return CheckReport(
+                verdict="SKIP_NO_CREDENTIALS",
+                netrc_present=False,
+                error="no api.wandb.ai entry in ~/.netrc",
+            )
+        now = now or datetime.now(timezone.utc)
+
+        runs = []
+        failures = []
+        for ensemble in MONTHLY_ENSEMBLES:
+            project = f"{ensemble}_forecasting"
+            try:
+                facts = self._latest_run(project)
+            except Exception as exc:  # noqa: BLE001 — collected; all-fail => UNREACHABLE
+                failures.append(f"{project}: {type(exc).__name__}: {exc}")
+                continue
+            runs.append(self._judge(ensemble, project, facts, now))
+
+        if not runs:
+            return CheckReport(
+                verdict="UNREACHABLE",
+                netrc_present=netrc_present,
+                error="; ".join(failures) or "no projects reachable",
+            )
+
+        overall = (
+            "EXECUTION_CURRENT"
+            if len(runs) == len(MONTHLY_ENSEMBLES)
+            and all(r.verdict == "COMPUTED" for r in runs)
+            else "EXECUTION_STALE"
+        )
+        return CheckReport(
+            verdict=overall,
+            netrc_present=netrc_present,
+            ensembles=tuple(runs),
+            error="; ".join(failures) if failures else None,
+        )
+
+    @staticmethod
+    def _judge(
+        ensemble: str, project: str, facts: Optional[dict], now: datetime
+    ) -> EnsembleRun:
+        if facts is None:
+            return EnsembleRun(ensemble=ensemble, project=project, verdict="NEVER_RUN")
+        created_text = str(facts.get("created_at"))
+        created = datetime.fromisoformat(created_text.replace("Z", "+00:00"))
+        if created.tzinfo is None:
+            created = created.replace(tzinfo=timezone.utc)
+        days = (now - created).days
+        finished = facts.get("state") == "finished"
+        verdict = "COMPUTED" if finished and days <= CYCLE_BUDGET_DAYS else "NOT_COMPUTED"
+        return EnsembleRun(
+            ensemble=ensemble,
+            project=project,
+            verdict=verdict,
+            run_name=facts.get("run_name"),
+            created_at=created_text[:19],
+            state=facts.get("state"),
+            train_end_month_id=facts.get("train_end_month_id"),
+            days_since=days,
+        )
+
+    def _safe_netrc_probe(self) -> Optional[bool]:
+        try:
+            return bool(self._netrc_probe())
+        except Exception:  # noqa: BLE001 — the hint must never sink the check
+            return None
+
+    @staticmethod
+    def _netrc_has_wandb_host() -> bool:
+        import netrc
+
+        return netrc.netrc().authenticators("api.wandb.ai") is not None
+
+    @staticmethod
+    def _latest_run_via_wandb(project: str) -> Optional[dict]:
+        """Default client: wandb public API, lazy import, newest run only."""
+        import wandb
+
+        api = wandb.Api(timeout=25)
+        try:
+            runs = api.runs(f"{WANDB_ENTITY}/{project}", order="-created_at", per_page=1)
+            run = next(iter(runs), None)
+        except Exception as exc:
+            if "Could not find project" in str(exc):
+                return None
+            raise
+        if run is None:
+            return None
+        train = (run.config.get("forecasting") or {}).get("train") or (None, None)
+        return {
+            "run_name": run.name,
+            "created_at": run.created_at,
+            "state": run.state,
+            "train_end_month_id": train[1],
+        }
+
+
+_EXIT_CODE_BY_VERDICT = {
+    "EXECUTION_CURRENT": 0,
+    "SKIP_NO_CREDENTIALS": 0,
+    "EXECUTION_STALE": 1,
+    "UNREACHABLE": 2,
+}
+
+
+def main(check: Optional[WandbExecutionCheck] = None, now: Optional[datetime] = None) -> int:
+    """Run the check, print raw facts, return the exit code."""
+    report = (check or WandbExecutionCheck()).run(now=now)
+    print(render(report))
+    return _EXIT_CODE_BY_VERDICT[report.verdict]
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Story S5 of **epic #238** (tracking #247). Closes #243.

`python -m tools.liveness.wandb_execution` — per-ensemble execution recency with the train-window data-cutoff receipt surfaced per run. TDD 13 tests; injected client/netrc/clock seams; truthful SKIP; zero new deps.

**First live run (2026-07-19): EXECUTION_CURRENT** — all four monthly ensembles finished within budget (June-29 pair: 19 days, cutoff month 557; July-15 pair: 3 days, cutoff 558). The hand-probed evidence from the trust-crisis day is now a permanent instrument.

🤖 Generated with [Claude Code](https://claude.com/claude-code)