### PR TITLE
test(liveness): ADR-005 'live' marker + taxonomy fix + 100% branch coverage (C-103)

### DIFF
--- a/docs/ADRs/005_testing.md
+++ b/docs/ADRs/005_testing.md
@@ -1,6 +1,6 @@
 # ADR-005: Testing as Mandatory Critical Infrastructure
 
-**Status:** Accepted
+**Status:** Accepted (amended 2026-07-19: fourth category `live`)
 **Date:** 2026-03-15
 **Deciders:** Simon (project maintainer)
 **Informed:** All contributors
@@ -26,6 +26,15 @@ We adopt a three-team testing taxonomy:
 | **Green** (Correctness) | Verify the system works as intended | `test_config_completeness.py` — required keys exist, values are valid |
 | **Beige** (Convention) | Catch configuration drift and convention violations | `test_model_structure.py` — naming, file presence; `test_config_partitions.py` — delegation to shared module; `test_cli_pattern.py` — CLI import consistency |
 | **Red** (Adversarial) | Expose failure modes by testing edge cases | `test_failure_modes.py` — config loading error paths |
+| **Live** (Real-world) | Probe real external services (network, credentials); must `pytest.skip` truthfully when the environment lacks access — never a false red | `tests/test_liveness_*.py` — one live probe per surface (amendment 2026-07-19) |
+
+**Amendment 2026-07-19 (falsify audit, register C-103):** green/beige/red all
+describe *offline* tests distinguished by the question they ask; tests that
+touch the real world are a fourth axis, not a kind of red. The liveness
+suites had mislabeled live network probes as `red` (which means
+adversarial/error-path); those are now `live`, and `red` marks the actual
+error-path tests. Rule: a `live` test asserts only invariants, never
+freshness values, and skips with the reason on any environment failure.
 
 ### Test Design Principles
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,4 +3,5 @@ markers = [
     "red: adversarial / error-path tests (ADR-005)",
     "beige: convention and structural compliance tests (ADR-005)",
     "green: correctness and functional tests (ADR-005)",
+    "live: tests that touch real external services; skip truthfully offline (ADR-005 amendment 2026-07-19)",
 ]

--- a/reports/technical_risk_register.md
+++ b/reports/technical_risk_register.md
@@ -3,7 +3,7 @@
 **Last updated:** 2026-07-19  
 **Governing ADR:** [ADR-010](../docs/ADRs/010_technical_risk_register.md)  
 **Total entries:** 104 (100 concerns + 4 disagreements)  
-**Concerns:** Open 45 | Mitigated 16 | Resolved 37 | Accepted 3 | Partially Resolved 1  
+**Concerns:** Open 46 | Mitigated 16 | Resolved 37 | Accepted 3 | Partially Resolved 1  
 **Disagreements:** Open 4  
 
 ---
@@ -1289,6 +1289,19 @@
 | **Status** | Open |
 | **Location** | `tools/liveness/__main__.py` SURFACES registry: no viewser surface (the ACTUAL input of the four production ensembles; the suite watches the datafactory input production does not yet consume), no website probe (only `api.viewsforecasting.org`); `tools/liveness/unfao_delivery.py` reports `*_newest_bytes` but never judges them (a 12-byte parquet counts as DELIVERING) |
 | **Notes** | Tier 3 rationale: no wrong output is produced — the gap is scope, and the register + README non-goals note make it visible rather than silent. Closing requires a maintainer scope decision: (a) a viewser liveness surface (an S9), (b) a minimum-bytes/row-count judgment on delivered files (liveness vs content-sanity boundary), (c) whether the website is a distinct surface from the API or out of scope. Until decided, the README documents these as known non-goals so all-green cannot be over-read. See also C-99 (heartbeat), C-96 (input freshness class). |
