### PR TITLE
[þing-01] Drop the three harvest tokens from consumer envs (#286)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -35,7 +35,4 @@ APPWRITE_UNFAO_QUARANTINED_FILE_IDS=         # [id] curation quarantine list (ma
 
 # ── Other platform secrets referenced by code (data ingest; NOT needed for a --saved
 #    run-0, but required for fresh data fetches). Confirm scope before relying on these.
-ACLED_PASSWORD=                              # [SECRET] ACLED data source
-GDL_API_TOKEN=                               # [SECRET] GDL data source
-UCDP_API_TOKEN=                              # [SECRET] UCDP data source
 VIEWS_DATAFACTORY=                           # datafactory access (confirm exact meaning)


### PR DESCRIPTION
Executes þing-01 ledger row **M2 / #286**. Deletes `ACLED_PASSWORD`, `GDL_API_TOKEN`, `UCDP_API_TOKEN` from `.env.example` (and the gitignored live `.env`, done locally). grep-confirmed zero readers in this repo; they belong only where datafactory harvests run. Shrinks the S6 copy-chain centre by three secrets at zero cost. Part of the ratified þing-01 verdict. Closes #286.