### PR TITLE
test(coherence): add parametric-baseline algorithms to the known map (greens 8 dwarf failures, C-80)

### DIFF
--- a/tests/test_algorithm_coherence.py
+++ b/tests/test_algorithm_coherence.py
@@ -40,6 +40,10 @@ ALGORITHM_TO_PACKAGE = {
     "ZeroModel": "views_baseline",
     "LocfModel": "views_baseline",
     "ConflictologyModel": "views_baseline",
+    # parametric climatology (ADR-022) — real, exported views_baseline classes
+    # (views_baseline/model/models/distributional/{parametric,parametric_hurdle}.py)
+    "ParametricConflictology": "views_baseline",
+    "ParametricHurdleConflictology": "views_baseline",
     # views_hydranet algorithms
     "HydraNet": "views_hydranet",
 }


### PR DESCRIPTION
Tech-debt-cleanup. The algorithm-coherence allowlist (`ALGORITHM_TO_PACKAGE`) drifted behind views-baseline: `ParametricConflictology` + `ParametricHurdleConflictology` are real exported classes (ADR-022) but weren't in the map, failing all 8 `*_dwarf` models. Test-side fix only — no model configs touched (dwarfs are parallel-session-owned). Greens 8 of the 9 red-baseline failures; the 1 remaining (`test_both_trios_use_same_loss`) is the parallel-session violet_visitor loss experiment, deferred to its owner. test_algorithm_coherence: 342 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)