### PR TITLE
fix(un_fao): drop the dead orange_ensemble ghost comment (closes #77)

### DIFF
--- a/apis/un_fao/configs/config_meta.py
+++ b/apis/un_fao/configs/config_meta.py
@@ -12,7 +12,6 @@ def get_meta_config():
         "algorithm": "API",
         # "creator": "Your name here",
         "historical_targets": ["lr_ged_sb", "lr_ged_ns", "lr_ged_os"],
-        # "ensemble": "orange_ensemble",
         "level": "pgm"
     }
     return meta_config


### PR DESCRIPTION
#77's real work was already done (postprocessor active `"ensemble": "rusty_bucket"`). The last `orange_ensemble` string was a dead commented-out line in the API config — a ghost reference to the retired ensemble, which the API side doesn't use. Removed; config still parses. No active or commented orange_ensemble reference remains except the accurate 'replaces the ghost orange_ensemble' documentation note in the postprocessor. Closes #77.

🤖 Generated with [Claude Code](https://claude.com/claude-code)