### PR TITLE
feat(liveness): S7 — DRY consolidation + python -m tools.liveness (the dashboard) (#245)

### DIFF
--- a/tests/test_liveness_runner.py
+++ b/tests/test_liveness_runner.py
@@ -1,0 +1,95 @@
+"""Liveness S7: shared report utilities + the aggregate runner — issue #245.
+
+TDD for the WET->DRY consolidation. Extraction covers ONLY what >=2 checks
+demonstrably duplicated: the fact renderer, the Appwrite API helpers
+(credentials/fetch/query builders), and the verdict->exit-code map. The
+aggregate runner composes the six checks' mains: one raw-facts block per
+surface, exit code = worst verdict, SKIP verdicts non-fatal.
+"""
+
+import pytest
+
+from tools.liveness.report import (
+    EXIT_CODE_BY_VERDICT,
+    exit_code_for,
+    render_facts,
+    worst_exit,
+)
+from tools.liveness.__main__ import SURFACES, run_all
+
+pytestmark = pytest.mark.green
+
+
+# ── render_facts ──────────────────────────────────────────────────────
+
+def test_render_facts_skips_none_and_formats_lines():
+    text = render_facts([("a", 1), ("b", None), ("c", "x")])
+    assert text == "a: 1\nc: x"
+
+
+# ── the merged verdict map ────────────────────────────────────────────
+
+def test_every_check_verdict_is_classified():
+    ok = {"LIVE_FRESH", "INPUT_FRESH", "STORE_ACTIVE", "STORE_FRESH",
+          "EXECUTION_CURRENT", "DELIVERING"}
+    skip = {"SKIP_NO_CREDENTIALS", "SKIP_NO_PACKAGE", "VPN_REQUIRED"}
+    warn = {"LIVE_STALE", "LIVE_NOT_SERVING", "INPUT_STALE", "STORE_IDLE",
+            "STORE_STALE", "DELIVERY_STALLED", "EXECUTION_STALE"}
+    fail = {"UNREACHABLE"}
+    for verdict in ok | skip:
+        assert exit_code_for(verdict) == 0, verdict
+    for verdict in warn:
+        assert exit_code_for(verdict) == 1, verdict
+    for verdict in fail:
+        assert exit_code_for(verdict) == 2, verdict
+    assert set(EXIT_CODE_BY_VERDICT) == ok | skip | warn | fail
+
+def test_unknown_verdict_fails_loud():
+    with pytest.raises(KeyError):
+        exit_code_for("MADE_UP_VERDICT")
+
+def test_worst_exit():
+    assert worst_exit([0, 0, 0]) == 0
+    assert worst_exit([0, 1, 0]) == 1
+    assert worst_exit([1, 2, 0]) == 2
+    assert worst_exit([]) == 0
+
+
+# ── the aggregate runner ──────────────────────────────────────────────
+
+def test_registry_covers_all_six_surfaces():
+    assert [name for name, _ in SURFACES] == [
+        "old_api", "datafactory_input", "appwrite_store",
+        "unfao_delivery", "wandb_execution", "vpn_store",
+    ]
+
+def test_run_all_prints_blocks_and_returns_worst(capsys):
+    fakes = [("alpha", lambda: 0), ("beta", lambda: 1), ("gamma", lambda: 0)]
+    code = run_all(surfaces=fakes)
+    out = capsys.readouterr().out
+    assert code == 1
+    assert "alpha" in out and "beta" in out and "gamma" in out
+
+def test_run_all_unreachable_dominates(capsys):
+    fakes = [("a", lambda: 1), ("b", lambda: 2)]
+    assert run_all(surfaces=fakes) == 2
+
+def test_run_all_all_green(capsys):
+    fakes = [("a", lambda: 0), ("b", lambda: 0)]
+    assert run_all(surfaces=fakes) == 0
+
+def test_run_all_survives_a_crashing_check(capsys):
+    def boom():
+        raise RuntimeError("check exploded")
+    fakes = [("a", lambda: 0), ("broken", boom), ("c", lambda: 0)]
+    code = run_all(surfaces=fakes)
+    out = capsys.readouterr().out
+    assert code == 2                      # a crashing check is worst-class
+    assert "check exploded" in out        # reported as a fact, not swallowed
+
+
+# ── behavior preservation: the six mains still exist and are callable ──
+
+def test_all_surface_mains_importable():
+    for name, main_callable in SURFACES:
+        assert callable(main_callable), name

--- a/tools/liveness/__main__.py
+++ b/tools/liveness/__main__.py
@@ -1,0 +1,54 @@
+"""The liveness dashboard: every forecast surface, one command, raw facts.
+
+Usage:
+    python -m tools.liveness      # exit = worst verdict across all surfaces
+                                  # (0 healthy/skips, 1 attention, 2 unreachable)
+
+Runs each surface's check in sequence and prints its raw-facts block. A
+crashing check is contained and reported as an UNREACHABLE-class fact —
+one broken surface must never hide the others (epic #238, S7).
+"""
+
+from __future__ import annotations
+
+from typing import Callable, List, Optional, Tuple
+
+from tools.liveness import (
+    appwrite_store,
+    datafactory_input,
+    old_api,
+    unfao_delivery,
+    vpn_store,
+    wandb_execution,
+)
+from tools.liveness.report import worst_exit
+
+SURFACES: Tuple[Tuple[str, Callable[[], int]], ...] = (
+    ("old_api", old_api.main),
+    ("datafactory_input", datafactory_input.main),
+    ("appwrite_store", appwrite_store.main),
+    ("unfao_delivery", unfao_delivery.main),
+    ("wandb_execution", wandb_execution.main),
+    ("vpn_store", vpn_store.main),
+)
+
+_RULE = "─" * 60
+
+
+def run_all(surfaces: Optional[Tuple[Tuple[str, Callable[[], int]], ...]] = None) -> int:
+    """Run every surface check; print each block; return the worst exit code."""
+    codes: List[int] = []
+    for name, run_main in surfaces if surfaces is not None else SURFACES:
+        print(f"{_RULE}\n{name}\n{_RULE}")
+        try:
+            codes.append(int(run_main()))
+        except Exception as exc:  # noqa: BLE001 — contain: one crash must not hide the rest
+            print(f"surface: {name}\nverdict: UNREACHABLE\nerror: {type(exc).__name__}: {exc}")
+            codes.append(2)
+        print()
+    print(f"{_RULE}\nworst_exit: {worst_exit(codes)}")
+    return worst_exit(codes)
+
+
+if __name__ == "__main__":
+    raise SystemExit(run_all())

--- a/tools/liveness/appwrite_api.py
+++ b/tools/liveness/appwrite_api.py
@@ -1,0 +1,126 @@
+"""Shared Appwrite API helpers for the liveness checks (S7 extraction, #245).
+
+One home for what the appwrite_store and unfao_delivery checks demonstrably
+duplicated: credentials (dataclass, .env parsing, resolution order), the
+server-side query builders (the 2026-07-19 pagination-bug cure), and the
+default stdlib fetch.
+
+Credentials resolution order (values never rendered anywhere):
+    1. process env vars (APPWRITE_ENDPOINT / _DATASTORE_PROJECT_ID / _DATASTORE_API_KEY)
+    2. known platform .env files, discovered by walking this file's ancestors
+       (robust from the main checkout AND from git worktrees).
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Callable, Dict, Optional
+
+FETCH_TIMEOUT_SECONDS = 25
+
+_ENV_LINE = re.compile(
+    r"^export\s+(APPWRITE_ENDPOINT|APPWRITE_DATASTORE_PROJECT_ID|"
+    r"APPWRITE_DATASTORE_API_KEY)\s*=\s*(.+?)\s*$"
+)
+
+FetchJson = Callable[[str, Dict[str, str]], object]
+
+
+@dataclass(frozen=True)
+class AppwriteCredentials:
+    endpoint: str
+    project_id: str
+    api_key: str
+
+
+def load_credentials_from_env_file(path: Path) -> Optional[AppwriteCredentials]:
+    """Parse an export-style .env; None unless all three keys are present."""
+    try:
+        text = path.read_text()
+    except OSError:
+        return None
+    found: Dict[str, str] = {}
+    for line in text.splitlines():
+        match = _ENV_LINE.match(line.strip())
+        if match:
+            found[match.group(1)] = match.group(2).strip("\"'")
+    try:
+        return AppwriteCredentials(
+            endpoint=found["APPWRITE_ENDPOINT"],
+            project_id=found["APPWRITE_DATASTORE_PROJECT_ID"],
+            api_key=found["APPWRITE_DATASTORE_API_KEY"],
+        )
+    except KeyError:
+        return None
+
+
+def _known_env_files():
+    """Candidate platform .env files, discovered by walking ancestors — robust
+    to running from the main checkout AND from a git worktree under
+    .claude/worktrees/ (where fixed parent-counting breaks)."""
+    return tuple(
+        ancestor / "views-faoapi" / ".env"
+        for ancestor in Path(__file__).resolve().parents
+        if (ancestor / "views-faoapi" / ".env").exists()
+    )
+
+
+def resolve_credentials() -> Optional[AppwriteCredentials]:
+    """Env vars first, then the known platform .env files."""
+    import os
+
+    env = {k: os.environ.get(k) for k in (
+        "APPWRITE_ENDPOINT", "APPWRITE_DATASTORE_PROJECT_ID", "APPWRITE_DATASTORE_API_KEY",
+    )}
+    if all(env.values()):
+        return AppwriteCredentials(
+            env["APPWRITE_ENDPOINT"],              # type: ignore[arg-type]
+            env["APPWRITE_DATASTORE_PROJECT_ID"],  # type: ignore[arg-type]
+            env["APPWRITE_DATASTORE_API_KEY"],     # type: ignore[arg-type]
+        )
+    for candidate in _known_env_files():
+        credentials = load_credentials_from_env_file(candidate)
+        if credentials is not None:
+            return credentials
+    return None
+
+
+def newest_first_query(limit: int = 5) -> str:
+    """Appwrite query string: order by $createdAt descending, capped.
+
+    Encoded once so every bucket listing is immune to the 25-per-page
+    default that produced the 2026-07-19 false-idle verdict.
+    """
+    import json as _json
+    from urllib.parse import quote as _quote
+
+    queries = (
+        {"method": "orderDesc", "attribute": "$createdAt"},
+        {"method": "limit", "values": [limit]},
+    )
+    return "&".join("queries[]=" + _quote(_json.dumps(q)) for q in queries)
+
+
+def stream_newest_query(prefix: str) -> str:
+    """Appwrite query string: newest file whose name starts with ``prefix``."""
+    import json as _json
+    from urllib.parse import quote as _quote
+
+    queries = (
+        {"method": "startsWith", "attribute": "name", "values": [prefix]},
+        {"method": "orderDesc", "attribute": "$createdAt"},
+        {"method": "limit", "values": [1]},
+    )
+    return "&".join("queries[]=" + _quote(_json.dumps(q)) for q in queries)
+
+
+def fetch_json(url: str, headers: Dict[str, str]) -> object:
+    """Default fetch: stdlib urllib, lazy import, explicit timeout."""
+    import json
+    import urllib.request
+
+    request = urllib.request.Request(url, headers=headers)
+    with urllib.request.urlopen(request, timeout=FETCH_TIMEOUT_SECONDS) as response:
+        return json.load(response)

--- a/tools/liveness/appwrite_store.py
+++ b/tools/liveness/appwrite_store.py
@@ -29,11 +29,9 @@ effects (C-93), zero new dependencies, truthful SKIP without credentials.
 
 from __future__ import annotations
 
-import re
 from dataclasses import dataclass
 from datetime import datetime, timezone
-from pathlib import Path
-from typing import Callable, Dict, List, Optional
+from typing import Dict, List, Optional
 
 APPWRITE_BUCKET_ID = "production_forecasts"
 REAL_METADATA_DATABASE_ID = "file_metadata"
@@ -43,89 +41,28 @@ HISTORICAL_WRONG_COLLECTION_ID = "forecasts_metadata"
 # A monthly-cadence store is "active" if something landed within ~1.5 cycles.
 ACTIVE_WITHIN_DAYS = 45
 
-_FETCH_TIMEOUT_SECONDS = 25
-
-def _known_env_files():
-    """Candidate platform .env files, discovered by walking ancestors — robust
-    to running from the main checkout AND from a git worktree under
-    .claude/worktrees/ (where fixed parent-counting breaks)."""
-    return tuple(
-        ancestor / "views-faoapi" / ".env"
-        for ancestor in Path(__file__).resolve().parents
-        if (ancestor / "views-faoapi" / ".env").exists()
-    )
-
-_ENV_LINE = re.compile(
-    r"^export\s+(APPWRITE_ENDPOINT|APPWRITE_DATASTORE_PROJECT_ID|"
-    r"APPWRITE_DATASTORE_API_KEY)\s*=\s*(.+?)\s*$"
+# Shared Appwrite plumbing lives in appwrite_api (S7 extraction, #245);
+# names are re-exported here so existing imports/tests keep working.
+from tools.liveness.appwrite_api import (  # noqa: E402  (kept near use)
+    AppwriteCredentials,
+    FetchJson,
+    fetch_json,
+    load_credentials_from_env_file,
+    newest_first_query,
+    resolve_credentials,
 )
+from tools.liveness.report import exit_code_for, render_facts  # noqa: E402
 
-FetchJson = Callable[[str, Dict[str, str]], object]
-
-
-def newest_first_query(limit: int = 5) -> str:
-    """Appwrite query string: order by $createdAt descending, capped.
-
-    Encoded once so every bucket listing in this package is immune to the
-    25-per-page default that produced the 2026-07-19 false-idle verdict.
-    """
-    import json as _json
-    from urllib.parse import quote as _quote
-
-    queries = (
-        {"method": "orderDesc", "attribute": "$createdAt"},
-        {"method": "limit", "values": [limit]},
-    )
-    return "&".join("queries[]=" + _quote(_json.dumps(q)) for q in queries)
-
-
-
-@dataclass(frozen=True)
-class AppwriteCredentials:
-    endpoint: str
-    project_id: str
-    api_key: str
-
-
-def load_credentials_from_env_file(path: Path) -> Optional[AppwriteCredentials]:
-    """Parse an export-style .env; None unless all three keys are present."""
-    try:
-        text = path.read_text()
-    except OSError:
-        return None
-    found: Dict[str, str] = {}
-    for line in text.splitlines():
-        match = _ENV_LINE.match(line.strip())
-        if match:
-            found[match.group(1)] = match.group(2).strip("\"'")
-    try:
-        return AppwriteCredentials(
-            endpoint=found["APPWRITE_ENDPOINT"],
-            project_id=found["APPWRITE_DATASTORE_PROJECT_ID"],
-            api_key=found["APPWRITE_DATASTORE_API_KEY"],
-        )
-    except KeyError:
-        return None
-
-
-def resolve_credentials() -> Optional[AppwriteCredentials]:
-    """Env vars first, then the known platform .env files."""
-    import os
-
-    env = {k: os.environ.get(k) for k in (
-        "APPWRITE_ENDPOINT", "APPWRITE_DATASTORE_PROJECT_ID", "APPWRITE_DATASTORE_API_KEY",
-    )}
-    if all(env.values()):
-        return AppwriteCredentials(
-            env["APPWRITE_ENDPOINT"],            # type: ignore[arg-type]
-            env["APPWRITE_DATASTORE_PROJECT_ID"],  # type: ignore[arg-type]
-            env["APPWRITE_DATASTORE_API_KEY"],   # type: ignore[arg-type]
-        )
-    for candidate in _known_env_files():
-        credentials = load_credentials_from_env_file(candidate)
-        if credentials is not None:
-            return credentials
-    return None
+__all__ = [
+    "AppwriteCredentials",
+    "AppwriteStoreCheck",
+    "CheckReport",
+    "load_credentials_from_env_file",
+    "main",
+    "newest_first_query",
+    "render",
+    "resolve_credentials",
+]
 
 
 @dataclass(frozen=True)
@@ -166,7 +103,7 @@ def render(report: CheckReport) -> str:
         ("historical_wrong_collection_id", HISTORICAL_WRONG_COLLECTION_ID),
         ("error", report.error),
     ]
-    return "\n".join(f"{key}: {value}" for key, value in facts if value is not None)
+    return render_facts(facts)
 
 
 class AppwriteStoreCheck:
@@ -180,7 +117,7 @@ class AppwriteStoreCheck:
         self.credentials = (
             resolve_credentials() if credentials == "RESOLVE" else credentials
         )
-        self._fetch = fetch or self._fetch_json
+        self._fetch = fetch or fetch_json
 
     def run(self, now: Optional[datetime] = None) -> CheckReport:
         if self.credentials is None:
@@ -261,30 +198,13 @@ class AppwriteStoreCheck:
         except Exception:  # noqa: BLE001 — discovery is auxiliary; unknown, honestly
             return None, None
 
-    @staticmethod
-    def _fetch_json(url: str, headers: Dict[str, str]) -> object:
-        """Default fetch: stdlib urllib, lazy import, explicit timeout."""
-        import json
-        import urllib.request
-
-        request = urllib.request.Request(url, headers=headers)
-        with urllib.request.urlopen(request, timeout=_FETCH_TIMEOUT_SECONDS) as response:
-            return json.load(response)
-
-
-_EXIT_CODE_BY_VERDICT = {
-    "STORE_ACTIVE": 0,
-    "SKIP_NO_CREDENTIALS": 0,
-    "STORE_IDLE": 1,
-    "UNREACHABLE": 2,
-}
 
 
 def main(check: Optional[AppwriteStoreCheck] = None, now: Optional[datetime] = None) -> int:
     """Run the check, print raw facts, return the exit code."""
     report = (check or AppwriteStoreCheck()).run(now=now)
     print(render(report))
-    return _EXIT_CODE_BY_VERDICT[report.verdict]
+    return exit_code_for(report.verdict)
 
 
 if __name__ == "__main__":

--- a/tools/liveness/datafactory_input.py
+++ b/tools/liveness/datafactory_input.py
@@ -33,6 +33,8 @@ from typing import Callable, Optional
 
 from tools.partitions.domain import month_id_to_date
 
+from tools.liveness.report import exit_code_for, render_facts
+
 _DEFAULT_REPO_ROOT = Path(__file__).resolve().parent.parent.parent
 
 
@@ -72,7 +74,7 @@ def render(report: CheckReport) -> str:
         ("margin_months", report.margin_months),
         ("error", report.error),
     ]
-    return "\n".join(f"{key}: {value}" for key, value in facts if value is not None)
+    return render_facts(facts)
 
 
 class DatafactoryInputCheck:
@@ -145,18 +147,13 @@ class DatafactoryInputCheck:
         return host is not None and credentials.authenticators(host) is not None
 
 
-_EXIT_CODE_BY_VERDICT = {
-    "INPUT_FRESH": 0,
-    "INPUT_STALE": 1,
-    "UNREACHABLE": 2,
-}
 
 
 def main(check: Optional[DatafactoryInputCheck] = None) -> int:
     """Run the check, print raw facts, return the exit code."""
     report = (check or DatafactoryInputCheck()).run()
     print(render(report))
-    return _EXIT_CODE_BY_VERDICT[report.verdict]
+    return exit_code_for(report.verdict)
 
 
 if __name__ == "__main__":

--- a/tools/liveness/old_api.py
+++ b/tools/liveness/old_api.py
@@ -38,6 +38,8 @@ from typing import Callable, List, Optional, Tuple
 
 from tools.partitions.domain import date_to_month_id, month_id_to_date
 
+from tools.liveness.report import exit_code_for, render_facts
+
 BASE_URL = "https://api.viewsforecasting.org"
 
 # Freshness budget: cadence is one run per data-month, published ~1 month
@@ -122,7 +124,7 @@ def render(report: CheckReport) -> str:
         ("serving_rows_sampled", report.serving_rows_sampled),
         ("error", report.error),
     ]
-    return "\n".join(f"{key}: {value}" for key, value in facts if value is not None)
+    return render_facts(facts)
 
 
 class OldApiCheck:
@@ -211,12 +213,6 @@ class OldApiCheck:
             return json.load(response)
 
 
-_EXIT_CODE_BY_VERDICT = {
-    "LIVE_FRESH": 0,
-    "LIVE_STALE": 1,
-    "LIVE_NOT_SERVING": 1,
-    "UNREACHABLE": 2,
-}
 
 
 def main(
@@ -225,7 +221,7 @@ def main(
     """Run the check, print raw facts, return the exit code."""
     report = OldApiCheck(fetch=fetch).run(now_month_id=now_month_id)
     print(render(report))
-    return _EXIT_CODE_BY_VERDICT[report.verdict]
+    return exit_code_for(report.verdict)
 
 
 if __name__ == "__main__":

--- a/tools/liveness/report.py
+++ b/tools/liveness/report.py
@@ -1,0 +1,55 @@
+"""Shared report utilities for the liveness checks (S7 extraction, issue #245).
+
+Extracted ONLY after six checks demonstrably duplicated these pieces
+(WET-before-DRY, epic #238): the one-fact-per-line renderer and the
+verdict -> exit-code classification.
+
+Exit-code contract (uniform across every surface):
+    0 — healthy, or a truthful SKIP (missing creds/package/VPN is a fact
+        about the environment, not a failure of the surface)
+    1 — reachable but stale/idle/not-serving (attention needed)
+    2 — unreachable (the surface cannot be observed at all)
+"""
+
+from __future__ import annotations
+
+from typing import Iterable, List, Tuple
+
+EXIT_CODE_BY_VERDICT = {
+    # healthy
+    "LIVE_FRESH": 0,
+    "INPUT_FRESH": 0,
+    "STORE_ACTIVE": 0,
+    "STORE_FRESH": 0,
+    "EXECUTION_CURRENT": 0,
+    "DELIVERING": 0,
+    # truthful skips
+    "SKIP_NO_CREDENTIALS": 0,
+    "SKIP_NO_PACKAGE": 0,
+    "VPN_REQUIRED": 0,
+    # attention
+    "LIVE_STALE": 1,
+    "LIVE_NOT_SERVING": 1,
+    "INPUT_STALE": 1,
+    "STORE_IDLE": 1,
+    "STORE_STALE": 1,
+    "DELIVERY_STALLED": 1,
+    "EXECUTION_STALE": 1,
+    # unobservable
+    "UNREACHABLE": 2,
+}
+
+
+def render_facts(facts: Iterable[Tuple[str, object]]) -> str:
+    """One ``key: value`` line per fact; None values are omitted."""
+    return "\n".join(f"{key}: {value}" for key, value in facts if value is not None)
+
+
+def exit_code_for(verdict: str) -> int:
+    """Map a check verdict to the uniform exit code; unknown verdicts raise."""
+    return EXIT_CODE_BY_VERDICT[verdict]
+
+
+def worst_exit(codes: List[int]) -> int:
+    """The aggregate exit code: the worst of the parts (empty -> 0)."""
+    return max(codes, default=0)

--- a/tools/liveness/unfao_delivery.py
+++ b/tools/liveness/unfao_delivery.py
@@ -22,13 +22,17 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from datetime import datetime, timezone
-from typing import Callable, Dict, Optional, Tuple
+from typing import Optional, Tuple
 
-from tools.liveness.appwrite_store import (
+from tools.liveness.appwrite_api import (
     AppwriteCredentials,
+    FetchJson,
+    fetch_json,
     newest_first_query,
     resolve_credentials,
+    stream_newest_query,
 )
+from tools.liveness.report import exit_code_for, render_facts
 
 UNFAO_BUCKET_ID = "unfao_bucket"
 FORECAST_PREFIX = "forecast_dataset_"
@@ -37,25 +41,6 @@ HISTORICAL_PREFIX = "historical_dataset_"
 # Monthly delivery cadence: a stream is "delivering" if something landed
 # within ~1.5 cycles.
 DELIVERING_WITHIN_DAYS = 45
-
-_FETCH_TIMEOUT_SECONDS = 25
-
-FetchJson = Callable[[str, Dict[str, str]], object]
-
-
-def stream_newest_query(prefix: str) -> str:
-    """Appwrite query string: newest file whose name starts with ``prefix``."""
-    import json as _json
-    from urllib.parse import quote as _quote
-
-    queries = (
-        {"method": "startsWith", "attribute": "name", "values": [prefix]},
-        {"method": "orderDesc", "attribute": "$createdAt"},
-        {"method": "limit", "values": [1]},
-    )
-    return "&".join("queries[]=" + _quote(_json.dumps(q)) for q in queries)
-
-
 
 @dataclass(frozen=True)
 class CheckReport:
@@ -101,7 +86,7 @@ def render(report: CheckReport) -> str:
         ("other_files", report.other_files),
         ("error", report.error),
     ]
-    return "\n".join(f"{key}: {value}" for key, value in facts if value is not None)
+    return render_facts(facts)
 
 
 def _newest(files: list) -> Optional[dict]:
@@ -119,7 +104,7 @@ class UnfaoDeliveryCheck:
         self.credentials = (
             resolve_credentials() if credentials == "RESOLVE" else credentials
         )
-        self._fetch = fetch or self._fetch_json
+        self._fetch = fetch or fetch_json
 
     def run(self, now: Optional[datetime] = None) -> CheckReport:
         if self.credentials is None:
@@ -204,30 +189,13 @@ class UnfaoDeliveryCheck:
             days,
         )
 
-    @staticmethod
-    def _fetch_json(url: str, headers: Dict[str, str]) -> object:
-        """Default fetch: stdlib urllib, lazy import, explicit timeout."""
-        import json
-        import urllib.request
-
-        request = urllib.request.Request(url, headers=headers)
-        with urllib.request.urlopen(request, timeout=_FETCH_TIMEOUT_SECONDS) as response:
-            return json.load(response)
-
-
-_EXIT_CODE_BY_VERDICT = {
-    "DELIVERING": 0,
-    "SKIP_NO_CREDENTIALS": 0,
-    "DELIVERY_STALLED": 1,
-    "UNREACHABLE": 2,
-}
 
 
 def main(check: Optional[UnfaoDeliveryCheck] = None, now: Optional[datetime] = None) -> int:
     """Run the check, print raw facts, return the exit code."""
     report = (check or UnfaoDeliveryCheck()).run(now=now)
     print(render(report))
-    return _EXIT_CODE_BY_VERDICT[report.verdict]
+    return exit_code_for(report.verdict)
 
 
 if __name__ == "__main__":

--- a/tools/liveness/vpn_store.py
+++ b/tools/liveness/vpn_store.py
@@ -38,6 +38,8 @@ from tools.liveness.old_api import (
 )
 from tools.partitions.domain import date_to_month_id, month_id_to_date
 
+from tools.liveness.report import exit_code_for, render_facts
+
 STORE_HOST = "gjoll.muspelheim.local"
 LEGACY_SCHEMA = "forecasts_metadata"  # the phantom-collection-ID origin (see docstring)
 
@@ -87,7 +89,7 @@ def render(report: CheckReport) -> str:
         ("freshness_budget_months", FRESHNESS_BUDGET_MONTHS),
         ("error", report.error),
     ]
-    return "\n".join(f"{key}: {value}" for key, value in facts if value is not None)
+    return render_facts(facts)
 
 
 class VpnStoreCheck:
@@ -160,20 +162,13 @@ class VpnStoreCheck:
         return frame[["name", "min_month", "max_month"]].to_dict("records")
 
 
-_EXIT_CODE_BY_VERDICT = {
-    "STORE_FRESH": 0,
-    "VPN_REQUIRED": 0,
-    "SKIP_NO_PACKAGE": 0,
-    "STORE_STALE": 1,
-    "UNREACHABLE": 2,
-}
 
 
 def main(check: Optional[VpnStoreCheck] = None, now_month_id: Optional[int] = None) -> int:
     """Run the check, print raw facts, return the exit code."""
     report = (check or VpnStoreCheck()).run(now_month_id=now_month_id)
     print(render(report))
-    return _EXIT_CODE_BY_VERDICT[report.verdict]
+    return exit_code_for(report.verdict)
 
 
 if __name__ == "__main__":

--- a/tools/liveness/wandb_execution.py
+++ b/tools/liveness/wandb_execution.py
@@ -29,6 +29,8 @@ from dataclasses import dataclass
 from datetime import datetime, timezone
 from typing import Callable, Optional, Tuple
 
+from tools.liveness.report import exit_code_for
+
 WANDB_ENTITY = "views_pipeline"
 
 # Mirrors monthly_run.sh (the hand-run production list). Keep in sync by hand.
@@ -71,7 +73,7 @@ class CheckReport:
 def render(report: CheckReport) -> str:
     """One fact per line, ``key: value``; per-ensemble blocks are prefixed."""
     lines = [
-        f"surface: wandb_execution",
+        "surface: wandb_execution",
         f"verdict: {report.verdict}",
         f"entity: {report.entity}",
         f"cycle_budget_days: {CYCLE_BUDGET_DAYS}",
@@ -208,19 +210,13 @@ class WandbExecutionCheck:
         }
 
 
-_EXIT_CODE_BY_VERDICT = {
-    "EXECUTION_CURRENT": 0,
-    "SKIP_NO_CREDENTIALS": 0,
-    "EXECUTION_STALE": 1,
-    "UNREACHABLE": 2,
-}
 
 
 def main(check: Optional[WandbExecutionCheck] = None, now: Optional[datetime] = None) -> int:
     """Run the check, print raw facts, return the exit code."""
     report = (check or WandbExecutionCheck()).run(now=now)
     print(render(report))
-    return _EXIT_CODE_BY_VERDICT[report.verdict]
+    return exit_code_for(report.verdict)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Story S7 of **epic #238** (tracking #247). Closes #245.

**`python -m tools.liveness` — the whole system, one command.** Extraction limited to demonstrated duplication (renderer, verdict→exit map, Appwrite credentials/queries/fetch); behavior preservation proven by all 92 pre-existing tests passing **unmodified** (+10 new; 102 total). Crash containment: one broken check can never hide the rest.

**First full dashboard (2026-07-19):** old_api LIVE_FRESH · datafactory_input INPUT_FRESH (margin 6) · appwrite_store STORE_ACTIVE (19d) · wandb_execution EXECUTION_CURRENT (4/4) · **unfao_delivery DELIVERY_STALLED (131/111d — the one true red)** · vpn_store VPN_REQUIRED → **worst_exit: 1**.

The epic's reason for existing, delivered: the bare-minimum MVP check the maintainer defined — now runnable by anyone, anywhere, in ten seconds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)