### PR TITLE
fix(liveness,gitignore): read our OWN .env; close the .gitignore gaps (#298, #299)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -169,7 +169,14 @@ celerybeat.pid
 *.sage.py
 
 # Environments
+# `.env` alone left two shapes exposed on a PUBLIC repo (#299): `.env.faoapi` — the exact filename
+# the production server uses — and `.env.<date>`, the shape of a file made on a rotation day.
+# `.env.bak`/`.env.local` were covered only incidentally, by `*.bak` and `*.local` further down.
+# `!.env.example` is REQUIRED: that file is tracked and is the credential schema
+# `tools/check_credentials.py` reads. Asserted by tests/test_credentials_presence.py.
 .env
+.env.*
+!.env.example
 .venv
 env/
 envs/

--- a/docs/CICs/LivenessChecks.md
+++ b/docs/CICs/LivenessChecks.md
@@ -84,6 +84,8 @@ string — never narration.
 | A surface's network/parse fails | Contained inside that surface as a `verdict=UNREACHABLE` fact (exit 2), never an uncaught crash. |
 | A surface `main` itself crashes | The aggregate runner catches it, prints an `UNREACHABLE` fact, assigns exit 2 — the other surfaces still run. |
 | Missing credentials / package / VPN | A **truthful skip** (C-75): `SKIP_NO_CREDENTIALS` / `SKIP_NO_PACKAGE` / `VPN_REQUIRED` → exit **0**. Not-observed is not the same as not-live. |
+| **Partially** configured credentials (#298) | `CREDENTIALS_INCOMPLETE` → exit **1**, naming the missing variables. Deliberately *not* a truthful skip: "nothing is configured" is an honest absence of observation, "configured, but half of it" is a fault a human must fix. Exit 1 (attention), not 2 — the world is reachable; our configuration is not right. Collapsing the two is what allowed the Appwrite surfaces to fall back to another repository's `.env` unnoticed. |
+| Credentials resolvable only from **another repository's** `.env` | Not resolvable. The Appwrite surfaces read process env, then **this repository's own** `.env` (`REPO_ROOT/.env`, either `KEY=` or `export KEY=` style) — and nothing else. Observing under a foreign identity answers a different question than the one the verdict reports, and an exit code carries no caveat. Pinned by `tests/test_liveness_appwrite_store.py::test_resolve_credentials_does_NOT_read_another_repos_env`. |
 | Reachable but stale/idle/not-serving | Verdict maps to exit **1** (attention). |
 
 ## 7. Boundaries and Interactions

--- a/tests/test_credentials_presence.py
+++ b/tests/test_credentials_presence.py
@@ -40,6 +40,50 @@ def test_env_example_exists_and_declares_the_canonical_keys():
     assert not missing, f".env.example is missing canonical keys: {sorted(missing)}"
 
 
+# --- #299: the .gitignore gaps -------------------------------------------------
+# This repo is PUBLIC. Before #299 the only literal was `.env`; `.env.bak` and
+# `.env.local` were covered incidentally by `*.bak`/`*.local`, and the two shapes most
+# likely to exist on a rotation day were not covered at all. These tests pin both
+# halves of the fix — the broadening AND the negation that keeps the schema tracked,
+# because a `.env.*` rule without `!.env.example` would silently un-track the file the
+# checker above reads.
+
+def _is_ignored(name: str) -> bool:
+    import subprocess
+
+    return subprocess.run(
+        ["git", "check-ignore", "-q", name], cwd=REPO_ROOT
+    ).returncode == 0
+
+
+@pytest.mark.red
+@pytest.mark.parametrize(
+    "name",
+    [
+        ".env",
+        ".env.faoapi",      # the exact filename the production server uses
+        ".env.20260728",    # the shape of a file made on a rotation day
+        ".env.save",
+        ".env.bak",
+        ".env.local",
+    ],
+)
+def test_credential_file_shapes_are_gitignored(name):
+    assert _is_ignored(name), (
+        f"{name} is NOT gitignored — on a public repo that is one careless `git add` "
+        f"from a published credential (#299)"
+    )
+
+
+@pytest.mark.red
+def test_env_example_is_NOT_gitignored():
+    assert not _is_ignored(".env.example"), (
+        ".env.example must stay tracked — it is the credential schema "
+        "tools/check_credentials.py reads. If a broad `.env.*` rule is added without "
+        "the `!.env.example` negation, this fails (#299)"
+    )
+
+
 def test_parse_env_filled_ignores_comments_blanks_and_empties(tmp_path):
     f = tmp_path / ".env"
     f.write_text(

--- a/tests/test_liveness_appwrite_store.py
+++ b/tests/test_liveness_appwrite_store.py
@@ -24,6 +24,7 @@ from datetime import datetime, timezone
 
 import pytest
 
+from tools.liveness import appwrite_api
 from tools.liveness.appwrite_store import (
     HISTORICAL_WRONG_COLLECTION_ID,
     REAL_METADATA_DATABASE_ID,
@@ -111,6 +112,96 @@ def test_credentials_none_when_keys_incomplete(tmp_path):
     env = tmp_path / ".env"
     env.write_text("export APPWRITE_ENDPOINT=https://x\n")
     assert load_credentials_from_env_file(env) is None
+
+
+# --- #298: read our OWN .env, both line styles, and say what is missing ---------
+# The export-style test above passed throughout the period this module could not read
+# this repo's own `.env` at all — which is why it never caught the bug. These do.
+
+def test_credentials_parse_bare_key_style_env_file(tmp_path):
+    """This repo's own .env is bare `KEY=value` — 16 bare lines, 0 export lines.
+
+    The old regex was anchored on `^export`, so it silently excluded the file it was
+    most supposed to read.
+    """
+    env = tmp_path / ".env"
+    env.write_text(
+        "APPWRITE_ENDPOINT=https://x.example/v1\n"
+        "APPWRITE_DATASTORE_PROJECT_ID=p1\n"
+        "APPWRITE_DATASTORE_API_KEY=k1\n"
+        "OTHER=ignored\n"
+    )
+    creds = load_credentials_from_env_file(env)
+    assert creds == AppwriteCredentials("https://x.example/v1", "p1", "k1")
+
+
+def test_credentials_strip_trailing_comment_on_unquoted_value(tmp_path):
+    """`.env` is bash-sourceable here, so coordinate lines carry trailing comments."""
+    env = tmp_path / ".env"
+    env.write_text(
+        "APPWRITE_ENDPOINT=https://x.example/v1   # the endpoint\n"
+        "APPWRITE_DATASTORE_PROJECT_ID=p1\n"
+        'APPWRITE_DATASTORE_API_KEY="k1"\n'
+    )
+    creds = load_credentials_from_env_file(env)
+    assert creds == AppwriteCredentials("https://x.example/v1", "p1", "k1")
+
+
+def test_resolve_credentials_does_NOT_read_another_repos_env(monkeypatch, tmp_path):
+    """THE specification of #298: a foreign `.env` must not supply our credentials.
+
+    Before the fix this module walked ancestors for `views-faoapi/.env` and would
+    resolve from it — so views-models observed its own internal shelf under the FAO
+    service's identity, and reported that as "the shelf is healthy". The decoy below
+    is exactly that file. If this test ever fails, the borrowing is back.
+    """
+    for key in ("APPWRITE_ENDPOINT", "APPWRITE_DATASTORE_PROJECT_ID",
+                "APPWRITE_DATASTORE_API_KEY"):
+        monkeypatch.delenv(key, raising=False)
+
+    decoy = tmp_path / "views-faoapi" / ".env"
+    decoy.parent.mkdir(parents=True)
+    decoy.write_text(
+        "export APPWRITE_ENDPOINT=https://foreign.example/v1\n"
+        "export APPWRITE_DATASTORE_PROJECT_ID=foreign\n"
+        "export APPWRITE_DATASTORE_API_KEY=foreign\n"
+    )
+    # Our own .env is absent in this fake repo root.
+    monkeypatch.setattr(appwrite_api, "REPO_ROOT", tmp_path / "views-models")
+
+    assert appwrite_api.resolve_credentials() is None, (
+        "credentials resolved from a foreign repo's .env — #298 has regressed"
+    )
+
+
+def test_credential_gap_report_distinguishes_absent_from_partial(monkeypatch, tmp_path):
+    """Nothing configured is a truthful skip; half-configured is a misconfiguration."""
+    for key in ("APPWRITE_ENDPOINT", "APPWRITE_DATASTORE_PROJECT_ID",
+                "APPWRITE_DATASTORE_API_KEY"):
+        monkeypatch.delenv(key, raising=False)
+    root = tmp_path / "repo"
+    root.mkdir()
+    monkeypatch.setattr(appwrite_api, "REPO_ROOT", root)
+
+    verdict, error = appwrite_api.credential_gap_report()
+    assert verdict == "SKIP_NO_CREDENTIALS", "no .env at all is an honest absence"
+
+    (root / ".env").write_text("APPWRITE_ENDPOINT=https://x\n")
+    verdict, error = appwrite_api.credential_gap_report()
+    assert verdict == "CREDENTIALS_INCOMPLETE", "a partial .env is a misconfiguration"
+    assert "APPWRITE_DATASTORE_PROJECT_ID" in error
+    assert "APPWRITE_DATASTORE_API_KEY" in error
+    assert "APPWRITE_ENDPOINT" not in error.split("missing", 1)[1].split(".", 1)[0], (
+        "the error must name what is MISSING, not what is present"
+    )
+
+
+def test_credentials_incomplete_is_registered_and_louder_than_a_skip():
+    """The verdict must map to exit 1, not 0 — pinned because report.py is the contract."""
+    from tools.liveness.report import exit_code_for
+
+    assert exit_code_for("CREDENTIALS_INCOMPLETE") == 1
+    assert exit_code_for("SKIP_NO_CREDENTIALS") == 0
 
 
 # ── verdicts ──────────────────────────────────────────────────────────
@@ -262,13 +353,16 @@ def test_resolve_credentials_prefers_process_env(monkeypatch):
     )
 
 
-def test_resolve_credentials_none_when_nothing_available(monkeypatch):
+def test_resolve_credentials_none_when_nothing_available(monkeypatch, tmp_path):
     from tools.liveness import appwrite_api
 
     for name in ("APPWRITE_ENDPOINT", "APPWRITE_DATASTORE_PROJECT_ID",
                  "APPWRITE_DATASTORE_API_KEY"):
         monkeypatch.delenv(name, raising=False)
-    monkeypatch.setattr(appwrite_api, "_known_env_files", tuple)
+    # Seam changed by #298: the module no longer walks ancestors for a foreign repo's
+    # .env, so there is no _known_env_files to stub. It reads exactly REPO_ROOT/.env,
+    # and REPO_ROOT is now the seam.
+    monkeypatch.setattr(appwrite_api, "REPO_ROOT", tmp_path)
     assert appwrite_api.resolve_credentials() is None
 
 
@@ -278,7 +372,6 @@ def test_resolve_credentials_skips_env_file_missing_keys(monkeypatch, tmp_path):
     for name in ("APPWRITE_ENDPOINT", "APPWRITE_DATASTORE_PROJECT_ID",
                  "APPWRITE_DATASTORE_API_KEY"):
         monkeypatch.delenv(name, raising=False)
-    incomplete = tmp_path / ".env"
-    incomplete.write_text("export APPWRITE_ENDPOINT=https://example.test/v1\n")
-    monkeypatch.setattr(appwrite_api, "_known_env_files", lambda: (incomplete,))
+    (tmp_path / ".env").write_text("export APPWRITE_ENDPOINT=https://example.test/v1\n")
+    monkeypatch.setattr(appwrite_api, "REPO_ROOT", tmp_path)
     assert appwrite_api.resolve_credentials() is None

--- a/tests/test_liveness_runner.py
+++ b/tests/test_liveness_runner.py
@@ -34,7 +34,11 @@ def test_every_check_verdict_is_classified():
           "EXECUTION_CURRENT", "DELIVERING"}
     skip = {"SKIP_NO_CREDENTIALS", "SKIP_NO_PACKAGE", "VPN_REQUIRED"}
     warn = {"LIVE_STALE", "LIVE_NOT_SERVING", "INPUT_STALE", "STORE_IDLE",
-            "STORE_STALE", "DELIVERY_STALLED", "EXECUTION_STALE"}
+            "STORE_STALE", "DELIVERY_STALLED", "EXECUTION_STALE",
+            # #298: a `.env` exists but is incomplete. In `warn`, not `skip`, on
+            # purpose — "nothing configured" is an honest absence of observation,
+            # "half configured" is a fault a human must fix.
+            "CREDENTIALS_INCOMPLETE"}
     fail = {"UNREACHABLE"}
     for verdict in ok | skip:
         assert exit_code_for(verdict) == 0, verdict

--- a/tools/liveness/README.md
+++ b/tools/liveness/README.md
@@ -67,7 +67,7 @@ metadata collection exist?
   `orderDesc($createdAt)` query — never the 25-per-page default listing,
   which produced a false-idle verdict on 2026-07-19).
 - `STORE_IDLE` — nothing new in 45 days.
