### PR TITLE
[þing-01] un_fao launcher reads coordinates from the PLATFORM-001 registry (#287)

### DIFF
--- a/postprocessors/un_fao/run.sh
+++ b/postprocessors/un_fao/run.sh
@@ -47,5 +47,28 @@ else
   pip install git+https://${GITHUB_TOKEN}@github.com/views-platform/views-postprocessing.git@main
 fi
 
+# ── þing-01 / PLATFORM-001 (#287): coordinates come from the OWNED registry, not a copied .env ──
+# The non-secret Appwrite coordinates (endpoint, project/bucket/collection/db ids & names) are
+# READ from the single canonical coordinate registry — never copied into this repo. The one SECRET
+# (APPWRITE_DATASTORE_API_KEY) stays an operator slot. This is a DECLARATION layered on run.sh, not
+# a rewrite. TRANSITIONAL: the .env sourced above still works as the operator slot + fallback; the
+# hard cutover (registry-only coordinates, secret from a real store, .env retired) is sequenced with
+# #280 and pairs with views-postprocessing's kill of its runtime load_dotenv (their P1). Uses the
+# just-activated env's python because tomllib needs 3.11+. Override the path with APPWRITE_REGISTRY.
+APPWRITE_REGISTRY="${APPWRITE_REGISTRY:-$project_path/../views-appwrite/docs/ADRs/platform/coordinate_registry.toml}"
+if [ -f "$APPWRITE_REGISTRY" ]; then
+  if _coords="$(python "$project_path/tools/registry_to_env.py" "$APPWRITE_REGISTRY" 2>/dev/null)"; then
+    while IFS= read -r _cl; do
+      [ -z "$_cl" ] && continue
+      export "${_cl%%=*}=${_cl#*=}"
+    done <<< "$_coords"
+    echo "PLATFORM-001: Appwrite coordinates read from the registry (secret stays the operator slot)."
+  else
+    echo "PLATFORM-001 note: registry read failed — using .env coordinates transitionally (#280 retires this)."
+  fi
+else
+  echo "PLATFORM-001 note: registry not found at $APPWRITE_REGISTRY — using .env transitionally (#280 retires this)."
+fi
+
 echo "Running $script_path/main.py "
 python $script_path/main.py "$@"

--- a/tools/registry_to_env.py
+++ b/tools/registry_to_env.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python3
+"""Emit ``NAME=value`` env lines for the NON-SECRET coordinates in a PLATFORM-001
+coordinate registry (þing-01 #275 / #287, verdict D2).
+
+Reads the OWNED registry file (``views-appwrite/docs/ADRs/platform/coordinate_registry.toml``)
+and prints only the **connection** and **target** classes — the non-secret identifiers a
+consumer needs. It NEVER emits a secret: secret entries in the registry are *slots* (name +
+required scopes) that carry no value, and the operator supplies the actual key separately. This
+is the read-don't-copy discipline that retires the laptop-``.env`` copy-chain: the registry is
+read and its values emitted; the file is never copied into a repo, and no value is ever baked
+into code (PLATFORM-001 §4).
+
+Mirrors ``views-faoapi/deployment/registry_to_env.py`` — the same canonical reader. A tiny
+per-consumer copy of a stdlib-only reader is the þing-01 pattern; the single source of truth is
+the DATA (the registry), never the reader. Requires Python ≥ 3.11 (``tomllib``); run it with the
+launcher's activated env python, not the system interpreter.
+
+Usage:  python registry_to_env.py <registry.toml>
+"""
+
+from __future__ import annotations
+
+import sys
+import tomllib
+
+# The declared classes that hold non-secret coordinate values. `secret` (slots, no value),
+# `excluded`, `meta`, and `test_environment` are deliberately NOT emitted.
+_COORDINATE_CLASSES = ("connection", "target")
+
+
+def coordinates(registry_path: str) -> list[str]:
+    """Return ``NAME=value`` lines for every connection/target coordinate in the registry.
+
+    Raises on a malformed registry or a coordinate entry missing its ``value`` — fail loud
+    rather than emit a half-built environment (verdict D5)."""
+    with open(registry_path, "rb") as fh:
+        registry = tomllib.load(fh)
+    lines: list[str] = []
+    for cls in _COORDINATE_CLASSES:
+        for name, entry in registry.get(cls, {}).items():
+            if "value" not in entry:
+                raise ValueError(f"registry coordinate {name!r} (class {cls!r}) has no value")
+            lines.append(f"{name}={entry['value']}")
+    return lines
+
+
+if __name__ == "__main__":
+    if len(sys.argv) != 2:
+        sys.exit("usage: registry_to_env.py <registry.toml>")
+    print("\n".join(coordinates(sys.argv[1])))


### PR DESCRIPTION
Executes þing-01 ledger row **M3 / #287**, the pairing half of views-postprocessing's P1.

**What:** the un_fao launcher (`run.sh`) now reads the non-secret Appwrite **coordinates** from the owned **coordinate registry** (`views-appwrite/.../coordinate_registry.toml`) rather than the copied laptop `.env`. The one **secret** stays an operator slot.

**Non-breaking / transitional** (per the issue's "declared meanwhile … sequenced with #280"): the block is *additive* (layered on `run.sh`, not a rewrite), placed after conda activation to use the env's 3.11 python (`tomllib`); `.env` still works as the operator slot + fallback. The hard cutover (registry-only, secret from a real store, `.env` retired) comes with #280.

**Files:** `tools/registry_to_env.py` (stdlib reader, mirrors faoapi's; emits connection+target only, never a secret) + an additive block in `postprocessors/un_fao/run.sh`.

**Verified:** reader emits the 12 coordinates with **zero** secret leakage; `run.sh` passes `bash -n` and handles space-bearing values ("Production Forecasts").

Pairs with views-postprocessing's P1 — once merged, postprocessing can kill its runtime `load_dotenv`. Closes #287.