### PR TITLE
feat(liveness): old_api serving probe covers both cm and pgm levels

### DIFF
--- a/tests/test_liveness_old_api.py
+++ b/tests/test_liveness_old_api.py
@@ -232,7 +232,8 @@ def test_report_contains_literal_url_and_run_name():
     assert report.run_count == len(CAPTURED_RUNS)
     assert report.data_cutoff_month_id == 557
     assert report.data_cutoff_date == "2026-05"
-    assert report.serving_rows_sampled == 2
+    assert report.serving_rows_cm == 2
+    assert report.serving_rows_pgm == 2
 
 def test_render_is_one_fact_per_line():
     fetch = _fake_fetch({"?month=": SERVING_ROWS, BASE_URL: _runs_doc(CAPTURED_RUNS)})
@@ -328,3 +329,28 @@ def test_default_fetch_uses_stdlib_urllib(monkeypatch):
         lambda url, timeout: FakeResponse(b'{"runs": []}'),
     )
     assert OldApiCheck._fetch_json("https://example.test/") == {"runs": []}
+
+
+
+# ── the pgm serving probe (both levels must serve) ────────────────────
+
+def test_not_serving_when_pgm_empty_but_cm_serves():
+    """A run that serves country-month but returns nothing at grid level is
+    NOT fully serving — the 2026-07-19 'one endpoint' gap."""
+    fetch = _fake_fetch({
+        "/pgm?": EMPTY_ROWS,
+        "?month=": SERVING_ROWS,
+        BASE_URL: _runs_doc(CAPTURED_RUNS),
+    })
+    report = OldApiCheck(fetch=fetch).run(now_month_id=CAPTURE_NOW)
+    assert report.verdict == "LIVE_NOT_SERVING"
+    assert report.serving_rows_cm == 2
+    assert report.serving_rows_pgm == 0
+
+
+def test_render_shows_both_serving_levels():
+    fetch = _fake_fetch({"?month=": SERVING_ROWS, BASE_URL: _runs_doc(CAPTURED_RUNS)})
+    text = render(OldApiCheck(fetch=fetch).run(now_month_id=CAPTURE_NOW))
+    assert "serving_rows_cm: 2" in text
+    assert "serving_rows_pgm: 2" in text
+

--- a/tools/liveness/README.md
+++ b/tools/liveness/README.md
@@ -43,7 +43,8 @@ Is the newest published fatalities run fresh, and does it actually serve rows?
   behind the current calendar month = 1 month publication lag + 1 grace).
 - `LIVE_STALE` — listed but too old; `months_behind` says how far.
 - `LIVE_NOT_SERVING` — run is listed but returned no rows for its first
-  forecast month.
+  forecast month at **either** data level (`cm` and `pgm` are both probed;
+  a run serving country-month but empty at grid level is not serving).
 - `UNREACHABLE`.
 
 ### `datafactory_input` — the datafactory zarr input store

--- a/tools/liveness/old_api.py
+++ b/tools/liveness/old_api.py
@@ -20,7 +20,9 @@ THE NAMING CONVENTION (encoded once — CONFIRMED by the API's own docs):
 
 API facts (captured live 2026-07-19):
     GET /                      -> {"runs": [...]}  (NOT chronologically sorted)
-    GET /{run}/cm?month={id}&pagesize=N -> {"data": [rows...]}
+    GET /{run}/{level}?month={id}&pagesize=N -> {"data": [rows...]}
+        levels: cm (country_id keys) and pgm (pg_id keys) — both confirmed
+        served by the latest run; a run empty at EITHER level is not serving
     unknown run                -> HTTP 422
 
 Design: injected fetch callable (DIP; mirrors
@@ -50,6 +52,9 @@ FRESHNESS_BUDGET_MONTHS = PUBLICATION_LAG_MONTHS + GRACE_MONTHS
 
 _FETCH_TIMEOUT_SECONDS = 20
 _SERVING_SAMPLE_PAGESIZE = 2
+
+# Both public data levels must serve rows for a run to count as serving.
+SERVING_LEVELS = ("cm", "pgm")
 
 _RUN_NAME_PATTERN = re.compile(r"^fatalities(\d+)_(\d{4})_(\d{2})_t(\d+)$")
 
@@ -104,7 +109,8 @@ class CheckReport:
     data_cutoff_date: Optional[str] = None
     now_month_id: Optional[int] = None
     months_behind: Optional[int] = None
-    serving_rows_sampled: Optional[int] = None
+    serving_rows_cm: Optional[int] = None
+    serving_rows_pgm: Optional[int] = None
     error: Optional[str] = None
 
 
@@ -121,7 +127,8 @@ def render(report: CheckReport) -> str:
         ("now_month_id", report.now_month_id),
         ("months_behind", report.months_behind),
         ("freshness_budget_months", FRESHNESS_BUDGET_MONTHS),
-        ("serving_rows_sampled", report.serving_rows_sampled),
+        ("serving_rows_cm", report.serving_rows_cm),
+        ("serving_rows_pgm", report.serving_rows_pgm),
         ("error", report.error),
     ]
     return render_facts(facts)
@@ -166,9 +173,15 @@ class OldApiCheck:
         cutoff_id = date_to_month_id(year, month)
         months_behind = now_month_id - cutoff_id
 
-        rows_sampled, serving_error = self._sample_serving_rows(latest, cutoff_id)
+        sampled = {}
+        errors = []
+        for level in SERVING_LEVELS:
+            rows, level_error = self._sample_serving_rows(latest, cutoff_id, level)
+            sampled[level] = rows
+            if level_error is not None:
+                errors.append(f"{level}: {level_error}")
 
-        if rows_sampled == 0:
+        if min(sampled.values()) == 0:
             verdict = "LIVE_NOT_SERVING"
         elif months_behind <= FRESHNESS_BUDGET_MONTHS:
             verdict = "LIVE_FRESH"
@@ -184,16 +197,17 @@ class OldApiCheck:
             data_cutoff_date=month_id_to_date(cutoff_id),
             now_month_id=now_month_id,
             months_behind=months_behind,
-            serving_rows_sampled=rows_sampled,
-            error=serving_error,
+            serving_rows_cm=sampled["cm"],
+            serving_rows_pgm=sampled["pgm"],
+            error="; ".join(errors) if errors else None,
         )
 
     def _sample_serving_rows(
-        self, run_name: str, cutoff_id: int
+        self, run_name: str, cutoff_id: int, level: str
     ) -> Tuple[int, Optional[str]]:
         """Sample rows from the run's first forecast month (cutoff + 1)."""
         url = (
-            f"{BASE_URL}/{run_name}/cm"
+            f"{BASE_URL}/{run_name}/{level}"
             f"?month={cutoff_id + 1}&pagesize={_SERVING_SAMPLE_PAGESIZE}"
         )
         try:


### PR DESCRIPTION
Closes the "one endpoint" gap surfaced in review of the liveness suite: the serving probe only sampled `/{run}/cm`, so a run empty at grid level still read LIVE_FRESH. Now both public data levels are sampled; empty at either → `LIVE_NOT_SERVING`. New facts `serving_rows_cm`/`serving_rows_pgm`.

Live verification: `fatalities003_2026_05_t01` serves 2/2 rows (cm/pgm) → LIVE_FRESH. TDD, 132 liveness tests green, branch coverage 100%, ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)