### PR TITLE
feat(tests): family-agnostic sample-count reader + decoy-divergence guard (C-104, sprint S3)

### DIFF
--- a/docs/ADRs/015_posterior_sample_count_standard.md
+++ b/docs/ADRs/015_posterior_sample_count_standard.md
@@ -39,6 +39,9 @@ This pulls the check forward to CI — a mismatch fails in seconds, not at minut
 ### 4. A non-blocking report surfaces off-standard counts
 `tests/test_sample_count_standard.py` emits a **warning** (never fails) listing sample-producing models whose `n_posterior_samples != 128`, so drift is visible without crying wolf. A true **runtime** log-warning on forecasting/production runs is a pipeline-core follow-up (views-models cannot add runtime behaviour without touching the immutable `run.sh` / per-model `main.py`).
 
+### 5. The count reader is family-agnostic and divergence-guarded (amended 2026-07-20, register C-104)
+Posterior sample count is named differently by each family's runtime — baseline `n_samples`, hydranet `n_posterior_samples`, r2darts `num_samples`, stepshifter `pred_samples` — while the runtime object and the ADR-013 wire already agree on one name (`PredictionFrame.sample_count`). `conftest.get_n_posterior_samples` therefore reads **whichever** sample-count key a config declares, rather than forcing a cross-repo rename (prefer-agnostic-over-uniform). A config that declares **multiple** of these keys with **different values fails loud**: that divergence is the decoy trap that silently discarded a sample-count change during the 2026-07-20 FAO delivery (a baseline config carries both `n_samples`, the runtime key, and `n_posterior_samples`, this contract's key, kept equal only by hand). The authoritative check remains the produced `pf.sample_count` at aggregation (pipeline-core, register C-85); this getter guards the config layer.
+
 ## Consequences
 
 ### Positive

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -126,13 +126,33 @@ def get_regression_targets(model_dir: Path) -> list[str]:
     return located.get("meta") or located.get("hp") or []
 
 