+
+---
+
+### C-103 — liveness test-suite taxonomy contradicts ADR-005; coverage below the "fully covered" bar
+
+| Field | Value |
+|---|---|
+| **Tier** | 3 |
+| **Trigger** | Anyone running `pytest -m red` expecting the adversarial suite (gets six live network probes instead); `pytest -m beige` expecting structural compliance of tools/liveness (gets nothing); or trusting "fully covered" while refactoring the default network clients (95% branch coverage — precisely the default clients' error paths are unwatched) |
+| **Source** | falsify (2026-07-19, claim "100% covered, green/beige/red all around" → FALSIFIED, 3 hard / 2 soft) |
+| **Status** | Open |
+| **Location** | All `tests/test_liveness_*.py`: live network probes marked `red` (ADR-005 red = adversarial/error-path, `pyproject.toml:3`); genuine error-path tests sit under file-level `green`; zero `beige` tests; measured 95% branch coverage (misses: default clients' error branches, `resolve_credentials` fallbacks, `__main__` guards). Enforcement stubs: `tests/test_liveness_taxonomy.py` |
+| **Notes** | Root cause: marker *names* read from pyproject at S1 but not their *definitions* — "red = live/dangerous" was pattern-matched from a template test and WET-propagated through all six suites. Maintainer decision (2026-07-19): **Option A** — amend ADR-005 with a fourth `live` marker for tests that touch real external services; relabel the six probes `live`; red goes to the actual error-path tests; add beige structural suites; close the coverage gap (real tests for the coverable seams, `# pragma: no cover` only for `__main__` guards, with reasons). See also C-101 (same audit series), C-03 (tests not in CI). |
 
 ---
 

--- a/reports/technical_risk_register.md
+++ b/reports/technical_risk_register.md
@@ -3,7 +3,7 @@
 **Last updated:** 2026-07-19  
 **Governing ADR:** [ADR-010](../docs/ADRs/010_technical_risk_register.md)  
 **Total entries:** 104 (100 concerns + 4 disagreements)  
-**Concerns:** Open 46 | Mitigated 16 | Resolved 37 | Accepted 3 | Partially Resolved 1  
+**Concerns:** Open 45 | Mitigated 16 | Resolved 38 | Accepted 3 | Partially Resolved 1  
 **Disagreements:** Open 4  
 
 ---
@@ -1299,7 +1299,7 @@
 | **Tier** | 3 |
 | **Trigger** | Anyone running `pytest -m red` expecting the adversarial suite (gets six live network probes instead); `pytest -m beige` expecting structural compliance of tools/liveness (gets nothing); or trusting "fully covered" while refactoring the default network clients (95% branch coverage — precisely the default clients' error paths are unwatched) |
 | **Source** | falsify (2026-07-19, claim "100% covered, green/beige/red all around" → FALSIFIED, 3 hard / 2 soft) |
-| **Status** | Open |
+| **Status** | Resolved (2026-07-19, same-day fix: ADR-005 amended with the `live` category + pyproject marker; 6 live probes relabeled; 22 error-path tests red-marked; 8 beige structural tests added; coverage closed to 100% branch — real tests for the default clients via fake modules, pragma only on `__main__` guards; taxonomy enforced by `tests/test_liveness_taxonomy.py`) |
 | **Location** | All `tests/test_liveness_*.py`: live network probes marked `red` (ADR-005 red = adversarial/error-path, `pyproject.toml:3`); genuine error-path tests sit under file-level `green`; zero `beige` tests; measured 95% branch coverage (misses: default clients' error branches, `resolve_credentials` fallbacks, `__main__` guards). Enforcement stubs: `tests/test_liveness_taxonomy.py` |
 | **Notes** | Root cause: marker *names* read from pyproject at S1 but not their *definitions* — "red = live/dangerous" was pattern-matched from a template test and WET-propagated through all six suites. Maintainer decision (2026-07-19): **Option A** — amend ADR-005 with a fourth `live` marker for tests that touch real external services; relabel the six probes `live`; red goes to the actual error-path tests; add beige structural suites; close the coverage gap (real tests for the coverable seams, `# pragma: no cover` only for `__main__` guards, with reasons). See also C-101 (same audit series), C-03 (tests not in CI). |
 

--- a/tests/test_liveness_appwrite_store.py
+++ b/tests/test_liveness_appwrite_store.py
@@ -17,7 +17,7 @@ check encodes the REAL IDs and reports drift.
 
 Unit tests are offline (fake fetch, fake credentials, injected clock);
 secrets never appear in any rendered output (pinned test). The live test is
-@pytest.mark.red and skips truthfully.
+@pytest.mark.live and skips truthfully.
 """
 
 from datetime import datetime, timezone
@@ -30,7 +30,6 @@ from tools.liveness.appwrite_store import (
     REAL_PROD_FORECASTS_COLLECTION_ID,
     AppwriteCredentials,
     AppwriteStoreCheck,
-    CheckReport,
     load_credentials_from_env_file,
     main,
     render,
@@ -133,6 +132,7 @@ def test_active_when_newest_file_recent():
     assert report.verdict == "STORE_ACTIVE"
     assert report.days_since_newest == 9
 
+@pytest.mark.red
 def test_unreachable_when_fetch_fails():
     fetch = _fake_fetch({"/storage/": OSError("tls handshake failed")})
     report = AppwriteStoreCheck(credentials=CREDS, fetch=fetch).run(now=NOW)
@@ -176,6 +176,7 @@ def test_real_collection_confirmed_and_wrong_id_absent():
     assert "production_forecasts" in report.collections_found
     assert HISTORICAL_WRONG_COLLECTION_ID not in report.collections_found
 
+@pytest.mark.red
 def test_collection_listing_failure_is_a_fact_not_a_crash():
     fetch = _fake_fetch({"/storage/": FILES_DOC, "/databases/": OSError("403")})
     report = AppwriteStoreCheck(credentials=CREDS, fetch=fetch).run(now=NOW)
@@ -213,6 +214,7 @@ def test_exit_one_idle(capsys):
     fetch = _fake_fetch({"/storage/": FILES_DOC, "/databases/": COLLECTIONS_DOC})
     assert main(check=AppwriteStoreCheck(credentials=CREDS, fetch=fetch), now=NOW) == 1
 
+@pytest.mark.red
 def test_exit_two_unreachable(capsys):
     fetch = _fake_fetch({"/storage/": OSError("boom")})
     assert main(check=AppwriteStoreCheck(credentials=CREDS, fetch=fetch), now=NOW) == 2
@@ -220,7 +222,7 @@ def test_exit_two_unreachable(capsys):
 
 # ── live integration (creds + network; skips truthfully) ──────────────
 
-@pytest.mark.red
+@pytest.mark.live
 def test_live_appwrite_store_invariants():
     check = AppwriteStoreCheck()
     if check.credentials is None:
@@ -233,3 +235,50 @@ def test_live_appwrite_store_invariants():
         pytest.skip(f"appwrite unreachable: {report.error}")
     assert report.total_files and report.total_files > 0
     assert report.real_collection_present is True
+
+
+@pytest.mark.beige
+def test_structural_conventions_appwrite_store():
+    """ADR-005 beige: surface module conventions — check/render/main exposed,
+    and every verdict this surface can emit is registered in the exit map."""
+    import tools.liveness.appwrite_store as module
+    from tools.liveness.report import EXIT_CODE_BY_VERDICT
+
+    assert callable(module.main) and callable(module.render)
+    assert hasattr(module, "CheckReport")
+    for verdict in ('STORE_ACTIVE', 'STORE_IDLE', 'SKIP_NO_CREDENTIALS', 'UNREACHABLE'):
+        assert verdict in EXIT_CODE_BY_VERDICT, verdict
+
+
+def test_resolve_credentials_prefers_process_env(monkeypatch):
+    from tools.liveness import appwrite_api
+
+    monkeypatch.setenv("APPWRITE_ENDPOINT", "https://example.test/v1")
+    monkeypatch.setenv("APPWRITE_DATASTORE_PROJECT_ID", "proj")
+    monkeypatch.setenv("APPWRITE_DATASTORE_API_KEY", "key")
+    credentials = appwrite_api.resolve_credentials()
+    assert credentials == appwrite_api.AppwriteCredentials(
+        "https://example.test/v1", "proj", "key"
+    )
+
+
+def test_resolve_credentials_none_when_nothing_available(monkeypatch):
+    from tools.liveness import appwrite_api
+
+    for name in ("APPWRITE_ENDPOINT", "APPWRITE_DATASTORE_PROJECT_ID",
+                 "APPWRITE_DATASTORE_API_KEY"):
+        monkeypatch.delenv(name, raising=False)
+    monkeypatch.setattr(appwrite_api, "_known_env_files", tuple)
+    assert appwrite_api.resolve_credentials() is None
+
+
+def test_resolve_credentials_skips_env_file_missing_keys(monkeypatch, tmp_path):
+    from tools.liveness import appwrite_api
+
+    for name in ("APPWRITE_ENDPOINT", "APPWRITE_DATASTORE_PROJECT_ID",
+                 "APPWRITE_DATASTORE_API_KEY"):
+        monkeypatch.delenv(name, raising=False)
+    incomplete = tmp_path / ".env"
+    incomplete.write_text("export APPWRITE_ENDPOINT=https://example.test/v1\n")
+    monkeypatch.setattr(appwrite_api, "_known_env_files", lambda: (incomplete,))
+    assert appwrite_api.resolve_credentials() is None

--- a/tests/test_liveness_datafactory_input.py
+++ b/tests/test_liveness_datafactory_input.py
@@ -10,7 +10,7 @@ Ground truth used below (verified live 2026-07-06/19): the store's
 last_valid_month_id was 558; meta/partitions.json currently requires 552.
 
 Unit tests are offline (injected reader + fixed requirements); the single
-live test is @pytest.mark.red and skips truthfully.
+live test is @pytest.mark.live and skips truthfully.
 """
 
 import json
@@ -19,7 +19,6 @@ from pathlib import Path
 import pytest
 
 from tools.liveness.datafactory_input import (
-    CheckReport,
     DatafactoryInputCheck,
     main,
     render,
@@ -79,6 +78,7 @@ def test_stale_when_coverage_short_of_requirement():
     assert report.verdict == "INPUT_STALE"
     assert report.margin_months == -12
 
+@pytest.mark.red
 def test_unreachable_when_reader_fails():
     report = _check(OSError("connection timed out")).run()
     assert report.verdict == "UNREACHABLE"
@@ -115,13 +115,14 @@ def test_exit_zero_when_fresh(capsys):
 def test_exit_one_when_stale(capsys):
     assert main(check=_check(500)) == 1
 
+@pytest.mark.red
 def test_exit_two_when_unreachable(capsys):
     assert main(check=_check(OSError("no route"))) == 2
 
 
 # ── live integration (network + datafactory install; skips truthfully) ─
 
-@pytest.mark.red
+@pytest.mark.live
 def test_live_datafactory_input_invariants():
     try:
         report = DatafactoryInputCheck().run()
@@ -132,3 +133,30 @@ def test_live_datafactory_input_invariants():
     assert report.last_valid_month_id is not None
     assert report.last_valid_month_id > 500  # sanity: post-2021 coverage
     assert report.required_month_id == required_month_id_from_partitions(REPO_ROOT)
+
+
+@pytest.mark.beige
+def test_structural_conventions_datafactory_input():
+    """ADR-005 beige: surface module conventions — check/render/main exposed,
+    and every verdict this surface can emit is registered in the exit map."""
+    import tools.liveness.datafactory_input as module
+    from tools.liveness.report import EXIT_CODE_BY_VERDICT
+
+    assert callable(module.main) and callable(module.render)
+    assert hasattr(module, "CheckReport")
+    for verdict in ('INPUT_FRESH', 'INPUT_STALE', 'SKIP_NO_PACKAGE', 'UNREACHABLE'):
+        assert verdict in EXIT_CODE_BY_VERDICT, verdict
+
+
+@pytest.mark.red
+def test_netrc_probe_failure_never_sinks_the_check():
+    def exploding_probe():
+        raise OSError("~/.netrc unreadable")
+
+    report = DatafactoryInputCheck(
+        read_last_valid_month_id=lambda: 558,
+        netrc_probe=exploding_probe,
+        required_month_id=552,
+    ).run()
+    assert report.netrc_present is None  # unknown, reported as such
+    assert report.verdict == "INPUT_FRESH"

--- a/tests/test_liveness_falsifications.py
+++ b/tests/test_liveness_falsifications.py
@@ -18,7 +18,7 @@ from pathlib import Path
 
 import pytest
 
-from tools.liveness import old_api, vpn_store
+from tools.liveness import vpn_store
 from tools.liveness.__main__ import run_all
 from tools.liveness.datafactory_input import DatafactoryInputCheck
 from tools.liveness.report import exit_code_for
@@ -29,6 +29,7 @@ pytestmark = pytest.mark.green
 _REPO_ROOT = Path(__file__).resolve().parent.parent
 
 
+@pytest.mark.red
 def test_p1_multiline_error_value_stays_one_fact_per_line():
     """P1 (hard): render contract is 'one fact per line, key: value', but a
     multi-line error value (seen live: sqlalchemy OperationalError) emits
@@ -56,6 +57,7 @@ def test_p2_datafactory_input_missing_package_is_truthful_skip():
     assert exit_code_for(report.verdict) == 0
 
 
+@pytest.mark.red
 def test_p4_wandb_malformed_created_at_does_not_crash_the_check():
     """P4 (hard): _judge runs outside the per-ensemble try; one run with a
     malformed created_at crashes the whole check uncaught (standalone module
@@ -75,6 +77,7 @@ def test_p4_wandb_malformed_created_at_does_not_crash_the_check():
     assert report.error is not None  # the malformed ensemble is a reported fact
 
 
+@pytest.mark.beige
 def test_p5_monthly_ensembles_mirrors_monthly_run_sh():
     """P5 (soft): the docstring says 'update BOTH when the roster changes'
     but nothing enforced it. This IS the tripwire: it passes today and fails

--- a/tests/test_liveness_old_api.py
+++ b/tests/test_liveness_old_api.py
@@ -10,7 +10,7 @@ REAL API response captured live on 2026-07-19 (CAPTURED_RUNS below, verbatim,
     published as fatalities003_2026_05_t01.
 
 Unit tests are offline (fake fetch, injected clock). The single live test is
-@pytest.mark.red and skips truthfully on any network problem (house pattern:
+@pytest.mark.live and skips truthfully on any network problem (house pattern:
 tests/test_reconciliation_viewser_provider.py).
 """
 
@@ -136,6 +136,7 @@ def test_parses_canonical_run_name():
 def test_parses_second_tag_sequence():
     assert parse_run_name("fatalities002_2023_09_t02") == (2, 2023, 9, 2)
 
+@pytest.mark.red
 def test_rejects_legacy_month_zero_names():
     # fatalities001_2022_00_t01 is real in the listing; month 00 must not
     # reach the month math (S1 review finding).
@@ -143,6 +144,7 @@ def test_rejects_legacy_month_zero_names():
 
 @pytest.mark.parametrize("name", ["escwa_2021_02_01", "d_2021_02_01", "r_2021_12_01",
                                   "escwa_features_2021_05_01", "f_2021_06_01", ""])
+@pytest.mark.red
 def test_rejects_non_fatalities_names(name):
     assert parse_run_name(name) is None
 
@@ -196,12 +198,14 @@ def test_fresh_when_cutoff_within_budget():
     assert report.months_behind == FRESHNESS_BUDGET_MONTHS == 2
     assert report.latest_run == "fatalities003_2026_05_t01"
 
+@pytest.mark.red
 def test_stale_when_cutoff_beyond_budget():
     fetch = _fake_fetch({"?month=": SERVING_ROWS, BASE_URL: _runs_doc(CAPTURED_RUNS)})
     report = OldApiCheck(fetch=fetch).run(now_month_id=CAPTURE_NOW + 1)  # Aug: 3 behind
     assert report.verdict == "LIVE_STALE"
     assert report.months_behind == 3
 
+@pytest.mark.red
 def test_unreachable_when_list_fetch_fails():
     fetch = _fake_fetch({BASE_URL: OSError("connection refused")})
     report = OldApiCheck(fetch=fetch).run(now_month_id=CAPTURE_NOW)
@@ -256,6 +260,7 @@ def test_exit_one_when_not_serving(capsys):
     fetch = _fake_fetch({"?month=": EMPTY_ROWS, BASE_URL: _runs_doc(CAPTURED_RUNS)})
     assert main(fetch=fetch, now_month_id=CAPTURE_NOW) == 1
 
+@pytest.mark.red
 def test_exit_two_when_unreachable(capsys):
     fetch = _fake_fetch({BASE_URL: OSError("no route")})
     assert main(fetch=fetch, now_month_id=CAPTURE_NOW) == 2
@@ -263,7 +268,7 @@ def test_exit_two_when_unreachable(capsys):
 
 # ── live integration (network; skips truthfully) ──────────────────────
 
-@pytest.mark.red
+@pytest.mark.live
 def test_live_old_api_invariants():
     try:
         report = OldApiCheck().run()
@@ -274,3 +279,52 @@ def test_live_old_api_invariants():
     assert report.run_count and report.run_count > 0
     assert report.latest_run is not None
     assert parse_run_name(report.latest_run) is not None
+
+
+@pytest.mark.beige
+def test_structural_conventions_old_api():
+    """ADR-005 beige: surface module conventions — check/render/main exposed,
+    and every verdict this surface can emit is registered in the exit map."""
+    import tools.liveness.old_api as module
+    from tools.liveness.report import EXIT_CODE_BY_VERDICT
+
+    assert callable(module.main) and callable(module.render)
+    assert hasattr(module, "CheckReport")
+    for verdict in ('LIVE_FRESH', 'LIVE_STALE', 'LIVE_NOT_SERVING', 'UNREACHABLE'):
+        assert verdict in EXIT_CODE_BY_VERDICT, verdict
+
+
+def test_latest_run_keeps_best_over_older_candidates():
+    assert latest_fatalities_run(
+        ["fatalities003_2026_05_t01", "fatalities001_2020_01_t01"]
+    ) == "fatalities003_2026_05_t01"
+
+
+@pytest.mark.red
+def test_serving_probe_error_is_a_fact_not_a_crash():
+    def fetch(url):
+        if url.endswith("/"):
+            return {"runs": ["fatalities003_2026_05_t01"]}
+        raise TimeoutError("serving probe timed out")
+
+    report = OldApiCheck(fetch=fetch).run(now_month_id=559)
+    assert report.verdict == "LIVE_NOT_SERVING"
+    assert "TimeoutError" in report.error
+
+
+def test_default_fetch_uses_stdlib_urllib(monkeypatch):
+    import io
+    import urllib.request
+
+    class FakeResponse(io.BytesIO):
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *exc):
+            return False
+
+    monkeypatch.setattr(
+        urllib.request, "urlopen",
+        lambda url, timeout: FakeResponse(b'{"runs": []}'),
+    )
+    assert OldApiCheck._fetch_json("https://example.test/") == {"runs": []}

--- a/tests/test_liveness_runner.py
+++ b/tests/test_liveness_runner.py
@@ -70,6 +70,7 @@ def test_run_all_prints_blocks_and_returns_worst(capsys):
     assert code == 1
     assert "alpha" in out and "beta" in out and "gamma" in out
 
+@pytest.mark.red
 def test_run_all_unreachable_dominates(capsys):
     fakes = [("a", lambda: 1), ("b", lambda: 2)]
     assert run_all(surfaces=fakes) == 2
@@ -78,6 +79,7 @@ def test_run_all_all_green(capsys):
     fakes = [("a", lambda: 0), ("b", lambda: 0)]
     assert run_all(surfaces=fakes) == 0
 
+@pytest.mark.red
 def test_run_all_survives_a_crashing_check(capsys):
     def boom():
         raise RuntimeError("check exploded")
@@ -93,3 +95,13 @@ def test_run_all_survives_a_crashing_check(capsys):
 def test_all_surface_mains_importable():
     for name, main_callable in SURFACES:
         assert callable(main_callable), name
+
+
+@pytest.mark.beige
+def test_structural_conventions_runner():
+    """ADR-005 beige: registry structure — six uniquely named surfaces, all
+    runnable, in the canonical order."""
+    names = [name for name, _ in SURFACES]
+    assert names == ["old_api", "datafactory_input", "appwrite_store",
+                     "unfao_delivery", "wandb_execution", "vpn_store"]
+    assert all(callable(run_main) for _, run_main in SURFACES)

--- a/tests/test_liveness_taxonomy.py
+++ b/tests/test_liveness_taxonomy.py
@@ -1,0 +1,81 @@
+"""Failing stubs from the 2026-07-19 falsification audit of the CLAIM
+"tools.liveness is 100% test covered, green/beige/red all around".
+
+Verdict: FALSIFIED. These meta-tests encode the gaps; they FAIL until the
+taxonomy work lands. ADR-005 (pyproject.toml markers): green = correctness/
+functional, beige = convention/structural compliance, red = adversarial/
+error-path. NOTE: red does NOT mean "live network probe" — the liveness
+suites currently misuse it that way.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.beige  # these ARE structural-compliance tests
+
+_TESTS_DIR = Path(__file__).resolve().parent
+_SUITE_FILES = sorted(
+    p for p in _TESTS_DIR.glob("test_liveness_*.py")
+    if p.name not in {"test_liveness_taxonomy.py"}
+)
+
+# Error-path / adversarial tests are recognizable by what they exercise.
+_ERROR_PATH_NAME = re.compile(
+    r"def (test_[a-z0-9_]*(unreachable|malformed|rejects|crash|breaks|"
+    r"error|failure|stale[a-z0-9_]*budget)[a-z0-9_]*)\("
+)
+
+
+def test_every_liveness_suite_has_beige_structural_tests():
+    """ADR-005 beige = convention/structural compliance. The claim says
+    'beige all around'; today NO liveness test file contains a single
+    beige-marked test."""
+    missing = [
+        f.name for f in _SUITE_FILES if "beige" not in f.read_text()
+    ]
+    assert not missing, f"suites with zero beige tests: {missing}"
+
+
+def test_error_path_tests_carry_the_red_marker():
+    """ADR-005 red = adversarial/error-path. The liveness suites' actual
+    adversarial tests (UNREACHABLE paths, malformed inputs, rejection cases)
+    sit under file-level green; the red marker is spent on live network
+    probes instead. Error-path tests must be red-marked."""
+    offenders = []
+    for suite in _SUITE_FILES:
+        text = suite.read_text()
+        for match in _ERROR_PATH_NAME.finditer(text):
+            # Look for a red mark in the decorator block above the def.
+            preceding = text[: match.start()].rsplit("\n\n", 1)[-1]
+            if "pytest.mark.red" not in preceding:
+                offenders.append(f"{suite.name}::{match.group(1)}")
+    assert not offenders, (
+        f"{len(offenders)} error-path tests not red-marked, e.g. {offenders[:5]}"
+    )
+
+
+def test_liveness_branch_coverage_is_complete():
+    """The claim says 100% covered; measured 2026-07-19: 95% branch coverage
+    (21 statements + 13 partial branches missed — default network clients'
+    error paths, resolve_credentials fallbacks, __main__ guards). Skips when
+    coverage tooling is absent; fails at the claimed bar when present."""
+    pytest.importorskip("coverage")
+    import subprocess
+    import sys
+
+    repo_root = _TESTS_DIR.parent
+    subprocess.run(
+        [sys.executable, "-m", "coverage", "run", "--branch",
+         "--source=tools/liveness", "-m", "pytest", "tests/", "-k",
+         "liveness and not taxonomy", "-q"],
+        cwd=repo_root, capture_output=True, check=False,
+    )
+    result = subprocess.run(
+        [sys.executable, "-m", "coverage", "report", "--format=total"],
+        cwd=repo_root, capture_output=True, text=True, check=False,
+    )
+    assert result.stdout.strip() == "100", f"coverage: {result.stdout.strip()}%"

--- a/tests/test_liveness_unfao_delivery.py
+++ b/tests/test_liveness_unfao_delivery.py
@@ -19,8 +19,6 @@ import pytest
 
 from tools.liveness.appwrite_store import AppwriteCredentials
 from tools.liveness.unfao_delivery import (
-    UNFAO_BUCKET_ID,
-    CheckReport,
     UnfaoDeliveryCheck,
     main,
     render,
@@ -107,6 +105,7 @@ def test_missing_stream_reported_as_never_delivered():
     assert report.forecast_verdict == "NEVER_DELIVERED"
     assert report.verdict == "DELIVERY_STALLED"
 
+@pytest.mark.red
 def test_unreachable_when_fetch_fails():
     report = UnfaoDeliveryCheck(credentials=CREDS,
                                 fetch=_fake_fetch({"unfao_bucket/files": OSError("dns fail")})).run(now=NOW)
@@ -143,6 +142,7 @@ def test_exit_one_stalled(capsys):
     fetch = _fake_fetch(_responses(REAL_FORECAST_DOC, REAL_HISTORICAL_DOC, REAL_OVERALL_DOC))
     assert main(check=UnfaoDeliveryCheck(credentials=CREDS, fetch=fetch), now=NOW) == 1
 
+@pytest.mark.red
 def test_exit_two_unreachable(capsys):
     fetch = _fake_fetch({"unfao_bucket/files": OSError("boom")})
     assert main(check=UnfaoDeliveryCheck(credentials=CREDS, fetch=fetch), now=NOW) == 2
@@ -150,7 +150,7 @@ def test_exit_two_unreachable(capsys):
 
 # ── live integration (creds + network; skips truthfully) ──────────────
 
-@pytest.mark.red
+@pytest.mark.live
 def test_live_unfao_delivery_invariants():
     check = UnfaoDeliveryCheck()
     if check.credentials is None:
@@ -163,3 +163,16 @@ def test_live_unfao_delivery_invariants():
         pytest.skip(f"unfao bucket unreachable: {report.error}")
     assert report.total_files and report.total_files > 0
     assert report.forecast_newest_name is not None
+
+
+@pytest.mark.beige
+def test_structural_conventions_unfao_delivery():
+    """ADR-005 beige: surface module conventions — check/render/main exposed,
+    and every verdict this surface can emit is registered in the exit map."""
+    import tools.liveness.unfao_delivery as module
+    from tools.liveness.report import EXIT_CODE_BY_VERDICT
+
+    assert callable(module.main) and callable(module.render)
+    assert hasattr(module, "CheckReport")
+    for verdict in ('DELIVERING', 'DELIVERY_STALLED', 'SKIP_NO_CREDENTIALS', 'UNREACHABLE'):
+        assert verdict in EXIT_CODE_BY_VERDICT, verdict

--- a/tests/test_liveness_vpn_store.py
+++ b/tests/test_liveness_vpn_store.py
@@ -17,14 +17,12 @@ Run-name parsing and freshness reuse S1 (tools.liveness.old_api) — one
 parser, one convention, everywhere.
 """
 
-from datetime import date
 
 import pytest
 
 from tools.liveness.old_api import FRESHNESS_BUDGET_MONTHS
 from tools.liveness.vpn_store import (
     STORE_HOST,
-    CheckReport,
     VpnStoreCheck,
     main,
     render,
@@ -60,11 +58,13 @@ def test_fresh_when_latest_within_budget():
     assert report.months_behind == FRESHNESS_BUDGET_MONTHS == 2
     assert report.latest_max_month == 593
 
+@pytest.mark.red
 def test_stale_when_latest_beyond_budget():
     report = VpnStoreCheck(list_runs=_client(RUN_ROWS)).run(now_month_id=CAPTURE_NOW + 3)
     assert report.verdict == "STORE_STALE"
     assert report.months_behind == 5
 
+@pytest.mark.red
 def test_vpn_required_on_host_resolution_failure():
     err = OSError('could not translate host name "gjoll.muspelheim.local" to address')
     report = VpnStoreCheck(list_runs=_client(err)).run(now_month_id=CAPTURE_NOW)
@@ -77,6 +77,7 @@ def test_skip_when_package_missing():
     )
     assert report.verdict == "SKIP_NO_PACKAGE"
 
+@pytest.mark.red
 def test_unreachable_on_other_errors():
     report = VpnStoreCheck(list_runs=_client(RuntimeError("password authentication failed"))).run(
         now_month_id=CAPTURE_NOW
@@ -115,13 +116,14 @@ def test_exit_zero_vpn_required(capsys):
 def test_exit_one_stale(capsys):
     assert main(check=VpnStoreCheck(list_runs=_client(RUN_ROWS)), now_month_id=CAPTURE_NOW + 6) == 1
 
+@pytest.mark.red
 def test_exit_two_unreachable(capsys):
     assert main(check=VpnStoreCheck(list_runs=_client(RuntimeError("boom"))), now_month_id=CAPTURE_NOW) == 2
 
 
 # ── live integration (VPN + package; skips truthfully) ────────────────
 
-@pytest.mark.red
+@pytest.mark.live
 def test_live_vpn_store_invariants():
     try:
         report = VpnStoreCheck().run()
@@ -130,3 +132,45 @@ def test_live_vpn_store_invariants():
     if report.verdict in ("VPN_REQUIRED", "SKIP_NO_PACKAGE", "UNREACHABLE"):
         pytest.skip(f"vpn store not reachable here: {report.verdict} {report.error or ''}")
     assert report.latest_run is not None
+
+
+@pytest.mark.beige
+def test_structural_conventions_vpn_store():
+    """ADR-005 beige: surface module conventions — check/render/main exposed,
+    and every verdict this surface can emit is registered in the exit map."""
+    import tools.liveness.vpn_store as module
+    from tools.liveness.report import EXIT_CODE_BY_VERDICT
+
+    assert callable(module.main) and callable(module.render)
+    assert hasattr(module, "CheckReport")
+    for verdict in ('STORE_FRESH', 'STORE_STALE', 'VPN_REQUIRED', 'SKIP_NO_PACKAGE', 'UNREACHABLE'):
+        assert verdict in EXIT_CODE_BY_VERDICT, verdict
+
+
+def test_default_client_flattens_the_metadata_frame(monkeypatch):
+    import sys
+    import types
+
+    class FakeFrame:
+        def reset_index(self):
+            return self
+
+        def __getitem__(self, columns):
+            return self
+
+        def to_dict(self, orient):
+            assert orient == "records"
+            return [{"name": "fatalities003_2026_05_t01",
+                     "min_month": 409, "max_month": 593}]
+
+    db_ops = types.ModuleType("views_forecasts.db_ops")
+    db_ops.ViewsMetadata = type(
+        "ViewsMetadata", (), {"get_runs": lambda self: FakeFrame()}
+    )
+    package = types.ModuleType("views_forecasts")
+    package.db_ops = db_ops
+    monkeypatch.setitem(sys.modules, "views_forecasts", package)
+    monkeypatch.setitem(sys.modules, "views_forecasts.db_ops", db_ops)
+    rows = VpnStoreCheck._list_runs_via_views_forecasts()
+    assert rows == [{"name": "fatalities003_2026_05_t01",
+                     "min_month": 409, "max_month": 593}]

--- a/tests/test_liveness_wandb_execution.py
+++ b/tests/test_liveness_wandb_execution.py
@@ -15,7 +15,7 @@ Each run's config also records its train-window end (the data-cutoff receipt
 that resolved the run-naming ambiguity: June-29 runs trained to month 557).
 
 Unit tests are offline (injected client + clock); the live test is
-@pytest.mark.red and skips truthfully.
+@pytest.mark.live and skips truthfully.
 """
 
 from datetime import datetime, timezone
@@ -23,10 +23,8 @@ from datetime import datetime, timezone
 import pytest
 
 from tools.liveness.wandb_execution import (
-    CYCLE_BUDGET_DAYS,
     MONTHLY_ENSEMBLES,
     CheckReport,
-    EnsembleRun,
     WandbExecutionCheck,
     main,
     render,
@@ -95,6 +93,7 @@ def test_unfinished_latest_run_is_not_computed():
     assert by_name["skinny_love"].verdict == "NOT_COMPUTED"
     assert report.verdict == "EXECUTION_STALE"
 
+@pytest.mark.red
 def test_unreachable_when_client_fails():
     facts = {p: OSError("api down") for p in REAL_FACTS}
     report = WandbExecutionCheck(latest_run=_client(facts), netrc_probe=lambda: True).run(now=NOW)
@@ -133,6 +132,7 @@ def test_exit_one_stale(capsys):
     check = WandbExecutionCheck(latest_run=_client(facts), netrc_probe=lambda: True)
     assert main(check=check, now=NOW) == 1
 
+@pytest.mark.red
 def test_exit_two_unreachable(capsys):
     facts = {p: OSError("down") for p in REAL_FACTS}
     check = WandbExecutionCheck(latest_run=_client(facts), netrc_probe=lambda: True)
@@ -141,7 +141,7 @@ def test_exit_two_unreachable(capsys):
 
 # ── live integration (netrc + network; skips truthfully) ──────────────
 
-@pytest.mark.red
+@pytest.mark.live
 def test_live_wandb_execution_invariants():
     check = WandbExecutionCheck()
     try:
@@ -152,3 +152,97 @@ def test_live_wandb_execution_invariants():
         pytest.skip(f"wandb not checkable here: {report.verdict} {report.error or ''}")
     assert len(report.ensembles) == len(MONTHLY_ENSEMBLES)
     assert any(e.created_at is not None for e in report.ensembles)
+
+
+@pytest.mark.beige
+def test_structural_conventions_wandb_execution():
+    """ADR-005 beige: surface module conventions — check/render/main exposed,
+    and every verdict this surface can emit is registered in the exit map."""
+    import tools.liveness.wandb_execution as module
+    from tools.liveness.report import EXIT_CODE_BY_VERDICT
+
+    assert callable(module.main) and callable(module.render)
+    assert hasattr(module, "CheckReport")
+    for verdict in ('EXECUTION_CURRENT', 'EXECUTION_STALE', 'SKIP_NO_CREDENTIALS', 'UNREACHABLE'):
+        assert verdict in EXIT_CODE_BY_VERDICT, verdict
+
+
+@pytest.mark.red
+def test_netrc_probe_failure_never_sinks_the_check():
+    def exploding_probe():
+        raise OSError("~/.netrc unreadable")
+
+    check = WandbExecutionCheck(
+        latest_run=lambda project: None, netrc_probe=exploding_probe
+    )
+    report = check.run(now=datetime(2026, 7, 19, tzinfo=timezone.utc))
+    assert report.netrc_present is None  # unknown, reported as such
+    assert report.verdict == "EXECUTION_STALE"  # all NEVER_RUN
+
+
+def test_render_omits_unknown_netrc_hint():
+    report = CheckReport(verdict="UNREACHABLE", netrc_present=None, error="boom")
+    assert "netrc_present" not in render(report)
+
+
+def _fake_wandb_module(behavior):
+    import types
+
+    class FakeApi:
+        def __init__(self, timeout=None):
+            pass
+
+        def runs(self, path, order=None, per_page=None):
+            return behavior(path)
+
+    module = types.ModuleType("wandb")
+    module.Api = FakeApi
+    return module
+
+
+def test_default_client_reads_newest_run(monkeypatch):
+    import sys
+    import types
+
+    run = types.SimpleNamespace(
+        name="vivid-flower-127", created_at="2026-06-29T16:56:27Z",
+        state="finished", config={"forecasting": {"train": (121, 557)}},
+    )
+    monkeypatch.setitem(
+        sys.modules, "wandb", _fake_wandb_module(lambda path: iter([run]))
+    )
+    facts = WandbExecutionCheck._latest_run_via_wandb("pink_ponyclub_forecasting")
+    assert facts == {"run_name": "vivid-flower-127",
+                     "created_at": "2026-06-29T16:56:27Z",
+                     "state": "finished", "train_end_month_id": 557}
+
+
+def test_default_client_returns_none_for_absent_project(monkeypatch):
+    import sys
+
+    def not_found(path):
+        raise ValueError(f"Could not find project {path}")
+
+    monkeypatch.setitem(sys.modules, "wandb", _fake_wandb_module(not_found))
+    assert WandbExecutionCheck._latest_run_via_wandb("gone_forecasting") is None
+
+
+def test_default_client_returns_none_for_empty_project(monkeypatch):
+    import sys
+
+    monkeypatch.setitem(
+        sys.modules, "wandb", _fake_wandb_module(lambda path: iter([]))
+    )
+    assert WandbExecutionCheck._latest_run_via_wandb("empty_forecasting") is None
+
+
+@pytest.mark.red
+def test_default_client_reraises_other_errors(monkeypatch):
+    import sys
+
+    def exploding(path):
+        raise RuntimeError("api down")
+
+    monkeypatch.setitem(sys.modules, "wandb", _fake_wandb_module(exploding))
+    with pytest.raises(RuntimeError):
+        WandbExecutionCheck._latest_run_via_wandb("pink_ponyclub_forecasting")

--- a/tools/liveness/README.md
+++ b/tools/liveness/README.md
@@ -145,3 +145,9 @@ Run the offline suite:
 ```bash
 conda run -n views_pipeline python -m pytest tests/ -k liveness
 ```
+
+Tests are marked per ADR-005 (amended 2026-07-19): `green` correctness,
+`beige` convention/structural compliance, `red` adversarial/error-path,
+`live` real-external-service probes (skip truthfully offline). Branch
+coverage of `tools/liveness` is 100% (only `__main__` guards pragma'd,
+with reasons); `tests/test_liveness_taxonomy.py` enforces the taxonomy.

--- a/tools/liveness/__main__.py
+++ b/tools/liveness/__main__.py
@@ -51,4 +51,4 @@ def run_all(surfaces: Optional[Tuple[Tuple[str, Callable[[], int]], ...]] = None
 
 
 if __name__ == "__main__":
-    raise SystemExit(run_all())
+    raise SystemExit(run_all())  # pragma: no cover — __main__ guard

--- a/tools/liveness/appwrite_store.py
+++ b/tools/liveness/appwrite_store.py
@@ -211,4 +211,4 @@ def main(check: Optional[AppwriteStoreCheck] = None, now: Optional[datetime] = N
 
 
 if __name__ == "__main__":
-    raise SystemExit(main())
+    raise SystemExit(main())  # pragma: no cover — __main__ guard

--- a/tools/liveness/datafactory_input.py
+++ b/tools/liveness/datafactory_input.py
@@ -170,4 +170,4 @@ def main(check: Optional[DatafactoryInputCheck] = None) -> int:
 
 
 if __name__ == "__main__":
-    raise SystemExit(main())
+    raise SystemExit(main())  # pragma: no cover — __main__ guard

--- a/tools/liveness/old_api.py
+++ b/tools/liveness/old_api.py
@@ -228,4 +228,4 @@ def main(
 
 
 if __name__ == "__main__":
-    raise SystemExit(main())
+    raise SystemExit(main())  # pragma: no cover — __main__ guard

--- a/tools/liveness/unfao_delivery.py
+++ b/tools/liveness/unfao_delivery.py
@@ -202,4 +202,4 @@ def main(check: Optional[UnfaoDeliveryCheck] = None, now: Optional[datetime] = N
 
 
 if __name__ == "__main__":
-    raise SystemExit(main())
+    raise SystemExit(main())  # pragma: no cover — __main__ guard

--- a/tools/liveness/vpn_store.py
+++ b/tools/liveness/vpn_store.py
@@ -175,4 +175,4 @@ def main(check: Optional[VpnStoreCheck] = None, now_month_id: Optional[int] = No
 
 
 if __name__ == "__main__":
-    raise SystemExit(main())
+    raise SystemExit(main())  # pragma: no cover — __main__ guard

--- a/tools/liveness/wandb_execution.py
+++ b/tools/liveness/wandb_execution.py
@@ -225,4 +225,4 @@ def main(check: Optional[WandbExecutionCheck] = None, now: Optional[datetime] = 
 
 
 if __name__ == "__main__":
-    raise SystemExit(main())
+    raise SystemExit(main())  # pragma: no cover — __main__ guard


### PR DESCRIPTION
Second falsify round on tools.liveness (claim: *100% covered, green/beige/red all around* → FALSIFIED). Registers and same-day-resolves **C-103**:

- **ADR-005 amendment (Option A, maintainer-decided):** new `live` marker for real-external-service probes; the six network probes relabeled `red`→`live`; `red` now marks the 22 actual adversarial/error-path tests; 8 new `beige` structural tests.
- **Coverage 95% → 100% branch** — real offline tests for the default network clients via fake modules; `# pragma: no cover` only on `__main__` guards.
- `tests/test_liveness_taxonomy.py` enforces all of it going forward.

Gates: ruff clean · 130 liveness tests green · full-suite failures are the 10 known pre-existing ones (dwarf models / parity / merge-readiness tripwire), none in liveness.

🤖 Generated with [Claude Code](https://claude.com/claude-code)