### PR TITLE
fix(un_fao): assert the installed build can produce what config_meta declares (#294)

### DIFF
--- a/postprocessors/un_fao/run.sh
+++ b/postprocessors/un_fao/run.sh
@@ -51,6 +51,49 @@ else
   pip install git+https://${GITHUB_TOKEN}@github.com/views-platform/views-postprocessing.git@main
 fi
 
+# ── #294: does the build we just installed do what config_meta DECLARES? ──────────────
+# The installs above pin `@main` — a MOVING branch pointer. Whether it can produce the
+# artifact this postprocessor declares is a fact about someone else's repository on the
+# day you run, and nothing here checked it.
+#
+# That is not hypothetical. On 2026-07-31 `@main` was 208 commits behind, carried zero
+# wire modules, and still ran to completion: it would have ignored `wire_contract: True`
+# and delivered the LEGACY parquet instead of the ADR-013 contract dialect — green run,
+# wrong artifact, and faoapi then serving the previous month. views-postprocessing#178
+# merged on 2026-08-01 and `@main` now carries the wire, so the pin happens to be correct
+# today. Correct by timing is not the same as verified, and the next drift is silent
+# again.
+#
+# So: read what config_meta declares, then assert the installed package can honour it.
+# Declaration read through importlib, never grep — a commented-out key looks identical to
+# a live one to a regex, which is register entry C-57.
+_wire_declared="$(python - "$script_path/configs/config_meta.py" <<'PY' 2>/dev/null || echo unknown
+import importlib.util, sys
+spec = importlib.util.spec_from_file_location("un_fao_config_meta", sys.argv[1])
+module = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(module)
+print("yes" if module.get_meta_config().get("wire_contract") else "no")
+PY
+)"
+
+if [ "$_wire_declared" = "yes" ]; then
+  if ! python -c "import views_postprocessing.contract.wire" >/dev/null 2>&1; then
+    echo "ERROR: config_meta declares wire_contract: True, but the installed" >&2
+    echo "       views-postprocessing cannot import views_postprocessing.contract.wire." >&2
+    echo "       This build CANNOT produce the ADR-013 contract dialect. Left to run, it" >&2
+    echo "       would exit 0 having delivered the legacy artifact, and FAO would keep" >&2
+    echo "       being served the previous month (#294)." >&2
+    echo "       Installed from: github.com/views-platform/views-postprocessing @main" >&2
+    echo "       Fix: point the pin at a build that carries the wire, or set" >&2
+    echo "       wire_contract: False if the legacy artifact is genuinely what you want." >&2
+    exit 1
+  fi
+  echo "Capability check: wire_contract declared and views_postprocessing.contract.wire importable."
+elif [ "$_wire_declared" = "unknown" ]; then
+  echo "Capability check SKIPPED: could not read wire_contract from config_meta." >&2
+  echo "  Not fatal — this check only ever ADDS a failure mode, it must not invent one." >&2
+fi
+
 # ── þing-01 / PLATFORM-001 (#287): coordinates come from the OWNED registry, not a copied .env ──
 # The non-secret Appwrite coordinates (endpoint, project/bucket/collection/db ids & names) are
 # READ from the single canonical coordinate registry — never copied into this repo. The one SECRET

