### PR TITLE
fix(liveness): falsification-audit fixes — C-101 Resolved, C-102 registered

### DIFF
--- a/reports/technical_risk_register.md
+++ b/reports/technical_risk_register.md
@@ -3,7 +3,7 @@
 **Last updated:** 2026-07-19  
 **Governing ADR:** [ADR-010](../docs/ADRs/010_technical_risk_register.md)  
 **Total entries:** 104 (100 concerns + 4 disagreements)  
-**Concerns:** Open 44 | Mitigated 16 | Resolved 36 | Accepted 3 | Partially Resolved 1  
+**Concerns:** Open 46 | Mitigated 16 | Resolved 36 | Accepted 3 | Partially Resolved 1  
 **Disagreements:** Open 4  
 
 ---
@@ -1263,6 +1263,32 @@
 | **Status** | Mitigated (2026-07-19: `tools/liveness` shipped, epic #238; residual = wiring it into an actual run cadence) |
 | **Location** | Demonstrated: `APPWRITE_PROD_FORECASTS_COLLECTION_ID='forecasts_metadata'` did not exist in live Appwrite → un_fao smoke run died at store lookup (`views_pipeline_ERROR.log`, postmortem). Same class: all ~13 `APPWRITE_*` vars × both delivery sides, `.netrc` entries, store run-names |
 | **Notes** | There is no preflight anywhere that checks config-vs-reality before a run touches production surfaces; the system's first contact with a wrong drawer-label is the live failure itself. **Exit: `tools/preflight`** (maintainer-proposed, design agreed): one read-only command auditing every declared external surface — inputs (viewser, datafactory zarr incl. `last_valid_month_id` vs partitions) and outputs (both stores, partner buckets, wandb) — with OK/FAIL/SKIP-with-reason semantics (truthful degradation per the C-75 lesson), runnable identically on a laptop and on the future production host, where it doubles as the acceptance checklist. **Mitigated 2026-07-19 (epic #238, S1–S8):** the exit exists as **`tools/liveness`** — `python -m tools.liveness` audits all six declared surfaces read-only (public API, datafactory zarr vs partitions, Appwrite `production_forecasts` incl. the REAL collection IDs that this entry's incident lacked, FAO `unfao_bucket` per stream, wandb execution, gjoll VPN store) with exactly the agreed semantics: raw facts, truthful SKIPs, exit 0/1/2, crash containment. The phantom `forecasts_metadata` ID is encoded as `HISTORICAL_WRONG_COLLECTION_ID` with the real IDs beside it (`tools/liveness/appwrite_store.py`), so this incident class is now machine-checkable before any live run. **Residual (why not Resolved):** the instrument is hand-run — nothing schedules it before `monthly_run.sh` or on a heartbeat (that is C-99's exit), and config *files* are still not diffed against reality (the check observes reality directly rather than validating each env var). See also C-96 (the zarr-freshness row, automated in `tools/liveness/datafactory_input.py`), C-97, C-99. |
+
+---
+
+### C-101 — tools/liveness verdict-truthfulness gaps: the instrument built to end false alarms can itself false-alarm or crash
+
+| Field | Value |
+|---|---|
+| **Tier** | 2 |
+| **Trigger** | Running the dashboard on a machine without `datafactory_query` (reports UNREACHABLE/exit 2 instead of a truthful skip); any wandb project returning a run with a malformed/absent `created_at` (uncaught ValueError crashes the standalone check with no report); adding a new verdict without registering it in `EXIT_CODE_BY_VERDICT` (runner prints two contradictory verdict blocks for one surface); any error value containing newlines (breaks the one-fact-per-line contract — already visible in live vpn_store output) |
+| **Source** | falsify (2026-07-19, claim "tools.liveness is air and water tight" → FALSIFIED, 3 hard / 3 soft) |
+| **Status** | Open |
+| **Location** | `tools/liveness/datafactory_input.py:101-110` (generic except swallows ImportError → UNREACHABLE, no SKIP_NO_PACKAGE unlike vpn_store); `tools/liveness/wandb_execution.py:124-131` (`_judge` outside the per-ensemble try); `tools/liveness/__main__.py:44-47` + every module `main()` (exit_code_for raises AFTER print → double block); `tools/liveness/report.py:43-45` (render_facts passes newlines through); enforcement tests: `tests/test_liveness_falsifications.py` (failing by design) |
+| **Notes** | Tier 2 rationale: structural fragility with named realistic triggers in the very instrument whose purpose is verdict truthfulness — a false UNREACHABLE from the dashboard re-creates the "who is lying?" failure mode it was built to end (C-75 class), and a crash-instead-of-report hides a surface. Root pattern (falsify pattern analysis): S7 extracted the renderer and exit map but NOT the exception/skip classification, so truthful-skip semantics are re-implemented per module and drift (vpn_store correct, datafactory_input not); contracts asserted in docstrings (one-fact-per-line, verdict-map totality, roster mirror) have no enforcement. Roster-mirror tripwire (monthly_run.sh vs MONTHLY_ENSEMBLES) ships with the fix. See also C-75 (truthful-skip lesson), C-94/C-95 (silent-when-unenforced class), C-100 (the incident class the suite mitigates). |
+
+---
+
+### C-102 — tools/liveness coverage gap vs its charter: viewser input, website host, and content-size judgment absent
+
+| Field | Value |
+|---|---|
+| **Tier** | 3 |
+| **Trigger** | A viewser outage, a viewsforecasting.org website failure, or an empty/truncated delivered file occurring while `python -m tools.liveness` reports all-green — the dashboard's silence is read as system health for a surface it does not watch |
+| **Source** | falsify (2026-07-19, Category H adequacy probe against epic #238's charter "all input and output destinations") |
+| **Status** | Open |
+| **Location** | `tools/liveness/__main__.py` SURFACES registry: no viewser surface (the ACTUAL input of the four production ensembles; the suite watches the datafactory input production does not yet consume), no website probe (only `api.viewsforecasting.org`); `tools/liveness/unfao_delivery.py` reports `*_newest_bytes` but never judges them (a 12-byte parquet counts as DELIVERING) |
+| **Notes** | Tier 3 rationale: no wrong output is produced — the gap is scope, and the register + README non-goals note make it visible rather than silent. Closing requires a maintainer scope decision: (a) a viewser liveness surface (an S9), (b) a minimum-bytes/row-count judgment on delivered files (liveness vs content-sanity boundary), (c) whether the website is a distinct surface from the API or out of scope. Until decided, the README documents these as known non-goals so all-green cannot be over-read. See also C-99 (heartbeat), C-96 (input freshness class). |
 
 ---
 

--- a/reports/technical_risk_register.md
+++ b/reports/technical_risk_register.md
@@ -3,7 +3,7 @@
 **Last updated:** 2026-07-19  
 **Governing ADR:** [ADR-010](../docs/ADRs/010_technical_risk_register.md)  
 **Total entries:** 104 (100 concerns + 4 disagreements)  
-**Concerns:** Open 46 | Mitigated 16 | Resolved 36 | Accepted 3 | Partially Resolved 1  
+**Concerns:** Open 45 | Mitigated 16 | Resolved 37 | Accepted 3 | Partially Resolved 1  
 **Disagreements:** Open 4  
 
 ---
@@ -1273,7 +1273,7 @@
 | **Tier** | 2 |
 | **Trigger** | Running the dashboard on a machine without `datafactory_query` (reports UNREACHABLE/exit 2 instead of a truthful skip); any wandb project returning a run with a malformed/absent `created_at` (uncaught ValueError crashes the standalone check with no report); adding a new verdict without registering it in `EXIT_CODE_BY_VERDICT` (runner prints two contradictory verdict blocks for one surface); any error value containing newlines (breaks the one-fact-per-line contract — already visible in live vpn_store output) |
 | **Source** | falsify (2026-07-19, claim "tools.liveness is air and water tight" → FALSIFIED, 3 hard / 3 soft) |
-| **Status** | Open |
+| **Status** | Resolved (2026-07-19, same-day fix: `one_line` newline escape in report.py; SKIP_NO_PACKAGE in datafactory_input; `_judge` inside the per-ensemble try; verdict classified before print in all six `main()`s; roster-mirror tripwire shipped — all enforced by `tests/test_liveness_falsifications.py`) |
 | **Location** | `tools/liveness/datafactory_input.py:101-110` (generic except swallows ImportError → UNREACHABLE, no SKIP_NO_PACKAGE unlike vpn_store); `tools/liveness/wandb_execution.py:124-131` (`_judge` outside the per-ensemble try); `tools/liveness/__main__.py:44-47` + every module `main()` (exit_code_for raises AFTER print → double block); `tools/liveness/report.py:43-45` (render_facts passes newlines through); enforcement tests: `tests/test_liveness_falsifications.py` (failing by design) |
 | **Notes** | Tier 2 rationale: structural fragility with named realistic triggers in the very instrument whose purpose is verdict truthfulness — a false UNREACHABLE from the dashboard re-creates the "who is lying?" failure mode it was built to end (C-75 class), and a crash-instead-of-report hides a surface. Root pattern (falsify pattern analysis): S7 extracted the renderer and exit map but NOT the exception/skip classification, so truthful-skip semantics are re-implemented per module and drift (vpn_store correct, datafactory_input not); contracts asserted in docstrings (one-fact-per-line, verdict-map totality, roster mirror) have no enforcement. Roster-mirror tripwire (monthly_run.sh vs MONTHLY_ENSEMBLES) ships with the fix. See also C-75 (truthful-skip lesson), C-94/C-95 (silent-when-unenforced class), C-100 (the incident class the suite mitigates). |
 

--- a/tests/test_liveness_falsifications.py
+++ b/tests/test_liveness_falsifications.py
@@ -1,0 +1,121 @@
+"""Regression tests from the 2026-07-19 falsification audit of tools.liveness.
+
+Claim audited: "tools.liveness is air and water tight." Verdict: FALSIFIED
+(register C-101, C-102). P1/P2/P4/P7 pin the fixed defects; P5 is the
+roster-mirror tripwire (fails when monthly_run.sh drifts from
+MONTHLY_ENSEMBLES); P8 is an xfail marking the C-102 coverage gap — it
+starts passing (XPASS, strict) the day a viewser surface ships, forcing
+this file and the register to be updated together.
+"""
+
+from __future__ import annotations
+
+import io
+import re
+import contextlib
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+
+from tools.liveness import old_api, vpn_store
+from tools.liveness.__main__ import run_all
+from tools.liveness.datafactory_input import DatafactoryInputCheck
+from tools.liveness.report import exit_code_for
+from tools.liveness.wandb_execution import MONTHLY_ENSEMBLES, WandbExecutionCheck
+
+pytestmark = pytest.mark.green
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+
+
+def test_p1_multiline_error_value_stays_one_fact_per_line():
+    """P1 (hard): render contract is 'one fact per line, key: value', but a
+    multi-line error value (seen live: sqlalchemy OperationalError) emits
+    continuation lines that belong to no key — machine-parsing breaks."""
+    error = "OperationalError: boom\n\n(Background on this error at: https://sqlalche.me/e/14/e3q8)"
+    report = vpn_store.CheckReport(verdict="VPN_REQUIRED", now_month_id=559, error=error)
+    for line in vpn_store.render(report).splitlines():
+        assert re.match(r"^[a-z_.]+: ", line), f"line breaks key: value contract: {line!r}"
+
+
+def test_p2_datafactory_input_missing_package_is_truthful_skip():
+    """P2 (hard): README exit contract says a missing package is a truthful
+    SKIP (exit 0) on every surface; datafactory_input reports UNREACHABLE
+    (exit 2) — a false alarm on any machine without datafactory_query."""
+
+    def reader_without_package():
+        raise ModuleNotFoundError("No module named 'datafactory_query'")
+
+    report = DatafactoryInputCheck(
+        read_last_valid_month_id=reader_without_package,
+        netrc_probe=lambda: False,
+        required_month_id=552,
+    ).run()
+    assert report.verdict == "SKIP_NO_PACKAGE"
+    assert exit_code_for(report.verdict) == 0
+
+
+def test_p4_wandb_malformed_created_at_does_not_crash_the_check():
+    """P4 (hard): _judge runs outside the per-ensemble try; one run with a
+    malformed created_at crashes the whole check uncaught (standalone module
+    dies with a traceback, no report), instead of that ensemble landing in
+    the failures fact."""
+
+    def latest_run(project):
+        if project == "pink_ponyclub_forecasting":
+            return {"run_name": "broken", "created_at": None, "state": "finished",
+                    "train_end_month_id": 557}
+        return {"run_name": "ok", "created_at": "2026-07-15T15:00:00Z",
+                "state": "finished", "train_end_month_id": 558}
+
+    check = WandbExecutionCheck(latest_run=latest_run, netrc_probe=lambda: True)
+    report = check.run(now=datetime(2026, 7, 19, tzinfo=timezone.utc))  # must not raise
+    assert report.verdict in {"EXECUTION_CURRENT", "EXECUTION_STALE"}
+    assert report.error is not None  # the malformed ensemble is a reported fact
+
+
+def test_p5_monthly_ensembles_mirrors_monthly_run_sh():
+    """P5 (soft): the docstring says 'update BOTH when the roster changes'
+    but nothing enforced it. This IS the tripwire: it passes today and fails
+    the moment monthly_run.sh's ensemble roster drifts from the constant."""
+    text = (_REPO_ROOT / "monthly_run.sh").read_text()
+    roster = tuple(re.findall(r'run_folder\s+"ensembles/([a-z_]+)"', text))
+    assert roster == MONTHLY_ENSEMBLES
+
+
+def test_p7_unknown_verdict_fails_before_printing(capsys):
+    """P7 (soft): a verdict missing from EXIT_CODE_BY_VERDICT must fail loud
+    BEFORE the report prints — otherwise the runner's containment appends a
+    second, contradictory verdict block for the same surface."""
+
+    class StubCheck:
+        def run(self, now_month_id=None):
+            return vpn_store.CheckReport(verdict="BOGUS_VERDICT")
+
+    with pytest.raises(KeyError):
+        vpn_store.main(check=StubCheck())
+    assert capsys.readouterr().out == ""  # nothing printed before the failure
+
+    buffer = io.StringIO()
+    with contextlib.redirect_stdout(buffer):
+        run_all(surfaces=(("vpn_store", lambda: vpn_store.main(check=StubCheck())),))
+    verdict_lines = [
+        line for line in buffer.getvalue().splitlines() if line.startswith("verdict:")
+    ]
+    assert verdict_lines == ["verdict: UNREACHABLE"], f"blocks: {verdict_lines}"
+
+
+@pytest.mark.xfail(
+    strict=True,
+    reason="C-102 (open, scope decision pending): viewser — the actual input "
+    "of the four production ensembles — has no liveness surface yet",
+)
+def test_p8_viewser_input_surface_exists():
+    """P8 (soft, adequacy): epic #238's charter is 'every input and output
+    destination' — but viewser, the ACTUAL input of the four production
+    ensembles, has no surface (the suite watches the datafactory input that
+    production does not yet consume)."""
+    from tools.liveness.__main__ import SURFACES
+
+    assert any("viewser" in name for name, _ in SURFACES)

--- a/tools/liveness/README.md
+++ b/tools/liveness/README.md
@@ -56,7 +56,7 @@ this automates the register C-96 tripwire.
 - `INPUT_STALE` — partitions outrun observed coverage: validation-tail
   "actuals" would be zero-fill, not observations. Do not trust validation
   metrics until this is green again.
-- `UNREACHABLE`.
+- `SKIP_NO_PACKAGE` (no `datafactory_query` installed) / `UNREACHABLE`.
 
 ### `appwrite_store` — the internal Appwrite prediction shelf
 Is anything landing on the `production_forecasts` bucket, and does the REAL
@@ -128,6 +128,17 @@ injected fetch/client/clock seams (DIP); lazy imports in default clients
 only; no import-time side effects (C-93); zero new dependencies; truthful
 skips (C-75). Unknown verdicts raise `KeyError` in `report.exit_code_for` —
 add new verdicts to `EXIT_CODE_BY_VERDICT` deliberately.
+
+## Known non-goals (register C-102 — do not over-read all-green)
+
+The suite does NOT yet watch: **viewser** (the actual input of the four
+production ensembles — the datafactory surface covers the input the *next*
+system consumes), the **website** (`viewsforecasting.org` is a distinct host
+from the API that IS probed), or **content sanity** (delivered file sizes
+are reported as facts but not judged — an empty parquet counts as
+DELIVERING). Liveness ≠ correctness: green means surfaces are alive and
+fresh, not that the numbers in them are right. Closing these is a scope
+decision tracked as C-102.
 
 Run the offline suite:
 

--- a/tools/liveness/appwrite_store.py
+++ b/tools/liveness/appwrite_store.py
@@ -203,8 +203,11 @@ class AppwriteStoreCheck:
 def main(check: Optional[AppwriteStoreCheck] = None, now: Optional[datetime] = None) -> int:
     """Run the check, print raw facts, return the exit code."""
     report = (check or AppwriteStoreCheck()).run(now=now)
+    # Classify BEFORE printing: an unregistered verdict must fail loud
+    # without emitting a half-block the runner would then contradict (C-101/P7).
+    code = exit_code_for(report.verdict)
     print(render(report))
-    return exit_code_for(report.verdict)
+    return code
 
 
 if __name__ == "__main__":

--- a/tools/liveness/datafactory_input.py
+++ b/tools/liveness/datafactory_input.py
@@ -51,7 +51,7 @@ def required_month_id_from_partitions(repo_root: Path = _DEFAULT_REPO_ROOT) -> i
 class CheckReport:
     """Raw facts about the datafactory input store — no narration."""
 
-    verdict: str  # INPUT_FRESH | INPUT_STALE | UNREACHABLE
+    verdict: str  # INPUT_FRESH | INPUT_STALE | SKIP_NO_PACKAGE | UNREACHABLE
     netrc_present: Optional[bool] = None
     last_valid_month_id: Optional[int] = None
     last_valid_date: Optional[str] = None
@@ -100,6 +100,16 @@ class DatafactoryInputCheck:
 
         try:
             last_valid = int(self._read_last_valid())
+        except (ImportError, ModuleNotFoundError) as exc:
+            # Truthful skip, mirroring vpn_store (C-75/C-101): a machine
+            # without datafactory_query is an environment fact, not an alarm.
+            return CheckReport(
+                verdict="SKIP_NO_PACKAGE",
+                netrc_present=netrc_present,
+                required_month_id=required,
+                required_date=month_id_to_date(required),
+                error=f"{type(exc).__name__}: {exc}",
+            )
         except Exception as exc:  # noqa: BLE001 — any failure is the UNREACHABLE fact
             return CheckReport(
                 verdict="UNREACHABLE",
@@ -152,8 +162,11 @@ class DatafactoryInputCheck:
 def main(check: Optional[DatafactoryInputCheck] = None) -> int:
     """Run the check, print raw facts, return the exit code."""
     report = (check or DatafactoryInputCheck()).run()
+    # Classify BEFORE printing: an unregistered verdict must fail loud
+    # without emitting a half-block the runner would then contradict (C-101/P7).
+    code = exit_code_for(report.verdict)
     print(render(report))
-    return exit_code_for(report.verdict)
+    return code
 
 
 if __name__ == "__main__":

--- a/tools/liveness/old_api.py
+++ b/tools/liveness/old_api.py
@@ -220,8 +220,11 @@ def main(
 ) -> int:
     """Run the check, print raw facts, return the exit code."""
     report = OldApiCheck(fetch=fetch).run(now_month_id=now_month_id)
+    # Classify BEFORE printing: an unregistered verdict must fail loud
+    # without emitting a half-block the runner would then contradict (C-101/P7).
+    code = exit_code_for(report.verdict)
     print(render(report))
-    return exit_code_for(report.verdict)
+    return code
 
 
 if __name__ == "__main__":

--- a/tools/liveness/report.py
+++ b/tools/liveness/report.py
@@ -40,9 +40,19 @@ EXIT_CODE_BY_VERDICT = {
 }
 
 
+def one_line(value: object) -> str:
+    """Collapse a fact value to one line — embedded newlines become ``\\n``.
+
+    The one-fact-per-line contract must hold even for error strings that
+    arrive multi-line (e.g. sqlalchemy OperationalError, C-101/P1)."""
+    return str(value).replace("\r", "").replace("\n", "\\n")
+
+
 def render_facts(facts: Iterable[Tuple[str, object]]) -> str:
     """One ``key: value`` line per fact; None values are omitted."""
-    return "\n".join(f"{key}: {value}" for key, value in facts if value is not None)
+    return "\n".join(
+        f"{key}: {one_line(value)}" for key, value in facts if value is not None
+    )
 
 
 def exit_code_for(verdict: str) -> int:

--- a/tools/liveness/unfao_delivery.py
+++ b/tools/liveness/unfao_delivery.py
@@ -194,8 +194,11 @@ class UnfaoDeliveryCheck:
 def main(check: Optional[UnfaoDeliveryCheck] = None, now: Optional[datetime] = None) -> int:
     """Run the check, print raw facts, return the exit code."""
     report = (check or UnfaoDeliveryCheck()).run(now=now)
+    # Classify BEFORE printing: an unregistered verdict must fail loud
+    # without emitting a half-block the runner would then contradict (C-101/P7).
+    code = exit_code_for(report.verdict)
     print(render(report))
-    return exit_code_for(report.verdict)
+    return code
 
 
 if __name__ == "__main__":

--- a/tools/liveness/vpn_store.py
+++ b/tools/liveness/vpn_store.py
@@ -167,8 +167,11 @@ class VpnStoreCheck:
 def main(check: Optional[VpnStoreCheck] = None, now_month_id: Optional[int] = None) -> int:
     """Run the check, print raw facts, return the exit code."""
     report = (check or VpnStoreCheck()).run(now_month_id=now_month_id)
+    # Classify BEFORE printing: an unregistered verdict must fail loud
+    # without emitting a half-block the runner would then contradict (C-101/P7).
+    code = exit_code_for(report.verdict)
     print(render(report))
-    return exit_code_for(report.verdict)
+    return code
 
 
 if __name__ == "__main__":

--- a/tools/liveness/wandb_execution.py
+++ b/tools/liveness/wandb_execution.py
@@ -29,7 +29,7 @@ from dataclasses import dataclass
 from datetime import datetime, timezone
 from typing import Callable, Optional, Tuple
 
-from tools.liveness.report import exit_code_for
+from tools.liveness.report import exit_code_for, one_line
 
 WANDB_ENTITY = "views_pipeline"
 
@@ -94,7 +94,7 @@ def render(report: CheckReport) -> str:
         if run.days_since is not None:
             lines.append(f"{prefix}.days_since: {run.days_since}")
     if report.error is not None:
-        lines.append(f"error: {report.error}")
+        lines.append(f"error: {one_line(report.error)}")
     return "\n".join(lines)
 
 
@@ -125,10 +125,12 @@ class WandbExecutionCheck:
             project = f"{ensemble}_forecasting"
             try:
                 facts = self._latest_run(project)
+                # _judge inside the try: a malformed run (e.g. created_at=None)
+                # is a per-ensemble failure fact, never a check crash (C-101/P4).
+                runs.append(self._judge(ensemble, project, facts, now))
             except Exception as exc:  # noqa: BLE001 — collected; all-fail => UNREACHABLE
                 failures.append(f"{project}: {type(exc).__name__}: {exc}")
                 continue
-            runs.append(self._judge(ensemble, project, facts, now))
 
         if not runs:
             return CheckReport(
@@ -215,8 +217,11 @@ class WandbExecutionCheck:
 def main(check: Optional[WandbExecutionCheck] = None, now: Optional[datetime] = None) -> int:
     """Run the check, print raw facts, return the exit code."""
     report = (check or WandbExecutionCheck()).run(now=now)
+    # Classify BEFORE printing: an unregistered verdict must fail loud
+    # without emitting a half-block the runner would then contradict (C-101/P7).
+    code = exit_code_for(report.verdict)
     print(render(report))
-    return exit_code_for(report.verdict)
+    return code
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Follow-up to epic #238. `/falsify` on "tools.liveness is air and water tight" → **FALSIFIED** (3 hard, 3 soft). This PR registers **C-101** (T2, verdict-truthfulness gaps) + **C-102** (T3, charter coverage gap), fixes everything fixable, and resolves C-101 same-day:

- Multi-line error values no longer break one-fact-per-line (`report.one_line`, was visible in live output)
- Missing `datafactory_query` → truthful `SKIP_NO_PACKAGE` (exit 0), not a false alarm
- Malformed wandb `created_at` → per-ensemble failure fact, not an uncaught crash
- Verdict classified before printing in all six `main()`s (no contradictory double blocks)
- Roster tripwire now parses `monthly_run.sh` (drift fails the suite)
- README non-goals section for C-102 (viewser / website / content sanity — scope decision pending)

Gates: ruff clean · **107 liveness tests green, 1 xfail (= the open C-102 gap, strict)** · live dashboard verdicts unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)