-- `SKIP_NO_CREDENTIALS` / `UNREACHABLE`.
+- `SKIP_NO_CREDENTIALS` / `CREDENTIALS_INCOMPLETE` / `UNREACHABLE`.
 
 ### `unfao_delivery` — the FAO partner bucket (`unfao_bucket`)
 When did FAO last receive anything, per stream (`forecast_dataset_*` and
@@ -76,7 +76,7 @@ When did FAO last receive anything, per stream (`forecast_dataset_*` and
 - `DELIVERING` — both streams ≤ 45 days.
 - `DELIVERY_STALLED` — at least one stream is `STALLED` or
   `NEVER_DELIVERED` (per-stream verdicts in the facts).
-- `SKIP_NO_CREDENTIALS` / `UNREACHABLE`.
+- `SKIP_NO_CREDENTIALS` / `CREDENTIALS_INCOMPLETE` / `UNREACHABLE`.
 
 ### `wandb_execution` — did the team compute this cycle?
 Latest **finished** forecasting run per monthly ensemble
@@ -112,9 +112,18 @@ public promotion)? Host resolves **only on the PRIO VPN**.
   config, and it killed the June 2026 un_fao run (register C-100).
 - **Credentials resolution** (`tools/liveness/appwrite_api.py`): process env
   vars first (`APPWRITE_ENDPOINT` / `APPWRITE_DATASTORE_PROJECT_ID` /
-  `APPWRITE_DATASTORE_API_KEY`), then known platform `.env` files found by
-  ancestor walk. **Secret values are never rendered** — reports show
-  `api_key_chars` (a length) only.
+  `APPWRITE_DATASTORE_API_KEY`), then **this repository's own** `.env` at the
+  repo root, in either `KEY=` or `export KEY=` style. **No other repository's
+  `.env` is read.** Until #298 this module walked ancestors for
+  `views-faoapi/.env` and matched only `export`-prefixed lines — so it could
+  not read views-models' own bare-`KEY=` file, and observed the internal shelf
+  under the **FAO service's identity** instead. That answers "can FAO see
+  this?" while reporting "the shelf is healthy"; a warning line would not have
+  helped, because what consumers read is the exit code. Nothing configured is
+  still a truthful `SKIP_NO_CREDENTIALS`; **partially** configured is
+  `CREDENTIALS_INCOMPLETE` (exit 1) and names the missing variables.
+  **Secret values are never rendered** — reports show `api_key_chars` (a
+  length) only.
 - **Appwrite listing** (`tools/liveness/appwrite_api.py`): always
   server-side `orderDesc($createdAt)` + `limit` — client-side sorting of a
   default page is the pagination bug this suite exists to prevent.