--- a/tests/test_unfao_launcher_capability.py
+++ b/tests/test_unfao_launcher_capability.py
@@ -1,0 +1,78 @@
+"""The un_fao launcher must not deliver an artifact it cannot produce (#294).
+
+`postprocessors/un_fao/run.sh` installs views-postprocessing from `@main` — a MOVING
+branch pointer. Whether that build can produce the artifact `config_meta` declares is a
+fact about another repository on the day you run, and nothing checked it.
+
+On 2026-07-31 `@main` was 208 commits behind and carried zero wire modules. A run would
+have completed successfully, ignored `wire_contract: True`, delivered the legacy parquet
+instead of the ADR-013 contract dialect, and left faoapi serving the previous month —
+green run, wrong artifact, no signal. views-postprocessing#178 merged on 2026-08-01 and
+`@main` now carries the wire, so the pin is correct today. **Correct by timing is not
+verified**, and the next drift is silent in exactly the same way.
+
+These tests pin the assertion, not the pin. Whatever pin is eventually chosen, the
+launcher must still refuse to run a build that cannot honour its own declaration.
+"""
+from pathlib import Path
+
+import pytest
+
+pytestmark = [pytest.mark.beige]
+
+RUN_SH = (
+    Path(__file__).resolve().parent.parent
+    / "postprocessors" / "un_fao" / "run.sh"
+)
+
+
+def _run_sh() -> str:
+    assert RUN_SH.exists(), "the un_fao launcher must exist"
+    return RUN_SH.read_text(encoding="utf-8")
+
+
+def test_launcher_asserts_the_declared_capability_before_running():
+    text = _run_sh()
+    assert "views_postprocessing.contract.wire" in text, (
+        "the launcher must verify the installed build can import the wire module before "
+        "running a delivery that declares wire_contract — otherwise a stale @main "
+        "silently ships the legacy artifact (#294)"
+    )
+    assert "wire_contract" in text, (
+        "the check must key on what config_meta DECLARES, not on a hardcoded assumption "
+        "— a postprocessor that legitimately wants the legacy artifact must not be "
+        "blocked by it"
+    )
+
+
+def test_capability_check_reads_config_meta_by_import_not_by_grep():
+    """C-57: to a regex, a commented-out key is indistinguishable from a live one.
+
+    The register records this exact failure twice — once in the partition tooling and
+    once in a model-cloning script that patched a commented template line. A shell
+    `grep '"wire_contract": True'` over config_meta would report the declaration as
+    present even when it is commented out.
+    """
+    text = _run_sh()
+    assert "importlib.util" in text, (
+        "the wire_contract declaration must be read by importing config_meta, never by "
+        "grepping it (C-57)"
+    )
+
+
+def test_unreadable_config_meta_does_not_invent_a_failure():
+    """A check that adds a failure mode must not add one it cannot justify."""
+    text = _run_sh()
+    assert "unknown" in text and "SKIPPED" in text, (
+        "if config_meta cannot be read, the capability check must skip truthfully rather "
+        "than abort — it only ever ADDS a failure mode, and an unreadable config is a "
+        "different problem that other checks own"
+    )
+
+
+def test_the_abort_names_what_went_wrong_and_what_to_do():
+    """A launcher that aborts at 3am must say why, and what would fix it."""
+    text = _run_sh()
+    for expected in ("#294", "wire_contract", "legacy artifact"):
+        assert expected in text, f"the abort message must mention {expected!r}"
+    assert "exit 1" in text, "declaring the capability and lacking it must be fatal"


### PR DESCRIPTION
## First: #294's premise is no longer true, and I checked before building on it

The issue was filed 2026-07-31, when `@main` was **208 commits behind with zero wire modules**. A run would have completed successfully, ignored `wire_contract: True`, delivered the legacy parquet instead of the ADR-013 contract dialect, and left faoapi serving the previous month.

**views-postprocessing#178 merged on 2026-08-01.** `@main` now carries `contract/wire/`, the gap is **9 commits**, and `load_dotenv` is gone — which also means #293's export fix is now what keeps the delivery working at all.

So the danger #294 describes has evaporated. I nearly built a fix on a stale premise; verifying first caught it, and the issue is corrected accordingly.

## What has *not* changed

`run.sh` pins `@main` — a **moving branch pointer** — and nothing verifies the build behind it. It is correct today **by timing**. The next drift is silent in exactly the same way.

So this ships **the assertion, not a pin**: whichever pin is eventually chosen, the launcher should still refuse to run a build that cannot honour its own declaration.

## The check

Reads what `config_meta` **declares**, then asserts the installed package can honour it:

- `wire_contract: True` + wire importable → continue
- `wire_contract: True` + wire missing → **abort**, naming the cause and the fix
- `wire_contract` false or absent → nothing to assert, continue
- `config_meta` unreadable → truthful non-fatal skip

The declaration is read via **`importlib`, never grep**. To a regex a commented-out key is indistinguishable from a live one — that is **C-57**, which this register has recorded twice already.

## Sharper than the issue realised

**The committed `config_meta` does not declare `wire_contract`.** Only the parked run-0 edits do (**C-110**). So this defect is *dormant* on `development` and **arms itself the moment those configs land** — which is precisely when nobody would be looking for it.

## Verification

Six paths, through a harness reproducing the run.sh block verbatim:

| case | result |
|---|---|
| declared + capable | continue |
| **declared + incapable** | **abort, exit 1** |
| `wire_contract: False` | skip |
| key absent (today's committed state) | skip |
| unparseable config | truthful skip, non-fatal |
| **key COMMENTED OUT (the C-57 trap)** | reads `no` — a grep would have said yes |

Also run against the **real** committed `config_meta` (skips, correct) and the **real parked** one (aborts, correct).

**Not verified:** the import branch against a genuinely installed views-postprocessing. The env that would carry it (`envs/views-postprocessing`) does not exist on this machine.

## Tests

Pin the assertion, not the pin: that it exists, that it reads by import rather than grep, that an unreadable config skips rather than inventing a failure, and that the abort names both cause and fix.

## Suite

Committed state: **7232 passed, 1 failed — #297 only**, pre-existing.

> The working tree additionally shows `test_y_pred_shape[violet_visitor_calibration]` failing. That is violet_visitor's **live experiment** writing new artifacts, not this change — confirmed by the isolated committed-state check, which carries no artifacts at all. Nothing under `models/violet_visitor/` was touched.

Closes #294.

🤖 Generated with [Claude Code](https://claude.com/claude-code)