-def get_n_posterior_samples(model_dir: Path) -> int | None:
-    """A model's declared posterior sample count, or None if undeclared.
+# The same concept — posterior draws per cell — is named differently by each
+# model family's runtime: baseline reads `n_samples`, hydranet
+# `n_posterior_samples`, r2darts `num_samples`, stepshifter `pred_samples`
+# (register C-104). The runtime object and the ADR-013 wire already agree on one
+# name (`PredictionFrame.sample_count` / header `sample_count`); only the config
+# layer is fragmented. This getter reads whichever key a config declares rather
+# than forcing a rename (prefer-agnostic-over-uniform).
+SAMPLE_COUNT_CONFIG_KEYS = (
+    "n_posterior_samples",
+    "n_samples",
+    "num_samples",
+    "pred_samples",
+)
 
-    config_hyperparameters is the primary location (where DL/baseline models
-    declare it), config_meta the fallback. Derive-don't-hardcode, mirroring
-    get_regression_targets — the single way views-models obtains this number for
-    the ensemble sample-count contract (ADR-015).
+
+def get_n_posterior_samples(model_dir: Path) -> int | None:
+    """A model's declared posterior sample count, family-agnostic, or None.
+
+    Reads whichever of ``SAMPLE_COUNT_CONFIG_KEYS`` a config declares (C-104), so
+    the ensemble sample-count contract (ADR-015) works regardless of which family
+    name a model uses. **Divergence guard:** a config that declares more than one
+    of these keys with DIFFERENT values is the decoy trap that silently discarded
+    a sample-count change during the 2026-07-20 FAO delivery (a baseline config
+    carries both `n_samples` — the runtime key — and `n_posterior_samples` — this
+    contract's key — kept equal only by hand); such divergence fails loud here
+    (register C-85/C-104) rather than letting CI validate a value the runtime
+    ignores.
     """
     config_dir = model_dir / "configs"
     for fname, getter_name in (
@@ -145,9 +165,21 @@ def get_n_posterior_samples(model_dir: Path) -> int | None:
         getter = getattr(load_config_module(path), getter_name, None)
         if getter is None:
             continue
-        val = (getter() or {}).get("n_posterior_samples")
-        if val is not None:
-            return int(val)
+        cfg = getter() or {}
+        present = {k: int(cfg[k]) for k in SAMPLE_COUNT_CONFIG_KEYS if cfg.get(k) is not None}
+        if not present:
+            continue
+        distinct = set(present.values())
+        if len(distinct) > 1:
+            raise ValueError(
+                f"{model_dir.name}: sample-count config keys disagree: {present}. "
+                f"A model declares one concept (posterior draws per cell) under "
+                f"multiple family names; they must hold the same value — a "
+                f"divergence means the runtime and the CI contract read different "
+                f"numbers (register C-104). Set them equal, or keep only the key "
+                f"this model's runtime reads."
+            )
+        return distinct.pop()
     return None
 
 

--- a/tests/test_sample_count_agnostic.py
+++ b/tests/test_sample_count_agnostic.py
@@ -1,0 +1,55 @@
+"""S3 (sprint: kill silent sample-count failures) — agnostic reader + decoy guard.
+
+Posterior sample count is named differently by each model family's runtime
+(baseline `n_samples`, hydranet `n_posterior_samples`, r2darts `num_samples`,
+stepshifter `pred_samples` — register C-104). `get_n_posterior_samples` now
+reads whichever key a config declares (no forced rename), and fails loud when a
+config declares several of them with DIFFERENT values — the decoy divergence
+that silently discarded a sample-count change during the 2026-07-20 FAO delivery
+(register C-85/C-104).
+"""
+import textwrap
+
+import pytest
+
+from tests.conftest import SAMPLE_COUNT_CONFIG_KEYS, get_n_posterior_samples
+
+pytestmark = pytest.mark.beige  # convention/structural compliance (ADR-005)
+
+
+def _model_with_hp(tmp_path, hp_body: str):
+    configs = tmp_path / "configs"
+    configs.mkdir(parents=True, exist_ok=True)
+    (configs / "config_hyperparameters.py").write_text(
+        textwrap.dedent(
+            f"""
+            def get_hp_config():
+                return {{{hp_body}}}
+            """
+        )
+    )
+    return tmp_path
+
+
+@pytest.mark.parametrize("key", SAMPLE_COUNT_CONFIG_KEYS)
+def test_reads_whichever_family_key_is_present(tmp_path, key):
+    m = _model_with_hp(tmp_path, f'"{key}": 48')
+    assert get_n_posterior_samples(m) == 48
+
+
+def test_multi_key_equal_is_accepted(tmp_path):
+    # the baseline convention: n_samples + n_posterior_samples, kept equal.
+    m = _model_with_hp(tmp_path, '"n_samples": 64, "n_posterior_samples": 64')
+    assert get_n_posterior_samples(m) == 64
+
+
+def test_multi_key_divergent_fails_loud(tmp_path):
+    # tonight's exact trap: edit one key, not the other.
+    m = _model_with_hp(tmp_path, '"n_samples": 128, "n_posterior_samples": 16')
+    with pytest.raises(ValueError, match="disagree"):
+        get_n_posterior_samples(m)
+
+
+def test_absent_returns_none(tmp_path):
+    m = _model_with_hp(tmp_path, '"steps": [1, 2, 3]')
+    assert get_n_posterior_samples(m) is None


### PR DESCRIPTION
Resolves C-104's danger without forcing a cross-repo rename. `conftest.get_n_posterior_samples` reads whichever family key a config declares (baseline `n_samples` / hydranet `n_posterior_samples` / r2darts `num_samples` / stepshifter `pred_samples`) and **fails loud on divergence** when a config carries several with different values — the decoy trap that silently ate the sample-count change during the 2026-07-20 delivery. Passes on all committed configs (equal today); zero model-config edits (no risk to parallel-owned files). ADR-015 §5 amended. 284 tests pass, ruff clean. Sprint S3 (follows S1 #281, S2 #282). Authoritative runtime check stays pf.sample_count (C-85).

🤖 Generated with [Claude Code](https://claude.com/claude-code)