### PR TITLE
feat(liveness): S6 — VPN store (gjoll) check with truthful VPN_REQUIRED (#244)

### DIFF
--- a/tests/test_liveness_vpn_store.py
+++ b/tests/test_liveness_vpn_store.py
@@ -1,0 +1,132 @@
+"""Liveness S6: the VPN-only legacy store (gjoll) — issue #244, epic #238.
+
+TDD suite written BEFORE the implementation. The legacy prediction store is
+Postgres on ``gjoll.muspelheim.local`` (PRIO-internal, resolvable only on
+the PRIO VPN), accessed via ``views_forecasts.db_ops.ViewsMetadata`` whose
+constructor connects immediately; ``.get_runs()`` returns [name, description,
+min_month, max_month]. Off-VPN the connection dies with
+``could not translate host name "gjoll.muspelheim.local"`` — which must be
+the truthful verdict VPN_REQUIRED, never a false RED.
+
+Historical receipt encoded here: the store's Postgres schema is literally
+``forecasts_metadata`` — the origin of the phantom Appwrite collection ID
+that killed the June 2026 run (someone copied the legacy schema name into
+the new store's config).
+
+Run-name parsing and freshness reuse S1 (tools.liveness.old_api) — one
+parser, one convention, everywhere.
+"""
+
+from datetime import date
+
+import pytest
+
+from tools.liveness.old_api import FRESHNESS_BUDGET_MONTHS
+from tools.liveness.vpn_store import (
+    STORE_HOST,
+    CheckReport,
+    VpnStoreCheck,
+    main,
+    render,
+)
+from tools.partitions.domain import date_to_month_id
+
+pytestmark = pytest.mark.green
+
+CAPTURE_NOW = date_to_month_id(2026, 7)  # 559
+
+RUN_ROWS = [
+    {"name": "escwa_2021_02_01", "min_month": 400, "max_month": 460},
+    {"name": "fatalities003_2026_04_t01", "min_month": 121, "max_month": 592},
+    {"name": "fatalities003_2026_05_t01", "min_month": 121, "max_month": 593},
+    {"name": "r_2021_12_01", "min_month": 400, "max_month": 460},
+]
+
+
+def _client(value):
+    def list_runs():
+        if isinstance(value, Exception):
+            raise value
+        return value
+    return list_runs
+
+
+# ── verdicts ──────────────────────────────────────────────────────────
+
+def test_fresh_when_latest_within_budget():
+    report = VpnStoreCheck(list_runs=_client(RUN_ROWS)).run(now_month_id=CAPTURE_NOW)
+    assert report.verdict == "STORE_FRESH"
+    assert report.latest_run == "fatalities003_2026_05_t01"
+    assert report.months_behind == FRESHNESS_BUDGET_MONTHS == 2
+    assert report.latest_max_month == 593
+
+def test_stale_when_latest_beyond_budget():
+    report = VpnStoreCheck(list_runs=_client(RUN_ROWS)).run(now_month_id=CAPTURE_NOW + 3)
+    assert report.verdict == "STORE_STALE"
+    assert report.months_behind == 5
+
+def test_vpn_required_on_host_resolution_failure():
+    err = OSError('could not translate host name "gjoll.muspelheim.local" to address')
+    report = VpnStoreCheck(list_runs=_client(err)).run(now_month_id=CAPTURE_NOW)
+    assert report.verdict == "VPN_REQUIRED"
+    assert STORE_HOST in (report.error or "")
+
+def test_skip_when_package_missing():
+    report = VpnStoreCheck(list_runs=_client(ModuleNotFoundError("No module named 'ingester3'"))).run(
+        now_month_id=CAPTURE_NOW
+    )
+    assert report.verdict == "SKIP_NO_PACKAGE"
+
+def test_unreachable_on_other_errors():
+    report = VpnStoreCheck(list_runs=_client(RuntimeError("password authentication failed"))).run(
+        now_month_id=CAPTURE_NOW
+    )
+    assert report.verdict == "UNREACHABLE"
+    assert "password authentication" in (report.error or "")
+
+def test_no_fatalities_runs_is_stale_class():
+    rows = [{"name": "escwa_2021_02_01", "min_month": 1, "max_month": 2}]
+    report = VpnStoreCheck(list_runs=_client(rows)).run(now_month_id=CAPTURE_NOW)
+    assert report.verdict == "STORE_STALE"
+    assert report.latest_run is None
+
+
+# ── raw facts ─────────────────────────────────────────────────────────
+
+def test_render_facts():
+    text = render(VpnStoreCheck(list_runs=_client(RUN_ROWS)).run(now_month_id=CAPTURE_NOW))
+    lines = text.strip().splitlines()
+    assert all(":" in line for line in lines)
+    assert any(STORE_HOST in line for line in lines)
+    assert any("fatalities003_2026_05_t01" in line for line in lines)
+    assert any("forecasts_metadata" in line for line in lines)  # the schema receipt
+
+
+# ── exit codes ────────────────────────────────────────────────────────
+
+def test_exit_zero_fresh(capsys):
+    assert main(check=VpnStoreCheck(list_runs=_client(RUN_ROWS)), now_month_id=CAPTURE_NOW) == 0
+
+def test_exit_zero_vpn_required(capsys):
+    err = OSError('could not translate host name "gjoll.muspelheim.local"')
+    assert main(check=VpnStoreCheck(list_runs=_client(err)), now_month_id=CAPTURE_NOW) == 0
+    assert "VPN_REQUIRED" in capsys.readouterr().out
+
+def test_exit_one_stale(capsys):
+    assert main(check=VpnStoreCheck(list_runs=_client(RUN_ROWS)), now_month_id=CAPTURE_NOW + 6) == 1
+
+def test_exit_two_unreachable(capsys):
+    assert main(check=VpnStoreCheck(list_runs=_client(RuntimeError("boom"))), now_month_id=CAPTURE_NOW) == 2
+
+
+# ── live integration (VPN + package; skips truthfully) ────────────────
+
+@pytest.mark.red
+def test_live_vpn_store_invariants():
+    try:
+        report = VpnStoreCheck().run()
+    except Exception as e:  # noqa: BLE001
+        pytest.skip(f"vpn store not checkable: {type(e).__name__}: {e}")
+    if report.verdict in ("VPN_REQUIRED", "SKIP_NO_PACKAGE", "UNREACHABLE"):
+        pytest.skip(f"vpn store not reachable here: {report.verdict} {report.error or ''}")
+    assert report.latest_run is not None

--- a/tools/liveness/vpn_store.py
+++ b/tools/liveness/vpn_store.py
@@ -1,0 +1,180 @@
+"""Liveness check for the VPN-only legacy prediction store (gjoll).
+
+Answers, with raw facts: does the legacy store hold a fresh fatalities run —
+i.e. are computed runs being uploaded, possibly awaiting public promotion?
+
+Usage:
+    python -m tools.liveness.vpn_store   # exit 0 fresh/vpn-required/skip / 1 stale / 2 unreachable
+
+The store is Postgres on ``gjoll.muspelheim.local`` — PRIO-internal,
+resolvable ONLY on the PRIO VPN. Off-VPN this check reports the truthful
+verdict ``VPN_REQUIRED`` (never a false RED): the observation boundary that
+caused the 2026-07-19 "who is lying?" episode is now an encoded, named
+verdict instead of a trap.
+
+Access is via ``views_forecasts.db_ops.ViewsMetadata`` (constructor connects;
+``.get_runs()`` -> name/description/min_month/max_month). Historical receipt:
+that store's Postgres schema is literally ``forecasts_metadata`` — the origin
+of the phantom Appwrite collection ID that killed the June 2026 un_fao run
+(the legacy schema name was copied into the new store's config).
+
+Run-name parsing and the freshness budget are REUSED from
+tools.liveness.old_api — one parser, one naming convention, everywhere.
+Design (house rules): injected list_runs client + clock (DIP), lazy imports
+in the default client only, no import-time side effects (C-93), zero new
+dependencies, truthful skips (C-75).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import date
+from typing import Callable, List, Optional
+
+from tools.liveness.old_api import (
+    FRESHNESS_BUDGET_MONTHS,
+    latest_fatalities_run,
+    parse_run_name,
+)
+from tools.partitions.domain import date_to_month_id, month_id_to_date
+
+STORE_HOST = "gjoll.muspelheim.local"
+LEGACY_SCHEMA = "forecasts_metadata"  # the phantom-collection-ID origin (see docstring)
+
+# The injected client: () -> list of run rows, each a dict with at least
+# {"name": str, "max_month": int}. The default connects via views_forecasts.
+ListRuns = Callable[[], List[dict]]
+
+_HOST_RESOLUTION_MARKERS = (
+    "could not translate host name",
+    "name or service not known",
+    "nodename nor servname",
+    "temporary failure in name resolution",
+)
+
+
+@dataclass(frozen=True)
+class CheckReport:
+    """Raw facts about the legacy VPN store — no narration."""
+
+    verdict: str  # STORE_FRESH | STORE_STALE | VPN_REQUIRED | SKIP_NO_PACKAGE | UNREACHABLE
+    host: str = STORE_HOST
+    schema: str = LEGACY_SCHEMA
+    run_count: Optional[int] = None
+    latest_run: Optional[str] = None
+    data_cutoff_month_id: Optional[int] = None
+    data_cutoff_date: Optional[str] = None
+    latest_max_month: Optional[int] = None
+    now_month_id: Optional[int] = None
+    months_behind: Optional[int] = None
+    error: Optional[str] = None
+
+
+def render(report: CheckReport) -> str:
+    """One fact per line, ``key: value``."""
+    facts = [
+        ("surface", "vpn_store"),
+        ("verdict", report.verdict),
+        ("host", report.host),
+        ("schema", report.schema),
+        ("run_count", report.run_count),
+        ("latest_run", report.latest_run),
+        ("data_cutoff_month_id", report.data_cutoff_month_id),
+        ("data_cutoff_date", report.data_cutoff_date),
+        ("latest_max_month", report.latest_max_month),
+        ("now_month_id", report.now_month_id),
+        ("months_behind", report.months_behind),
+        ("freshness_budget_months", FRESHNESS_BUDGET_MONTHS),
+        ("error", report.error),
+    ]
+    return "\n".join(f"{key}: {value}" for key, value in facts if value is not None)
+
+
+class VpnStoreCheck:
+    """Freshness of the legacy store's newest fatalities run (seams injected)."""
+
+    def __init__(self, list_runs: Optional[ListRuns] = None) -> None:
+        self._list_runs = list_runs or self._list_runs_via_views_forecasts
+
+    def run(self, now_month_id: Optional[int] = None) -> CheckReport:
+        if now_month_id is None:
+            today = date.today()
+            now_month_id = date_to_month_id(today.year, today.month)
+
+        try:
+            rows = list(self._list_runs())
+        except (ImportError, ModuleNotFoundError) as exc:
+            return CheckReport(
+                verdict="SKIP_NO_PACKAGE",
+                now_month_id=now_month_id,
+                error=f"{type(exc).__name__}: {exc}",
+            )
+        except Exception as exc:  # noqa: BLE001 — classified below, never a crash
+            message = str(exc).lower()
+            if any(marker in message for marker in _HOST_RESOLUTION_MARKERS):
+                verdict = "VPN_REQUIRED"
+            else:
+                verdict = "UNREACHABLE"
+            return CheckReport(
+                verdict=verdict,
+                now_month_id=now_month_id,
+                error=f"{type(exc).__name__}: {exc}",
+            )
+
+        names = [str(row.get("name", "")) for row in rows]
+        latest = latest_fatalities_run(names)
+        if latest is None:
+            return CheckReport(
+                verdict="STORE_STALE",
+                run_count=len(rows),
+                now_month_id=now_month_id,
+                error="no fatalities runs in the store listing",
+            )
+
+        _, year, month, _ = parse_run_name(latest)  # type: ignore[misc]
+        cutoff_id = date_to_month_id(year, month)
+        months_behind = now_month_id - cutoff_id
+        latest_row = next((r for r in rows if r.get("name") == latest), {})
+
+        verdict = (
+            "STORE_FRESH" if months_behind <= FRESHNESS_BUDGET_MONTHS else "STORE_STALE"
+        )
+        return CheckReport(
+            verdict=verdict,
+            run_count=len(rows),
+            latest_run=latest,
+            data_cutoff_month_id=cutoff_id,
+            data_cutoff_date=month_id_to_date(cutoff_id),
+            latest_max_month=latest_row.get("max_month"),
+            now_month_id=now_month_id,
+            months_behind=months_behind,
+        )
+
+    @staticmethod
+    def _list_runs_via_views_forecasts() -> List[dict]:
+        """Default client: the legacy store's own metadata API (lazy import;
+        the constructor is the connection probe)."""
+        from views_forecasts.db_ops import ViewsMetadata
+
+        frame = ViewsMetadata().get_runs().reset_index()
+        return frame[["name", "min_month", "max_month"]].to_dict("records")
+
+
+_EXIT_CODE_BY_VERDICT = {
+    "STORE_FRESH": 0,
+    "VPN_REQUIRED": 0,
+    "SKIP_NO_PACKAGE": 0,
+    "STORE_STALE": 1,
+    "UNREACHABLE": 2,
+}
+
+
+def main(check: Optional[VpnStoreCheck] = None, now_month_id: Optional[int] = None) -> int:
+    """Run the check, print raw facts, return the exit code."""
+    report = (check or VpnStoreCheck()).run(now_month_id=now_month_id)
+    print(render(report))
+    return _EXIT_CODE_BY_VERDICT[report.verdict]
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Story S6 of **epic #238** (tracking #247). Closes #244.

`python -m tools.liveness.vpn_store` — freshness of the legacy store's newest fatalities run, via its own `ViewsMetadata` API. Off-VPN → **VPN_REQUIRED** (exit 0, truthful skip — the exact observation boundary that caused the who-is-lying episode, now a named verdict). TDD 12 tests; S1 parser reused (one naming convention everywhere).

**Bonus mystery closed:** the store's Postgres schema is literally `forecasts_metadata` — the origin of the phantom Appwrite collection ID (legacy schema name copied into new-store config). C-100's causal chain is now complete and encoded.

**Live off-VPN run:** VPN_REQUIRED, exit 0 ✓. **On-VPN confirmation pending** the maintainer's next VPN session — one command, then this comment gets its receipt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)