--- a/tools/liveness/appwrite_api.py
+++ b/tools/liveness/appwrite_api.py
@@ -7,8 +7,17 @@ default stdlib fetch.
 
 Credentials resolution order (values never rendered anywhere):
     1. process env vars (APPWRITE_ENDPOINT / _DATASTORE_PROJECT_ID / _DATASTORE_API_KEY)
-    2. known platform .env files, discovered by walking this file's ancestors
-       (robust from the main checkout AND from git worktrees).
+    2. **this repository's own** ``.env``, at the repo root.
+
+#298 — why it is only its own file now. This module used to walk ancestors looking for
+``views-faoapi/.env``, a hardcoded FOREIGN repository, and its line regex matched only
+``export``-prefixed lines. views-models' own ``.env`` is bare ``KEY=`` style, so the regex
+excluded it and the path never looked at it. Net effect: views-models observed its own
+internal shelf **under the FAO service's identity** — the answer it got was "the FAO key
+can see this", reported as "the shelf is healthy". Those are different propositions, and
+they diverge the moment the two keys' scopes differ, which is the entire point of the
+least-privilege work. A warning line could not have fixed it: what consumers read is the
+exit code, and an exit code carries no warning. So the foreign path is gone, not annotated.
 """
 
 from __future__ import annotations
@@ -20,8 +29,19 @@ from typing import Callable, Dict, Optional
 
 FETCH_TIMEOUT_SECONDS = 25
 
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+REQUIRED_KEYS = (
+    "APPWRITE_ENDPOINT",
+    "APPWRITE_DATASTORE_PROJECT_ID",
+    "APPWRITE_DATASTORE_API_KEY",
+)
+
+# Both line styles, because the format is not this module's business (#298): this repo's
+# .env is bare `KEY=value`, views-faoapi's is `export KEY=value`, and a credential parser
+# that only understands one of them is asserting a habit, not a contract.
 _ENV_LINE = re.compile(
-    r"^export\s+(APPWRITE_ENDPOINT|APPWRITE_DATASTORE_PROJECT_ID|"
+    r"^(?:export\s+)?(APPWRITE_ENDPOINT|APPWRITE_DATASTORE_PROJECT_ID|"
     r"APPWRITE_DATASTORE_API_KEY)\s*=\s*(.+?)\s*$"
 )
 
@@ -35,56 +55,114 @@ class AppwriteCredentials:
     api_key: str
 
 
-def load_credentials_from_env_file(path: Path) -> Optional[AppwriteCredentials]:
-    """Parse an export-style .env; None unless all three keys are present."""
+def _clean(value: str) -> str:
+    """Strip surrounding quotes, or an unquoted trailing ` # comment`.
+
+    Both forms occur in real files: dotenv writes bare values, and the bash-sourceable
+    `.env` this repo uses carries trailing comments on the coordinate lines.
+    """
+    value = value.strip()
+    if len(value) >= 2 and value[0] == value[-1] and value[0] in "\"'":
+        return value[1:-1]
+    return value.split(" #", 1)[0].rstrip()
+
+
+def parse_env_file(path: Path) -> Dict[str, str]:
+    """The APPWRITE_* keys present in an env file. Missing file → empty mapping.
+
+    One job: read a file, return what it declares. It does not decide whether that is
+    enough — `load_credentials_from_env_file` and `missing_credentials` do, and keeping
+    those separate is what lets the caller tell "no file" from "incomplete file" (#298).
+    """
     try:
         text = path.read_text()
     except OSError:
-        return None
+        return {}
     found: Dict[str, str] = {}
     for line in text.splitlines():
         match = _ENV_LINE.match(line.strip())
         if match:
-            found[match.group(1)] = match.group(2).strip("\"'")
-    try:
-        return AppwriteCredentials(
-            endpoint=found["APPWRITE_ENDPOINT"],
-            project_id=found["APPWRITE_DATASTORE_PROJECT_ID"],
-            api_key=found["APPWRITE_DATASTORE_API_KEY"],
-        )
-    except KeyError:
+            found[match.group(1)] = _clean(match.group(2))
+    return found
+
+
+def load_credentials_from_env_file(path: Path) -> Optional[AppwriteCredentials]:
+    """Parse a `.env` (either line style); None unless all three keys are present."""
+    found = parse_env_file(path)
+    if not all(found.get(key) for key in REQUIRED_KEYS):
         return None
+    return AppwriteCredentials(
+        endpoint=found["APPWRITE_ENDPOINT"],
+        project_id=found["APPWRITE_DATASTORE_PROJECT_ID"],
+        api_key=found["APPWRITE_DATASTORE_API_KEY"],
+    )
 
 
-def _known_env_files():
-    """Candidate platform .env files, discovered by walking ancestors — robust
-    to running from the main checkout AND from a git worktree under
-    .claude/worktrees/ (where fixed parent-counting breaks)."""
+def own_env_file() -> Path:
+    """This repository's own `.env`. The only file this module reads (#298)."""
+    return REPO_ROOT / ".env"
+
+
+def missing_credentials() -> tuple:
+    """Which required variables are absent, considering process env then own `.env`.
+
+    Exists so a caller can distinguish **nothing configured** (a truthful skip, exit 0)
+    from **configured but incomplete** (a misconfiguration a human must fix — loud, and
+    it names the variables). Returning `None` from `resolve_credentials()` conflates the
+    two, and that conflation is half of what #298 is about.
+    """
+    import os
+
+    from_file = parse_env_file(own_env_file())
     return tuple(
-        ancestor / "views-faoapi" / ".env"
-        for ancestor in Path(__file__).resolve().parents
-        if (ancestor / "views-faoapi" / ".env").exists()
+        key for key in REQUIRED_KEYS
+        if not (os.environ.get(key) or from_file.get(key))
+    )
+
+
+def credential_gap_report() -> tuple:
+    """`(verdict, error)` describing why credentials could not be resolved.
+
+    Lives here, not in the surfaces: describing a credential state is the credentials
+    module's job, while mapping a verdict to an exit code stays `report.py`'s. Both
+    surfaces call it rather than each carrying the same six lines — this is one concept
+    in one place, not a premature generalisation of two different things.
+    """
+    missing = missing_credentials()
+    own = own_env_file()
+    if not missing:
+        # Nothing is missing, yet the caller has no credentials — so they were injected
+        # as None deliberately (a test, or a surface constructed without them). Do not
+        # report a configuration fault we cannot see; say what is actually true.
+        return (
+            "SKIP_NO_CREDENTIALS",
+            "no credentials supplied to this check (none were resolved for it)",
+        )
+    if len(missing) == len(REQUIRED_KEYS):
+        return (
+            "SKIP_NO_CREDENTIALS",
+            f"no Appwrite credentials in the environment and none in {own} "
+            f"(this repo's own .env; other repos' .env files are deliberately not read — #298)",
+        )
+    return (
+        "CREDENTIALS_INCOMPLETE",
+        f"credentials are partially configured — missing {', '.join(missing)}. "
+        f"Set them in the environment or in {own}",
     )
 
 
 def resolve_credentials() -> Optional[AppwriteCredentials]:
-    """Env vars first, then the known platform .env files."""
+    """Process env first, then **this repository's own** `.env`. Never another repo's."""
     import os
 
-    env = {k: os.environ.get(k) for k in (
-        "APPWRITE_ENDPOINT", "APPWRITE_DATASTORE_PROJECT_ID", "APPWRITE_DATASTORE_API_KEY",
-    )}
+    env = {key: os.environ.get(key) for key in REQUIRED_KEYS}
     if all(env.values()):
         return AppwriteCredentials(
             env["APPWRITE_ENDPOINT"],              # type: ignore[arg-type]
             env["APPWRITE_DATASTORE_PROJECT_ID"],  # type: ignore[arg-type]
             env["APPWRITE_DATASTORE_API_KEY"],     # type: ignore[arg-type]
         )
-    for candidate in _known_env_files():
-        credentials = load_credentials_from_env_file(candidate)
-        if credentials is not None:
-            return credentials
-    return None
+    return load_credentials_from_env_file(own_env_file())
 
 
 def newest_first_query(limit: int = 5) -> str:

--- a/tools/liveness/appwrite_store.py
+++ b/tools/liveness/appwrite_store.py
@@ -19,8 +19,10 @@ existed):
     un_fao run config; does not exist; killed the run at store lookup.
 
 Credentials resolution (encoded once, values never rendered): process env
