### PR TITLE
fix(un_fao): export APPWRITE_DATASTORE_API_KEY from run.sh (#293)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,6 +11,16 @@
 # "secrets-management architecture" GitHub issue). Do NOT invent an interim scheme here.
 #
 # Legend:  [SECRET] = a real credential, guard carefully.  [id] = non-secret identifier.
+#
+# QUOTE ANY VALUE CONTAINING A SPACE.  (#293)
+# This file is not only read by python-dotenv — `postprocessors/un_fao/run.sh` **sources** it as a
+# bash script. An unquoted value with a space is parsed as an assignment plus a command:
+#
+#     APPWRITE_UNFAO_BUCKET_NAME=UNFAO Bucket     ->  sets ...NAME=UNFAO, then runs `Bucket`
+#     APPWRITE_UNFAO_BUCKET_NAME="UNFAO Bucket"   ->  correct
+#
+# The *_NAME coordinates below are the ones that carry spaces in practice. Quoting them costs
+# nothing and prevents a silently truncated identifier. Quoted form is shown as the example value.
 
 # ── Appwrite — REQUIRED to publish a forecast to the shelf (rusty_bucket --prediction_store)
 #    and for the un_fao postprocessor. This is the set run-0 needs.
@@ -18,18 +28,18 @@ APPWRITE_ENDPOINT=                          # [id] Appwrite server URL
 APPWRITE_DATASTORE_PROJECT_ID=              # [id] Appwrite project id
 APPWRITE_DATASTORE_API_KEY=                 # [SECRET] the write credential
 APPWRITE_PROD_FORECASTS_BUCKET_ID=          # [id] the shelf bucket (production_forecasts)
-APPWRITE_PROD_FORECASTS_BUCKET_NAME=        # [id]
+APPWRITE_PROD_FORECASTS_BUCKET_NAME=""      # [id] QUOTE IT — this value contains a space
 APPWRITE_PROD_FORECASTS_COLLECTION_ID=      # [id] metadata collection
-APPWRITE_PROD_FORECASTS_COLLECTION_NAME=    # [id]
+APPWRITE_PROD_FORECASTS_COLLECTION_NAME=""  # [id] QUOTE IT — this value contains a space
 APPWRITE_METADATA_DATABASE_ID=              # [id] metadata database
-APPWRITE_METADATA_DATABASE_NAME=            # [id]
+APPWRITE_METADATA_DATABASE_NAME=""          # [id] QUOTE IT — this value contains a space
 
 # ── Appwrite — the FAO-facing store (unfao_bucket). Needed by the un_fao postprocessor
 #    and the faoapi serving side.
 APPWRITE_UNFAO_BUCKET_ID=                    # [id]
-APPWRITE_UNFAO_BUCKET_NAME=                  # [id]
+APPWRITE_UNFAO_BUCKET_NAME=""                # [id] QUOTE IT — this value contains a space
 APPWRITE_UNFAO_COLLECTION_ID=                # [id]
-APPWRITE_UNFAO_COLLECTION_NAME=              # [id]
+APPWRITE_UNFAO_COLLECTION_NAME=""            # [id] QUOTE IT — this value contains a space
 APPWRITE_UNFAO_APPROVED_FILE_IDS=            # [id] curation allow-list (may be empty)
 APPWRITE_UNFAO_QUARANTINED_FILE_IDS=         # [id] curation quarantine list (may be empty)
 

--- a/postprocessors/un_fao/run.sh
+++ b/postprocessors/un_fao/run.sh
@@ -17,9 +17,13 @@ script_path=$(dirname "$(realpath $0)")
 project_path="$( cd "$script_path/../../" >/dev/null 2>&1 && pwd )"
 env_path="$project_path/envs/views-postprocessing"
 
+# Sourcing sets SHELL variables; only what is `export`ed reaches `python main.py` (a child process).
+# Do NOT replace this with `set -a` — .env carries unquoted values containing spaces (the *_NAME
+# coordinates), which `set -a` would export truncated at the first space. Export by name instead. (#293)
 if [ -f "$project_path/.env" ]; then
   source "$project_path/.env"
   export GITHUB_TOKEN
+  export APPWRITE_DATASTORE_API_KEY   # the one secret; the operator slot. Coordinates come from the registry below.
 fi
 
 eval "$(conda shell.bash hook)"
@@ -50,24 +54,37 @@ fi
 # ── þing-01 / PLATFORM-001 (#287): coordinates come from the OWNED registry, not a copied .env ──
 # The non-secret Appwrite coordinates (endpoint, project/bucket/collection/db ids & names) are
 # READ from the single canonical coordinate registry — never copied into this repo. The one SECRET
-# (APPWRITE_DATASTORE_API_KEY) stays an operator slot. This is a DECLARATION layered on run.sh, not
-# a rewrite. TRANSITIONAL: the .env sourced above still works as the operator slot + fallback; the
-# hard cutover (registry-only coordinates, secret from a real store, .env retired) is sequenced with
-# #280 and pairs with views-postprocessing's kill of its runtime load_dotenv (their P1). Uses the
+# (APPWRITE_DATASTORE_API_KEY) stays an operator slot — exported by name above; see #293 for why a
+# bare `source` was never a carrier. This is a DECLARATION layered on run.sh, not a rewrite. The hard
+# cutover (registry-only coordinates, secret from a real store, .env retired) is sequenced with #280
+# and pairs with views-postprocessing's kill of its runtime load_dotenv (their P1). Uses the
 # just-activated env's python because tomllib needs 3.11+. Override the path with APPWRITE_REGISTRY.
+#
+# CORRECTION (#293): this comment previously claimed "the .env sourced above still works as the
+# operator slot + fallback". It did not — `source` without `export` never reached the python child,
+# so between views-postprocessing's load_dotenv removal (2026-07-28) and this change there was no
+# carrier for the secret at all. The claim was wrong when written.
 APPWRITE_REGISTRY="${APPWRITE_REGISTRY:-$project_path/../views-appwrite/docs/ADRs/platform/coordinate_registry.toml}"
 if [ -f "$APPWRITE_REGISTRY" ]; then
-  if _coords="$(python "$project_path/tools/registry_to_env.py" "$APPWRITE_REGISTRY" 2>/dev/null)"; then
+  # Failures are reported, not swallowed (#293): a silent fallback here degrades to a path that
+  # supplies nothing, because the sourced .env coordinates are not exported either.
+  if _coords="$(python "$project_path/tools/registry_to_env.py" "$APPWRITE_REGISTRY" 2>/tmp/registry_to_env.$$.err)"; then
     while IFS= read -r _cl; do
       [ -z "$_cl" ] && continue
       export "${_cl%%=*}=${_cl#*=}"
     done <<< "$_coords"
     echo "PLATFORM-001: Appwrite coordinates read from the registry (secret stays the operator slot)."
   else
-    echo "PLATFORM-001 note: registry read failed — using .env coordinates transitionally (#280 retires this)."
+    echo "PLATFORM-001 WARNING: registry read FAILED — Appwrite coordinates are NOT set." >&2
+    echo "  registry: $APPWRITE_REGISTRY" >&2
+    echo "  python:   $(python -V 2>&1)  (registry_to_env.py needs 3.11+ for tomllib)" >&2
+    sed 's/^/  /' /tmp/registry_to_env.$$.err >&2
+    echo "  The .env sourced earlier does NOT cover this — its coordinates are not exported (#293)." >&2
   fi
+  rm -f /tmp/registry_to_env.$$.err
 else
-  echo "PLATFORM-001 note: registry not found at $APPWRITE_REGISTRY — using .env transitionally (#280 retires this)."
+  echo "PLATFORM-001 WARNING: registry NOT FOUND at $APPWRITE_REGISTRY — Appwrite coordinates are NOT set." >&2
+  echo "  The .env sourced earlier does NOT cover this — its coordinates are not exported (#293)." >&2
 fi
 
 echo "Running $script_path/main.py "

--- a/postprocessors/un_fao/run.sh
+++ b/postprocessors/un_fao/run.sh
@@ -65,26 +65,43 @@ fi
 # so between views-postprocessing's load_dotenv removal (2026-07-28) and this change there was no
 # carrier for the secret at all. The claim was wrong when written.
 APPWRITE_REGISTRY="${APPWRITE_REGISTRY:-$project_path/../views-appwrite/docs/ADRs/platform/coordinate_registry.toml}"
+
+# Report the ACTUAL coordinate state rather than asserting one. The registry is not the only way
+# coordinates can arrive — an operator's shell, a wrapper or an EnvironmentFile may already have
+# exported them, which is exactly how the secret arrives. Claiming "NOT set" without looking would
+# repeat the mistake this change corrects (#293).
+_platform001_coordinate_state() {
+  if [ -n "$APPWRITE_ENDPOINT" ] && [ -n "$APPWRITE_DATASTORE_PROJECT_ID" ] \
+     && [ -n "$APPWRITE_UNFAO_BUCKET_ID" ]; then
+    echo "  Coordinates ARE present in the environment (exported outside this script) — continuing." >&2
+  else
+    echo "  Coordinates are NOT in the environment either — the run will fail at the datastore boundary." >&2
+    echo "  Note: the .env sourced earlier does not supply them; its values are not exported (#293)." >&2
+  fi
+}
+
 if [ -f "$APPWRITE_REGISTRY" ]; then
   # Failures are reported, not swallowed (#293): a silent fallback here degrades to a path that
-  # supplies nothing, because the sourced .env coordinates are not exported either.
-  if _coords="$(python "$project_path/tools/registry_to_env.py" "$APPWRITE_REGISTRY" 2>/tmp/registry_to_env.$$.err)"; then
+  # may supply nothing, because the sourced .env coordinates are not exported either.
+  _reg_err="$(mktemp "${TMPDIR:-/tmp}/registry_to_env.XXXXXX")"
+  trap 'rm -f "$_reg_err"' EXIT
+  if _coords="$(python "$project_path/tools/registry_to_env.py" "$APPWRITE_REGISTRY" 2>"$_reg_err")"; then
     while IFS= read -r _cl; do
       [ -z "$_cl" ] && continue
       export "${_cl%%=*}=${_cl#*=}"
     done <<< "$_coords"
     echo "PLATFORM-001: Appwrite coordinates read from the registry (secret stays the operator slot)."
   else
-    echo "PLATFORM-001 WARNING: registry read FAILED — Appwrite coordinates are NOT set." >&2
+    echo "PLATFORM-001 WARNING: registry read FAILED — coordinates not set BY THE REGISTRY." >&2
     echo "  registry: $APPWRITE_REGISTRY" >&2
     echo "  python:   $(python -V 2>&1)  (registry_to_env.py needs 3.11+ for tomllib)" >&2
-    sed 's/^/  /' /tmp/registry_to_env.$$.err >&2
-    echo "  The .env sourced earlier does NOT cover this — its coordinates are not exported (#293)." >&2
+    sed 's/^/  /' "$_reg_err" >&2
+    _platform001_coordinate_state
   fi
-  rm -f /tmp/registry_to_env.$$.err
+  rm -f "$_reg_err"; trap - EXIT
 else
-  echo "PLATFORM-001 WARNING: registry NOT FOUND at $APPWRITE_REGISTRY — Appwrite coordinates are NOT set." >&2
-  echo "  The .env sourced earlier does NOT cover this — its coordinates are not exported (#293)." >&2
+  echo "PLATFORM-001 WARNING: registry NOT FOUND at $APPWRITE_REGISTRY — coordinates not set BY THE REGISTRY." >&2
+  _platform001_coordinate_state
 fi
 
 echo "Running $script_path/main.py "


### PR DESCRIPTION
Fixes #293. Verified empirically, not by reading.

## The bug

`postprocessors/un_fao/run.sh` sourced `.env` and exported **only** `GITHUB_TOKEN`. Sourcing sets *shell* variables; without `export` they never reach the `python main.py` child. So nothing placed `APPWRITE_DATASTORE_API_KEY` into the postprocessor's environment.

views-postprocessing's own `load_dotenv` was the sole carrier until their P1 removed it on **2026-07-28** — the day after run-0 succeeded.

```
source .env; export GITHUB_TOKEN            ->  shell: YES   python child: NO
+ export APPWRITE_DATASTORE_API_KEY         ->               python child: YES
```

## Why explicit export, not `set -a`

#293 offered `set -a` as option A. **It would corrupt five values.** `.env` carries unquoted `*_NAME` coordinates containing spaces — sourcing already emits five `command not found` errors today. Under `set -a` those five would be exported **truncated at the first space** (`Production Forecasts` → `Production`), with only the PLATFORM-001 registry block standing between that and a wrong bucket name — and that block failed silently. Explicit export avoids the whole class.

## Also in this PR

- **Corrects a false claim I wrote in the #287 comment block** — it stated the sourced `.env` *"still works as the operator slot + fallback"*. It never did. That was wrong when written, and the correction is recorded in place.
- **Makes the registry failure loud** instead of `2>/dev/null`. A silent fallback there degrades to a path that supplies nothing, because the sourced `.env` coordinates are not exported either. Now reports the registry path, the Python version (`registry_to_env.py` needs 3.11+ for `tomllib`) and the captured stderr.
- **`.env.example`** documents that `run.sh` **sources** the file, so values with spaces must be quoted, and shows the quoted form on the five `*_NAME` keys that carry them.

## Not in this PR

**#294** — `run.sh` installs `views-postprocessing@main`, which is 208 commits stale and has **zero** `unfao/wire/` files, so the launcher silently delivers the legacy artifact instead of the declared contract dialect. Independent defect, filed separately, and the more dangerous of the two: this one failed loud, that one doesn't fail at all.

## Verification

- `bash -n` clean on both files.
- Export semantics confirmed before and after by running the launcher's exact idiom and checking `os.environ` membership in a child process (membership only — no value printed).
- Registry-failure branch exercised with a bad path; warning renders on stderr.

Not run end-to-end: a full `un_fao` delivery needs the conda env this box doesn't have (`envs/views-postprocessing` is absent) and would publish to the FAO bucket. The issue's own acceptance test — one run reaching upload without an `EnvironmentError` — is still owed by whoever next runs it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)