### PR TITLE
chore(creds): credential schema + self-diagnosis + register C-108 (architecture deferred to #280)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,41 @@
+# views-models — credential schema (NAMES ONLY; NEVER commit real values)
+#
+# HOW TO USE
+#   cp .env.example .env      # .env is gitignored — verified
+#   then fill the values from the Appwrite console (and the data-source providers).
+#   Check completeness at any time:  python tools/check_credentials.py
+#
+# WHERE VALUES COME FROM (as of 2026-07-27): the Appwrite console + the data-source
+# providers. There is not yet a durable secrets source of truth — that is a tracked
+# investigation (see reports/security/appwrite_credentials_audit.md and the
+# "secrets-management architecture" GitHub issue). Do NOT invent an interim scheme here.
+#
+# Legend:  [SECRET] = a real credential, guard carefully.  [id] = non-secret identifier.
+
+# ── Appwrite — REQUIRED to publish a forecast to the shelf (rusty_bucket --prediction_store)
+#    and for the un_fao postprocessor. This is the set run-0 needs.
+APPWRITE_ENDPOINT=                          # [id] Appwrite server URL
+APPWRITE_DATASTORE_PROJECT_ID=              # [id] Appwrite project id
+APPWRITE_DATASTORE_API_KEY=                 # [SECRET] the write credential
+APPWRITE_PROD_FORECASTS_BUCKET_ID=          # [id] the shelf bucket (production_forecasts)
+APPWRITE_PROD_FORECASTS_BUCKET_NAME=        # [id]
+APPWRITE_PROD_FORECASTS_COLLECTION_ID=      # [id] metadata collection
+APPWRITE_PROD_FORECASTS_COLLECTION_NAME=    # [id]
+APPWRITE_METADATA_DATABASE_ID=              # [id] metadata database
+APPWRITE_METADATA_DATABASE_NAME=            # [id]
+
+# ── Appwrite — the FAO-facing store (unfao_bucket). Needed by the un_fao postprocessor
+#    and the faoapi serving side.
+APPWRITE_UNFAO_BUCKET_ID=                    # [id]
+APPWRITE_UNFAO_BUCKET_NAME=                  # [id]
+APPWRITE_UNFAO_COLLECTION_ID=                # [id]
+APPWRITE_UNFAO_COLLECTION_NAME=              # [id]
+APPWRITE_UNFAO_APPROVED_FILE_IDS=            # [id] curation allow-list (may be empty)
+APPWRITE_UNFAO_QUARANTINED_FILE_IDS=         # [id] curation quarantine list (may be empty)
+
+# ── Other platform secrets referenced by code (data ingest; NOT needed for a --saved
+#    run-0, but required for fresh data fetches). Confirm scope before relying on these.
+ACLED_PASSWORD=                              # [SECRET] ACLED data source
+GDL_API_TOKEN=                               # [SECRET] GDL data source
+UCDP_API_TOKEN=                              # [SECRET] UCDP data source
+VIEWS_DATAFACTORY=                           # datafactory access (confirm exact meaning)

--- a/reports/technical_risk_register.md
+++ b/reports/technical_risk_register.md
@@ -3,7 +3,7 @@
 **Last updated:** 2026-07-19  
 **Governing ADR:** [ADR-010](../docs/ADRs/010_technical_risk_register.md)  
 **Total entries:** 104 (100 concerns + 4 disagreements)  
-**Concerns:** Open 46 | Mitigated 19 | Resolved 38 | Accepted 3 | Partially Resolved 1  
+**Concerns:** Open 47 | Mitigated 19 | Resolved 38 | Accepted 3 | Partially Resolved 1  
 **Disagreements:** Open 4  
 
 ---
@@ -1354,6 +1354,19 @@
 | **Status** | Mitigated (CIC authored, 2026-07-21, #275) |
 | **Location** | `tools/liveness/` — 8 modules / 6 surface-check classes (`old_api.py`, `datafactory_input.py`, `appwrite_store.py`, `unfao_delivery.py`, `wandb_execution.py`, `vpn_store.py`) sharing a `run() -> verdict` + injected-fetch + exit-code contract; 130 tests; epic #238. Now governed by `docs/CICs/LivenessChecks.md` |
 | **Notes** | Under **ADR-006** (intent contracts for non-trivial classes), the six liveness check classes — each a cohesive contract with an injected-dependency seam, a verdict enum, and an exit-code mapping — warrant a CIC, and the suite as a whole (an operational instrument used platform-wide) arguably warrants an ADR. It had neither. **Well-mitigated**, which is why Tier 4 not 3: a thorough `tools/liveness/README.md` documents every surface, verdict, exit code, and the encoded conventions with receipts; and ADR-005 (§ the `live` category) + ADR-017 (§ the observability instrument for derived state) both reference it. So the *contract existed in prose* — the gap was that it was not in the machine-checkable CIC form the repo's own convention prescribes, so `validate_docs.sh` and the CIC-audit tools could not guard it. **Resolution (#275, 2026-07-21):** authored `docs/CICs/LivenessChecks.md` — one subsystem-level CIC (the `ReconciliationWiring.md` precedent) covering the shared check-class contract, referencing the README as the human companion; wired `tools/liveness/report.py` and `tools/liveness/__main__.py` into `.github/workflows/cic_sync_check.yml` so a change to the verdict/exit-code map or the runner now forces the CIC to move in the same PR. A dedicated **ADR** for the suite remains optional (ADR-017 already leans on it) — deliberately not built. Cross-refs: C-103 (same subsystem, the test-taxonomy aspect — resolved), C-16 (CIC coverage of non-trivial classes), C-106 (the runtime-smoke work, similarly under-governed — no ADR yet). |
+
+---
+
+### C-108 — No durable, access-controlled source of truth for platform secrets
+
+| Field | Value |
+|---|---|
+| **Tier** | 2 |
+| **Trigger** | A laptop holding the only copy of the production Appwrite datastore API key dies / is reimaged / the colleague leaves; or a fresh checkout must run a production step. Today there is no durable backup to restore from and no documented provisioning — recovery means scrambling to regenerate keys in the Appwrite console (a rotation), and every consumer must be re-provisioned by hand. |
+| **Source** | credential audit 2026-07-27 (`reports/security/appwrite_credentials_audit.md`) |
+| **Status** | Open (immediate hygiene shipped; architecture deferred to a tracked investigation) |
+| **Location** | Platform-wide. Producer/postprocessor read via `load_dotenv` → `views-models/.env` (pipeline-core `configs/prediction_store.py` `_ENV_MAP`; postprocessing `unfao/managers/unfao.py`). Server: `views-faoapi/deployment/bootstrap.sh:21` hardcodes `SOURCE_ENV=/home/sonja/.../views-models/.env`. |
+| **Notes** | The 15 Appwrite keys (+ `ACLED_PASSWORD`, `GDL_API_TOKEN`, `UCDP_API_TOKEN`, `VIEWS_DATAFACTORY`) that a UN-facing production service depends on exist **only** in personal, gitignored `.env` files on ≤2 laptops plus one derived server copy (`.env.faoapi`). **No durable, backed-up, access-controlled source of truth; no independent per-person revocation; no rotation runbook; the deploy bootstrap is pinned to one individual's home directory.** This is the root cause of credentials repeatedly being re-supplied across sessions ("the mystery"). *Not a leak:* the audit verified **no secret is in git, in any repo, across full history**, and none is pasted into any tracked file — so this is a **fragility / recoverability** risk, not exposure. **Vocabulary is consistent** (one canonical naming across all repos); the problem is *provisioning architecture*, not sprawl. **Immediate hygiene shipped (this entry's partial):** `views-models/.env.example` (the documented schema), `tools/check_credentials.py` (self-diagnosing "which keys am I missing?"), and `tests/test_credentials_presence.py`. **Deferred by maintainer decision (2026-07-27), informed by an external assessment:** the real secrets-management architecture is a deliberate investigation, NOT chosen now — options are SOPS+age with individual keys (interim/low-complexity, per-person revocation), a secrets manager / OIDC short-lived creds (production automation), or a team password manager (human-accessed); GPG-shared-passphrase-in-a-repo is explicitly *interim bootstrap only, not the target*. Tracked in views-models#280. Cross-refs: the monthly-run-ritual entry (same "scattered on personal laptops" family), C-79 (infra/IP-in-config hygiene). |
 
 ---
 

--- a/tests/test_credentials_presence.py
+++ b/tests/test_credentials_presence.py
@@ -1,0 +1,70 @@
+"""Green tests for the credential schema (.env.example) and the presence checker.
+
+Validates the *mechanism* (schema completeness + the checker's missing/present logic)
+deterministically — it does NOT read the ambient environment, so it is stable in CI.
+Guards `reports/security/appwrite_credentials_audit.md`'s remediation from regressing.
+"""
+from pathlib import Path
+
+import pytest
+
+from tools import check_credentials
+
+pytestmark = pytest.mark.green
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+# The credentials run-0 (rusty_bucket --prediction_store) + the un_fao postprocessor need.
+_CRITICAL_KEYS = {
+    "APPWRITE_ENDPOINT",
+    "APPWRITE_DATASTORE_PROJECT_ID",
+    "APPWRITE_DATASTORE_API_KEY",
+    "APPWRITE_PROD_FORECASTS_BUCKET_ID",
+    "APPWRITE_PROD_FORECASTS_BUCKET_NAME",
+    "APPWRITE_PROD_FORECASTS_COLLECTION_ID",
+    "APPWRITE_PROD_FORECASTS_COLLECTION_NAME",
+    "APPWRITE_METADATA_DATABASE_ID",
+    "APPWRITE_METADATA_DATABASE_NAME",
+    "APPWRITE_UNFAO_BUCKET_ID",
+    "APPWRITE_UNFAO_BUCKET_NAME",
+    "APPWRITE_UNFAO_COLLECTION_ID",
+    "APPWRITE_UNFAO_COLLECTION_NAME",
+}
+
+
+def test_env_example_exists_and_declares_the_canonical_keys():
+    example = REPO_ROOT / ".env.example"
+    assert example.exists(), ".env.example (the credential schema) must exist"
+    declared = set(check_credentials._parse_env_names(example))
+    missing = _CRITICAL_KEYS - declared
+    assert not missing, f".env.example is missing canonical keys: {sorted(missing)}"
+
+
+def test_parse_env_filled_ignores_comments_blanks_and_empties(tmp_path):
+    f = tmp_path / ".env"
+    f.write_text(
+        "# a comment\n"
+        "\n"
+        "FILLED=somevalue\n"
+        "EMPTY=\n"
+        "SPACED =  val \n",
+        encoding="utf-8",
+    )
+    filled = check_credentials._parse_env_filled(f)
+    assert filled == {"FILLED", "SPACED"}  # EMPTY (blank value) is not "filled"
+
+
+def test_checker_flags_missing_and_passes_when_complete(tmp_path, monkeypatch):
+    (tmp_path / ".env.example").write_text("KEY_A=\nKEY_B=  # note\n", encoding="utf-8")
+    monkeypatch.setattr(check_credentials, "REPO_ROOT", tmp_path)
+    # ensure the checker can't be rescued by ambient env vars named KEY_A/KEY_B
+    monkeypatch.delenv("KEY_A", raising=False)
+    monkeypatch.delenv("KEY_B", raising=False)
+
+    # one filled, one blank -> INCOMPLETE (exit 1)
+    (tmp_path / ".env").write_text("KEY_A=value\nKEY_B=\n", encoding="utf-8")
+    assert check_credentials.main() == 1
+
+    # both filled -> OK (exit 0)
+    (tmp_path / ".env").write_text("KEY_A=value\nKEY_B=value\n", encoding="utf-8")
+    assert check_credentials.main() == 0

--- a/tools/check_credentials.py
+++ b/tools/check_credentials.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python3
+"""Self-diagnosing credential presence check for views-models.
+
+One command answers "which credentials am I missing?" without reading code —
+the fix for the recurring "the creds are a mystery" problem
+(see reports/security/appwrite_credentials_audit.md).
+
+    python tools/check_credentials.py
+
+The required key NAMES are the single-sourced schema in `.env.example`. This tool
+reports, per key, whether it is filled in the local (gitignored) `.env` or already
+present in the process environment, and exits non-zero if any is missing. It reads
+NO secret values into its output — only names and present/missing status.
+
+Stdlib only; no dependency on python-dotenv.
+"""
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+
+def _parse_env_names(path: Path) -> list[str]:
+    """Key names declared in an env file (lines like `KEY=` / `KEY=value`)."""
+    names: list[str] = []
+    if not path.exists():
+        return names
+    for line in path.read_text(encoding="utf-8").splitlines():
+        s = line.strip()
+        if not s or s.startswith("#") or "=" not in s:
+            continue
+        names.append(s.split("=", 1)[0].strip())
+    return names
+
+
+def _parse_env_filled(path: Path) -> set[str]:
+    """Key names that have a NON-EMPTY value in an env file (values never printed)."""
+    filled: set[str] = set()
+    if not path.exists():
+        return filled
+    for line in path.read_text(encoding="utf-8").splitlines():
+        s = line.strip()
+        if not s or s.startswith("#") or "=" not in s:
+            continue
+        k, v = s.split("=", 1)
+        if v.strip():
+            filled.add(k.strip())
+    return filled
+
+
+def main() -> int:
+    example = REPO_ROOT / ".env.example"
+    if not example.exists():
+        print("ERROR: .env.example not found — cannot determine the required key schema.")
+        return 2
+
+    required = _parse_env_names(example)
+    dotenv = REPO_ROOT / ".env"
+    filled_in_dotenv = _parse_env_filled(dotenv)
+
+    missing: list[str] = []
+    print(f"Credential check — schema: {example.relative_to(REPO_ROOT)}"
+          f" ({len(required)} keys) | local .env: {'present' if dotenv.exists() else 'ABSENT'}\n")
+    for key in required:
+        if filled_in_dotenv and key in filled_in_dotenv:
+            where = "filled in .env"
+        elif os.getenv(key):
+            where = "set in environment"
+        else:
+            where = "MISSING"
+            missing.append(key)
+        print(f"  {'ok  ' if where != 'MISSING' else 'MISS'}  {key:<42} {where}")
+
+    print()
+    if missing:
+        print(f"INCOMPLETE — {len(missing)} of {len(required)} missing: {', '.join(missing)}")
+        print("Fill them in .env (copy from .env.example; values from the Appwrite console).")
+        return 1
+    print(f"OK — all {len(required)} credentials present.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Immediate, **non-architectural** hygiene from the credential audit (`reports/security/appwrite_credentials_audit.md`). Ships:
- **`.env.example`** — the canonical credential schema (names only; never values). A fresh checkout now sees exactly what it needs.
- **`tools/check_credentials.py`** — `python tools/check_credentials.py` reports precisely which keys are missing (stdlib; reads `.env.example` as the schema; never prints values).
- **`tests/test_credentials_presence.py`** (green) — guards the schema + the checker's logic.
- **register C-108 (Tier 2)** — no durable/backed-up source of truth for the platform secrets a UN service depends on; hardcoded `/home/sonja` bootstrap path; no independent revocation. **Not a leak** — nothing secret is in git (full history verified); this is a *fragility/recoverability* risk.

**Explicitly out of scope:** the real secrets-management architecture is deferred to a tracked investigation (**#280**) per maintainer decision — no architecture chosen here, no GPG/interim scheme adopted. The populated `.env` is the maintainer's, never committed.

ruff clean; the presence test passes 3/3; no `.env` staged. 🤖 Generated with [Claude Code](https://claude.com/claude-code)