### PR TITLE
feat(ci): gitleaks over full history, exit code is the verdict (#300)

### DIFF
--- a/.github/workflows/secret_scan.yml
+++ b/.github/workflows/secret_scan.yml
@@ -1,0 +1,145 @@
+name: Secret Scan
+
+# Full-history credential scan. The exit code is the verdict (#300).
+#
+# Why this exists. This repo's 2026-07-27 credential audit stated "Zero secrets in git
+# — ever". Twenty seconds of a real scanner falsified the headline four days later,
+# finding AWS STS material in a notebook on a public branch. The lesson the þing-02
+# verdict took from that: a credential claim asserted in an agent's prose is not
+# evidence; a named tool, a pinned version, a recorded command and a re-runnable exit
+# code is. This job is that, and it replaces a contract clause rather than adding one.
+#
+# TWO WAYS THIS JOB COULD LIE, both guarded below. A secret scan that cannot fail is
+# worse than no scan, because the platform would believe it is covered.
+#
+#   1. SHALLOW CLONE. actions/checkout defaults to fetch-depth: 1. With one commit in
+#      the repository, `--log-opts="--all --full-history"` scans one commit, finds
+#      nothing and exits 0 — green forever, and every property of this job would be
+#      true and worthless. Hence `fetch-depth: 0`.
+#   2. A SILENTLY NARROWED SCAN. fetch-depth alone is not enough: nothing would catch
+#      the day someone "optimises" the checkout, or a future gitleaks changes what
+#      `--all` means.
+#
+# The guard below therefore checks TWO things, and the first is not optional.
+#
+#   `git rev-parse --is-shallow-repository` must be false. A ratio check ALONE cannot
+#   detect a shallow clone — verified 2026-07-31 by cloning this repo with --depth 1:
+#   gitleaks reported "1 commits scanned / no leaks found / exit 0", and
+#   `git rev-list --count --all` ALSO reported 1, so scanned/total = 100% and a
+#   self-calibrating ratio passes with flying colours. Both numbers come from the same
+#   truncated repository, so they agree with each other and lie together. Only the
+#   shallow flag is an independent witness.
+#
+#   The ratio check then still earns its place: it catches a scan narrowed by something
+#   other than clone depth (an edited --log-opts, a gitleaks change to what --all means)
+#   in a repository that is genuinely complete.
+
+on:
+  push:
+    branches: [main, development]
+  pull_request:
+    branches: [main, development]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+env:
+  # Pinned deliberately. "Latest" would mean the verdict changes without a commit.
+  GITLEAKS_VERSION: "8.30.1"
+  GITLEAKS_SHA256: "551f6fc83ea457d62a0d98237cbad105af8d557003051f41f3e7ca7b3f2470eb"
+  # gitleaks walks non-merge commits (1,435 of 1,642 here ≈ 87%). 50% is a wide margin
+  # against normal drift while still catching a shallow clone, which scans ~1.
+  MIN_SCANNED_FRACTION_PERCENT: "50"
+
+jobs:
+  gitleaks:
+    name: gitleaks (full history)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out FULL history
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0   # see guard 1 above — do not remove
+
+      - name: Install pinned gitleaks
+        run: |
+          set -euo pipefail
+          url="https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz"
+          curl -sSL "$url" -o gitleaks.tar.gz
+          echo "${GITLEAKS_SHA256}  gitleaks.tar.gz" | sha256sum -c -
+          tar xzf gitleaks.tar.gz gitleaks
+          ./gitleaks version
+
+      - name: Scan full history
+        id: scan
+        run: |
+          set -uo pipefail
+          # --redact: findings are reported by rule/file/commit/line, never by value,
+          # so a leak does not get re-published in a public CI log while being reported.
+          ./gitleaks git \
+            --log-opts="--all --full-history" \
+            --redact \
+            --report-format sarif \
+            --report-path gitleaks.sarif \
+            2>&1 | tee scan.log
+          echo "exit_code=${PIPESTATUS[0]}" >> "$GITHUB_OUTPUT"
+
+      - name: Assert the scan actually walked the history
+        run: |
+          set -euo pipefail
+
+          # GUARD 1 — the independent witness. Must come first: in a shallow clone the
+          # ratio check below compares two numbers that are both truncated, agree with
+          # each other, and pass. Only this flag is not derived from the scan itself.
+          if [ "$(git rev-parse --is-shallow-repository)" != "false" ]; then
+            echo "::error::This is a SHALLOW clone. gitleaks will report 'no leaks found'"
+            echo "::error::after scanning ~1 commit and exit 0 — a green that proves"
+            echo "::error::nothing. Restore 'fetch-depth: 0' on actions/checkout."
+            exit 1
+          fi
+
+          total=$(git rev-list --count --all)
+          scanned=$(grep -oE '[0-9]+ commits scanned' scan.log | grep -oE '^[0-9]+' | head -1 || true)
+
+          if [ -z "$scanned" ]; then
+            echo "::error::Could not read a commit count from gitleaks output. The"
+            echo "::error::vacuity guard cannot confirm the scan walked the history, so"
+            echo "::error::this run proves nothing. Failing rather than passing blind."
+            exit 1
+          fi
+
+          floor=$(( total * MIN_SCANNED_FRACTION_PERCENT / 100 ))
+          echo "commits in repository : $total"
+          echo "commits scanned       : $scanned"
+          echo "floor (${MIN_SCANNED_FRACTION_PERCENT}%)  : $floor"
+
+          if [ "$scanned" -lt "$floor" ]; then
+            echo "::error::gitleaks scanned $scanned of $total commits — below the"
+            echo "::error::${MIN_SCANNED_FRACTION_PERCENT}% floor. This is what a shallow clone looks like."
+            echo "::error::A clean result from a scan this narrow is meaningless. Check"
+            echo "::error::that actions/checkout still sets fetch-depth: 0."
+            exit 1
+          fi
+          echo "Vacuity guard passed — the scan saw the history."
+
+      - name: Upload findings report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: gitleaks-sarif
+          path: gitleaks.sarif
+          if-no-files-found: ignore
+
+      - name: The exit code is the verdict
+        run: |
+          code="${{ steps.scan.outputs.exit_code }}"
+          if [ "$code" != "0" ]; then
+            echo "::error::gitleaks exited $code — findings are in scan.log and the"
+            echo "::error::uploaded SARIF artifact (values redacted). If a finding is"
+            echo "::error::benign, add its fingerprint to .gitleaksignore WITH a written"
+            echo "::error::justification; an undocumented allowlist entry is"
+            echo "::error::indistinguishable from a hidden leak."
+            exit "$code"
+          fi
+          echo "No unallowlisted findings in full history."

--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,16 @@ __pycache__/
 *_proto
 *_prototype
 
+# CI configuration is never a build artifact (#300). The blanket *.json/*.yaml/*.yml
+# rules above exist for wandb run outputs, and they silently swallow NEW files under
+# .github/ — the four workflows tracked today survive only because they predate those
+# rules, and git does not ignore what is already tracked. Found the hard way while
+# adding .github/workflows/secret_scan.yml: `git add` reported it ignored and the
+# commit went through WITHOUT it, which is exactly the silent-omission class this
+# repo keeps rediscovering.
+!.github/
+!.github/**
+
 # Darts
 *.scalers
 *.pt.scalers

--- a/.gitleaksignore
+++ b/.gitleaksignore
@@ -1,0 +1,39 @@
+# gitleaks allowlist — every entry is a finding that WAS inspected and judged benign.
+#
+# Rules for this file (#300):
+#   1. Never add a fingerprint without a written justification below it. An
+#      undocumented allowlist entry is indistinguishable from a hidden leak.
+#   2. A fingerprint is `commit:path:rule:startline`. It embeds a commit SHA, so a
+#      history rewrite invalidates it and the job goes red for a reason unconnected
+#      to any new secret. If that happens, re-derive rather than deleting the entry.
+#   3. "Expired" is a justification. "Probably fine" is not.
+#
+# Current findings, from a full-history scan on 2026-07-31
+# (gitleaks 8.30.1, `--all --full-history`, 1,435 commits / 197.7 MB):
+# 6 findings, 4 unique. All four are below. None is a live credential.
+
+# ── 1–2. Documentation placeholders ───────────────────────────────────────────
+# `curl -H "Authorization: Bearer <21 chars beginning 'your'>"` in two API READMEs.
+# Inspected: the value is a placeholder, not a token. The two entries are the same
+# string — apis/un_fao/README.md was copied to apis/seldon_api/README.md.
+5d320e975a81e74e296b519bbdadd1d025ff19b3:apis/seldon_api/README.md:curl-auth-header:134
+7e82282ab01ca8c3f9e8667c00cb2a09d6bbea72:apis/un_fao/README.md:curl-auth-header:134
+
+# ── 3–4. Expired AWS STS material in a notebook ───────────────────────────────
+# Two `ASIA…` access-key IDs inside S3 **presigned URLs** in a Jupyter notebook,
+# committed 2025-02-18. Inspected:
+#   * `ASIA` is the AWS prefix for STS **temporary** credentials.
+#   * A presigned URL carries an access-key *ID* and a signature — never the secret
+#     access key.
+#   * A URL signed with temporary credentials expires with the session token: at
+#     most 36 hours. Signed 2025-02-18, so dead since 2025-02-20.
+# Not an Appwrite credential and nothing to revoke. Retained here rather than
+# rewritten out of history: the value is already expired, and rewriting public
+# history to remove a dead string costs more than it buys.
+#
+# NOTE for the record: the file is deleted from HEAD but the commit is still
+# reachable from the public branch `origin/purple_alien_experiments`. Deletion is
+# not removal (register S14/C-…); that branch is a separate question from this
+# allowlist.
+87ec1b423b3fe9a88a1458ba7b6bca149a152f9f:models/purple_alien/notebooks/experiement_reconcilliation.ipynb:aws-access-token:110
+87ec1b423b3fe9a88a1458ba7b6bca149a152f9f:models/purple_alien/notebooks/experiement_reconcilliation.ipynb:aws-access-token:111

--- a/tests/test_secret_scan_workflow.py
+++ b/tests/test_secret_scan_workflow.py
@@ -1,0 +1,137 @@
+"""Structural guards on the secret-scan workflow (#300).
+
+The workflow itself cannot be executed here, but the two properties that decide
+whether it is *capable of failing* are static and are pinned below.
+
+Why this file exists. A secret scan that cannot fail is worse than no scan: the þing-02
+verdict struck a contract clause and named this job as its replacement, so a false green
+here is a false assurance platform-wide. Two settings decide it, and both were verified
+empirically on 2026-07-31 by cloning this repo with `--depth 1`:
+
+    gitleaks git --log-opts="--all --full-history"   ->  "1 commits scanned"
+                                                        "no leaks found"
+                                                        exit 0
+
+A naive job calls that green forever. Worse, a ratio check ("did we scan most of the
+commits?") ALSO passes there, because `git rev-list --count --all` in a shallow clone is
+likewise 1 — both numbers come from the same truncated repository and lie together. Only
+`git rev-parse --is-shallow-repository` is an independent witness.
+"""
+from pathlib import Path
+
+import pytest
+
+pytestmark = [pytest.mark.beige]
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+WORKFLOW = REPO_ROOT / ".github" / "workflows" / "secret_scan.yml"
+ALLOWLIST = REPO_ROOT / ".gitleaksignore"
+
+
+def _workflow_text() -> str:
+    assert WORKFLOW.exists(), f"{WORKFLOW.name} must exist — it is D5's replacement"
+    return WORKFLOW.read_text(encoding="utf-8")
+
+
+def test_workflow_is_tracked_and_not_gitignored():
+    """The job must exist in git, not merely on someone's disk.
+
+    `.gitignore` carries blanket `*.json` / `*.yaml` / `*.yml` rules for wandb run
+    outputs. They also swallow anything new under `.github/` — the four workflows
+    tracked before this one survive only because git does not ignore what is already
+    tracked. Adding this file hit it directly: `git add` reported the path ignored and
+    the commit went through WITHOUT it, leaving a PR that looked complete and contained
+    no workflow. A `!.github/**` negation now prevents that; this test prevents its
+    removal.
+    """
+    import subprocess
+
+    ignored = subprocess.run(
+        ["git", "check-ignore", "-q", str(WORKFLOW.relative_to(REPO_ROOT))],
+        cwd=REPO_ROOT,
+    ).returncode == 0
+    assert not ignored, (
+        "the secret-scan workflow is gitignored — it would silently not exist in the "
+        "repository. Restore the `!.github/**` negation in .gitignore (#300)"
+    )
+
+    tracked = subprocess.run(
+        ["git", "ls-files", "--error-unmatch", str(WORKFLOW.relative_to(REPO_ROOT))],
+        cwd=REPO_ROOT, capture_output=True,
+    ).returncode == 0
+    assert tracked, "the secret-scan workflow exists on disk but is not tracked in git"
+
+
+def test_checkout_fetches_full_history():
+    """`fetch-depth: 0` — without it the scan walks one commit and passes green."""
+    assert "fetch-depth: 0" in _workflow_text(), (
+        "actions/checkout defaults to depth 1. Without `fetch-depth: 0` the "
+        "`--all --full-history` scan sees a single commit, finds nothing, and exits 0 "
+        "— a permanent false green (#300)"
+    )
+
+
+def test_shallow_repository_guard_is_present():
+    """The independent witness. A ratio check alone cannot detect a shallow clone."""
+    assert "--is-shallow-repository" in _workflow_text(), (
+        "the shallow-repository check is the only guard not derived from the scan "
+        "itself; a commits-scanned ratio passes in a shallow clone because both sides "
+        "of the ratio are truncated (#300)"
+    )
+
+
+def test_scan_covers_all_refs_and_full_history():
+    text = _workflow_text()
+    assert "--all --full-history" in text, (
+        "the scan must cover every ref, not just the checked-out branch — this repo's "
+        "only real finding lives on a branch, in a file deleted from HEAD"
+    )
+
+
+def test_gitleaks_version_is_pinned_with_a_checksum():
+    """'latest' would let the verdict change without a commit."""
+    text = _workflow_text()
+    assert "GITLEAKS_VERSION:" in text and "latest" not in text.lower().split("gitleaks_version:")[1][:40]
+    assert "sha256sum -c" in text, (
+        "a pinned version without a checksum pins a name, not an artifact"
+    )
+
+
+def test_findings_are_redacted_in_ci_logs():
+    assert "--redact" in _workflow_text(), (
+        "CI logs on a public repo are public; a scanner that prints the secret it "
+        "found has published it a second time"
+    )
+
+
+def test_every_allowlist_fingerprint_carries_a_justification():
+    """An undocumented allowlist entry is indistinguishable from a hidden leak."""
+    assert ALLOWLIST.exists(), ".gitleaksignore must exist"
+    lines = ALLOWLIST.read_text(encoding="utf-8").splitlines()
+
+    undocumented = []
+    for index, line in enumerate(lines):
+        entry = line.strip()
+        if not entry or entry.startswith("#"):
+            continue
+        # Walk up past any SIBLING fingerprints to the comment block that documents
+        # them. Grouping related findings under one justification is correct — the two
+        # README placeholders are literally the same string in two copied files — so
+        # requiring a comment immediately above every line would punish good practice.
+        # What must not exist is a fingerprint reachable only from blank space.
+        documented = False
+        for j in range(index - 1, -1, -1):
+            above = lines[j].strip()
+            if not above:
+                break            # blank line: the entry stands alone, undocumented
+            if above.startswith("#"):
+                documented = True
+                break
+            # else: a sibling fingerprint — keep walking up
+        if not documented:
+            undocumented.append(entry)
+
+    assert not undocumented, (
+        "these .gitleaksignore fingerprints have no comment above them explaining why "
+        f"the finding is benign: {undocumented}"
+    )


### PR DESCRIPTION
Second of three PRs from the þing-02 follow-through. This is D5's replacement mechanism — living in the repo rather than in the contract.

A named scanner, a **pinned version with a checksum**, `--all --full-history`, and the exit code as the verdict rather than an agent's prose. The reason this seat asked for the thing that bills it: its own 2026-07-27 audit said *"Zero secrets in git — ever"*, and twenty seconds of a real scanner falsified the headline four days later.

## The vacuity problem — and why my first guard was wrong

**A secret scan that cannot fail is worse than no scan**, because the platform believes it is covered. I demonstrated the risk rather than assuming it, by cloning this repo `--depth 1`:

```
gitleaks git --log-opts="--all --full-history"
  -> "1 commits scanned" / "no leaks found" / exit 0
```

A naive job calls that **green forever**.

My first guard compared gitleaks' reported commit count against `git rev-list --count --all` — self-calibrating, no magic number to rot. **Testing it in the shallow clone showed it passes there**: `rev-list` also reports 1, so scanned/total = 100%. Both numbers come from the same truncated repository and lie together.

So the guard now leads with **`git rev-parse --is-shallow-repository`** — the only witness not derived from the scan itself. The ratio check is kept, because it still catches a scan narrowed by something *other* than clone depth.

All three cases exercised:

| scenario | result |
|---|---|
| shallow clone | **guard 1 fires** |
| full clone, `--log-opts="-n 5"` | **guard 2 fires** |
| full clone, full scan | passes (1,441 commits, 197.8 MB) |

## A second silent-omission bug, found while committing

`git add .github/workflows/secret_scan.yml` reported the path **ignored**, and the commit went through *without it* — a PR that would have looked complete and contained no workflow.

Cause: `.gitignore` carries blanket `*.json` / `*.yaml` / `*.yml` rules for wandb run outputs. **The four workflows tracked today survive only because git does not ignore what is already tracked.** Any new one is silently dropped.

Fixed with a targeted `!.github/**` negation — verified that wandb artifacts and `envs/*.yml` stay ignored — and pinned by a test.

> Note: this PR touches `.gitignore` around line 31; **#303 touches it around line 172**. Different regions, no conflict expected, but they should merge in order.

## `.gitleaksignore`

All four current findings documented — two README placeholders (`your…`) and two AWS **STS temporary** key IDs inside S3 presigned URLs, expired ≤36 h after 2025-02-18. Without the file the job is red on day one; without the justifications an allowlist entry is indistinguishable from a hidden leak.

## Tests

`tests/test_secret_scan_workflow.py` pins the settings that decide whether this job is *capable of failing*: `fetch-depth: 0`, the shallow guard, the full-history opts, the version+checksum pin, `--redact`, that the workflow is tracked and un-ignored, and that every allowlist fingerprint carries a justification.

That last one was **negative-tested** — appending an undocumented fingerprint fails it, removing it passes — and it also caught an over-strict first draft of itself that would have punished grouping related findings under one comment.

## Verification

```
full-history scan with allowlist   exit 0, 1,441 commits, 197.8 MB
ruff                                clean
pytest                              7421 passed, 0 failed
```

Not verified: the workflow has not run on GitHub yet. Worth one `workflow_dispatch` after merge.

Closes #300.

🤖 Generated with [Claude Code](https://claude.com/claude-code)