### PR TITLE
chore(rusty_bucket): thin constituents to 16 samples/model (interim, #146)

### DIFF
--- a/ensembles/rusty_bucket/configs/config_hyperparameters.py
+++ b/ensembles/rusty_bucket/configs/config_hyperparameters.py
@@ -7,10 +7,12 @@ def get_hp_config():
         #   every constituent's n_posterior_samples == expected_samples_per_model
         # PFE concat concatenates draws on the sample axis (pipeline-core
         # prediction_frame_ensemble.py:99), so the pooled total is
-        # expected_models × expected_samples_per_model = 8 × 128 = 1024 draws.
+        # expected_models × expected_samples_per_model = 8 × 16 = 128 draws.
+        # (Thinned from 8×128=1024 on 2026-07-20: the full-S run peaks ~28.6 GB and
+        # cannot fit production hardware — see views-baseline memory issue + C-99.)
         # Equal per-model counts give each constituent equal weight in the pooled
         # mixture and a predictable pooled dimension; a mismatch fails loud at CI.
         "expected_models": 8,
-        "expected_samples_per_model": 128,
+        "expected_samples_per_model": 16,
     }
     return hp_config

--- a/models/temporary_bison/configs/config_hyperparameters.py
+++ b/models/temporary_bison/configs/config_hyperparameters.py
@@ -12,8 +12,8 @@ def get_hp_config():
         "steps": list(range(1, 37)),
         "time_steps": 36,
         "window_months": 36,
-        "n_samples": 128,
-        "n_posterior_samples": 128,
+        "n_samples": 16,
+        "n_posterior_samples": 16,
         "seed": 42,
         "skip_predictions_delivery": True,
     }

--- a/models/temporary_crane/configs/config_hyperparameters.py
+++ b/models/temporary_crane/configs/config_hyperparameters.py
@@ -12,8 +12,8 @@ def get_hp_config():
         "steps": list(range(1, 37)),
         "time_steps": 36,
         "window_months": 36,
-        "n_samples": 128,
-        "n_posterior_samples": 128,
+        "n_samples": 16,
+        "n_posterior_samples": 16,
         "seed": 42,
         "skip_predictions_delivery": True,
     }

--- a/models/temporary_finch/configs/config_hyperparameters.py
+++ b/models/temporary_finch/configs/config_hyperparameters.py
@@ -12,8 +12,8 @@ def get_hp_config():
         "steps": list(range(1, 37)),
         "time_steps": 36,
         "window_months": 36,
-        "n_samples": 128,
-        "n_posterior_samples": 128,
+        "n_samples": 16,
+        "n_posterior_samples": 16,
         "seed": 42,
         "skip_predictions_delivery": True,
     }

--- a/models/temporary_fox/configs/config_hyperparameters.py
+++ b/models/temporary_fox/configs/config_hyperparameters.py
@@ -12,8 +12,8 @@ def get_hp_config():
         "steps": list(range(1, 37)),
         "time_steps": 36,
         "window_months": 36,
-        "n_samples": 128,
-        "n_posterior_samples": 128,
+        "n_samples": 16,
+        "n_posterior_samples": 16,
         "seed": 42,
         "skip_predictions_delivery": True,
     }

--- a/models/temporary_heron/configs/config_hyperparameters.py
+++ b/models/temporary_heron/configs/config_hyperparameters.py
@@ -12,8 +12,8 @@ def get_hp_config():
         "steps": list(range(1, 37)),
         "time_steps": 36,
         "window_months": 36,
-        "n_samples": 128,
-        "n_posterior_samples": 128,
+        "n_samples": 16,
+        "n_posterior_samples": 16,
         "seed": 42,
         "skip_predictions_delivery": True,
     }

--- a/models/temporary_lynx/configs/config_hyperparameters.py
+++ b/models/temporary_lynx/configs/config_hyperparameters.py
@@ -12,8 +12,8 @@ def get_hp_config():
         "steps": list(range(1, 37)),
         "time_steps": 36,
         "window_months": 36,
-        "n_samples": 128,
-        "n_posterior_samples": 128,
+        "n_samples": 16,
+        "n_posterior_samples": 16,
         "seed": 42,
         "skip_predictions_delivery": True,
     }

--- a/models/temporary_otter/configs/config_hyperparameters.py
+++ b/models/temporary_otter/configs/config_hyperparameters.py
@@ -12,8 +12,8 @@ def get_hp_config():
         "steps": list(range(1, 37)),
         "time_steps": 36,
         "window_months": 36,
-        "n_samples": 128,
-        "n_posterior_samples": 128,
+        "n_samples": 16,
+        "n_posterior_samples": 16,
         "seed": 42,
         "skip_predictions_delivery": True,
     }

--- a/models/temporary_robin/configs/config_hyperparameters.py
+++ b/models/temporary_robin/configs/config_hyperparameters.py
@@ -12,8 +12,8 @@ def get_hp_config():
         "steps": list(range(1, 37)),
         "time_steps": 36,
         "window_months": 36,
-        "n_samples": 128,
-        "n_posterior_samples": 128,
+        "n_samples": 16,
+        "n_posterior_samples": 16,
         "seed": 42,
         "skip_predictions_delivery": True,
     }


### PR DESCRIPTION
Records the interim draw count (maintainer decision 2026-07-20): rusty_bucket + 8 temporary_* at n_samples=16 (pooled 128) until the pipeline is proven to run end-to-end, then upscale to 128 later. Full-S doesn't fit current hardware (C-99 / pipeline-core #273). Both keys equal (passes the S3 divergence guard); 284 tests green. Tracks #146. Was uncommitted working-tree work — now on the record (also preserved at origin/wip/safety-snapshot-20260720).

🤖 Generated with [Claude Code](https://claude.com/claude-code)