-vars first, else the known platform .env (views-faoapi/.env, export-style).
-Reports presence via character counts only.
+vars first, else **this repository's own** `.env` at the repo root, in either
+line style. It no longer reads `views-faoapi/.env` — doing so meant this repo
+observed its own shelf under the FAO identity (#298). Reports presence via
+character counts only.
 
 Design (house rules, mirrors the S1/S2 checks): injected fetch + credentials
 + clock (DIP), lazy stdlib urllib in the default fetch, no import-time side
@@ -49,6 +51,7 @@ from tools.liveness.appwrite_api import (  # noqa: E402  (kept near use)
     fetch_json,
     load_credentials_from_env_file,
     newest_first_query,
+    credential_gap_report,
     resolve_credentials,
 )
 from tools.liveness.report import exit_code_for, render_facts  # noqa: E402
@@ -70,6 +73,7 @@ class CheckReport:
     """Raw facts about the production_forecasts store — no narration."""
 
     verdict: str  # STORE_ACTIVE | STORE_IDLE | UNREACHABLE | SKIP_NO_CREDENTIALS
+    #              | CREDENTIALS_INCOMPLETE
     endpoint: Optional[str] = None
     bucket: str = APPWRITE_BUCKET_ID
     api_key_chars: Optional[int] = None
@@ -121,10 +125,8 @@ class AppwriteStoreCheck:
 
     def run(self, now: Optional[datetime] = None) -> CheckReport:
         if self.credentials is None:
-            return CheckReport(
-                verdict="SKIP_NO_CREDENTIALS",
-                error="no Appwrite credentials in env or known .env files",
-            )
+            verdict, error = credential_gap_report()
+            return CheckReport(verdict=verdict, error=error)
         now = now or datetime.now(timezone.utc)
         creds = self.credentials
         headers = {

--- a/tools/liveness/report.py
+++ b/tools/liveness/report.py
@@ -35,6 +35,12 @@ EXIT_CODE_BY_VERDICT = {
     "STORE_STALE": 1,
     "DELIVERY_STALLED": 1,
     "EXECUTION_STALE": 1,
+    # A `.env` exists but does not carry every required variable (#298). Deliberately
+    # NOT a truthful skip: "nothing is configured" is an honest absence of observation,
+    # while "configured, but half of it" is a misconfiguration a human must fix, and
+    # collapsing the two is what let this repo observe its shelf under a foreign key.
+    # Exit 1 (attention), not 2 — the world is reachable; our configuration is not right.
+    "CREDENTIALS_INCOMPLETE": 1,
     # unobservable
     "UNREACHABLE": 2,
 }

--- a/tools/liveness/unfao_delivery.py
+++ b/tools/liveness/unfao_delivery.py
@@ -11,9 +11,9 @@ then stalled unnoticed):
 Usage:
     python -m tools.liveness.unfao_delivery   # exit 0 delivering/skip / 1 stalled / 2 unreachable
 
-Credentials are REUSED from tools.liveness.appwrite_store (same Appwrite
-project + .env; S7 will home this in a shared credentials module — noted,
-deliberate). Design mirrors the sibling checks: injected fetch/credentials/
+Credentials are REUSED from tools.liveness.appwrite_api (same Appwrite project;
+resolved from process env, else **this repo's own** `.env` — never another
+repo's, per #298). Design mirrors the sibling checks: injected fetch/credentials/
 clock (DIP), lazy stdlib urllib, no import-time side effects (C-93),
 secrets never rendered, truthful SKIP without credentials.
 """
@@ -29,6 +29,7 @@ from tools.liveness.appwrite_api import (
     FetchJson,
     fetch_json,
     newest_first_query,
+    credential_gap_report,
     resolve_credentials,
     stream_newest_query,
 )
@@ -47,6 +48,7 @@ class CheckReport:
     """Raw facts about the FAO delivery bucket — no narration."""
 
     verdict: str  # DELIVERING | DELIVERY_STALLED | UNREACHABLE | SKIP_NO_CREDENTIALS
+    #              | CREDENTIALS_INCOMPLETE
     endpoint: Optional[str] = None
     bucket: str = UNFAO_BUCKET_ID
     total_files: Optional[int] = None
@@ -108,10 +110,8 @@ class UnfaoDeliveryCheck:
 
     def run(self, now: Optional[datetime] = None) -> CheckReport:
         if self.credentials is None:
-            return CheckReport(
-                verdict="SKIP_NO_CREDENTIALS",
-                error="no Appwrite credentials in env or known .env files",
-            )
+            verdict, error = credential_gap_report()
+            return CheckReport(verdict=verdict, error=error)
         now = now or datetime.now(timezone.utc)
         creds = self.credentials
         headers = {


### PR DESCRIPTION
First of three PRs from the þing-02 follow-through. Both changes are certain and testable; the plan deliberately keeps them out of the same PR as the CI work.

## #299 — the `.gitignore` gaps

`.gitignore` covered only the literal `.env`. `.env.bak` and `.env.local` were covered **incidentally**, by `*.bak` and `*.local` further down the file. The two shapes most likely to exist on the day someone rotates a key were not covered at all:

- **`.env.faoapi`** — the exact filename the production server uses
- **`.env.20260728`** — the shape of a file made on a rotation day

On a **public** repo. Now `.env` + `.env.*` with **`!.env.example`** — the negation is required, because `.env.example` is tracked and is the credential schema `tools/check_credentials.py` reads. A broad rule without it would silently un-track the schema.

Both halves are pinned by tests, including one asserting `.env.example` stays *un*-ignored. Verified no currently-tracked file became ignored.

## #298 — liveness reads its **own** `.env`

`tools/liveness/appwrite_api.py` walked ancestors looking for **`views-faoapi/.env`** — a hardcoded foreign repository — and its regex matched only `^export` lines. This repo's `.env` is bare `KEY=` style, so the regex excluded it *and* the path never looked at it.

Net effect: **views-models observed its own internal shelf under the FAO service's identity.** The answer it got was *"the FAO key can see this"*; it reported *"the shelf is healthy"*. Different propositions, and they diverge the moment the two keys' scopes differ — which is the entire point of the least-privilege work.

**A logged fallback was considered and rejected.** What consumers read is the exit code, and an exit code carries no warning. The foreign path is **deleted**, not annotated.

### Absent vs partial

Also splits two states the old `None` return conflated:

| state | verdict | exit |
|---|---|---|
| nothing configured | `SKIP_NO_CREDENTIALS` *(unchanged)* | 0 |
| **configured but incomplete** | **`CREDENTIALS_INCOMPLETE`**, naming the missing variables | **1** |

Exit 1, not 2 — the world is reachable; our configuration is not right.

The verdict is registered in `report.py` **deliberately**: that file is in `cic_sync_check.yml`'s map, so the CIC physically could not go stale behind this change. `docs/CICs/LivenessChecks.md` and `tools/liveness/README.md` both move with it.

## Tests

- bare-`KEY=` parse — **the actual bug**. The pre-existing export-style test passed throughout the entire period the bug existed, which is exactly why it never caught it.
- trailing-comment strip (this repo's `.env` is bash-sourceable and carries them)
- absent-vs-partial verdicts
- **the decoy test** — plants a `views-faoapi/.env` and asserts it is **not** read. That test *is* the specification of the fix; if it ever fails, the borrowing is back.

Two existing tests re-pointed from the deleted `_known_env_files` seam to `REPO_ROOT`. The runner's verdict-totality check caught the new verdict and had to be updated — working as designed.

One bug of mine was caught by the existing suite mid-change: `credential_gap_report()` reported "incomplete, missing *(nothing)*" when a caller injected `None` while the environment was complete. Fixed and covered.

## Verification

```
ruff                     clean
pytest (working tree)    7427 passed, 0 failed   (+12 tests)
tools/verify_committed.sh  1 failed — #297 only, pre-existing and not mine
live: python -m tools.liveness.appwrite_store
     -> STORE_ACTIVE, 461 files, resolved from views-models/.env
```

Closes #298, closes #299.

🤖 Generated with [Claude Code](https://claude.com/claude-code)