### PR TITLE
fix(un_fao): the registry is the only source of coordinates, and its absence is fatal (#308, #309)

### DIFF
--- a/postprocessors/un_fao/run.sh
+++ b/postprocessors/un_fao/run.sh
@@ -17,6 +17,31 @@ script_path=$(dirname "$(realpath $0)")
 project_path="$( cd "$script_path/../../" >/dev/null 2>&1 && pwd )"
 env_path="$project_path/envs/views-postprocessing"
 
+# ── #308: the registry must resolve, and its absence is FATAL — checked FIRST ─────────
+# The default below is a relative sibling hop: it assumes views-appwrite is checked out
+# next to views-models at exactly this path. On a different layout, in CI, or in a
+# container, it is simply absent.
+#
+# This check is deliberately here — before conda, before pip, before anything — because
+# the cost of continuing is not a missing warning, it is a failure that lands minutes
+# later at the datastore boundary, describing a symptom rather than the cause, in front
+# of whoever is least equipped to trace it back to a checkout layout.
+#
+# Existence only at this point: parsing needs tomllib, which needs the 3.11 interpreter
+# conda has not activated yet. The parse is checked below, and is equally fatal.
+APPWRITE_REGISTRY="${APPWRITE_REGISTRY:-$project_path/../views-appwrite/docs/ADRs/platform/coordinate_registry.toml}"
+if [ ! -f "$APPWRITE_REGISTRY" ]; then
+  echo "FATAL: the Appwrite coordinate registry does not exist." >&2
+  echo "  looked for: $APPWRITE_REGISTRY" >&2
+  echo "  override with: APPWRITE_REGISTRY=/path/to/coordinate_registry.toml" >&2
+  echo "" >&2
+  echo "  The default is a relative hop to a sibling checkout of views-appwrite. If this" >&2
+  echo "  machine lays the repositories out differently, set APPWRITE_REGISTRY explicitly." >&2
+  echo "  This is fatal by design (#308): the registry is the ONLY source of Appwrite" >&2
+  echo "  coordinates. Continuing would fail later, somewhere less informative." >&2
+  exit 1
+fi
+
 # Sourcing sets SHELL variables; only what is `export`ed reaches `python main.py` (a child process).
 # Do NOT replace this with `set -a` — .env carries unquoted values containing spaces (the *_NAME
 # coordinates), which `set -a` would export truncated at the first space. Export by name instead. (#293)
@@ -107,45 +132,66 @@ fi
 # operator slot + fallback". It did not — `source` without `export` never reached the python child,
 # so between views-postprocessing's load_dotenv removal (2026-07-28) and this change there was no
 # carrier for the secret at all. The claim was wrong when written.
-APPWRITE_REGISTRY="${APPWRITE_REGISTRY:-$project_path/../views-appwrite/docs/ADRs/platform/coordinate_registry.toml}"
+# The path was resolved and its existence made fatal at the top of this script (#308).
+#
+# REMOVED HERE (#308/#309): `_platform001_coordinate_state()`, added 2026-07-31, which on a
+# missing registry announced "Coordinates ARE present in the environment (exported outside
+# this script) — continuing." **That claim was false.** It tested SHELL variables, which
+# `source .env` above does set — but nothing exports them, so the python child never saw
+# them. Verified: after `source .env; export GITHUB_TOKEN APPWRITE_DATASTORE_API_KEY`, the
+# shell has APPWRITE_ENDPOINT and `python -c 'os.environ.get("APPWRITE_ENDPOINT")'` returns
+# None. It was written to avoid asserting an unverified environment fact, and asserted one
+# by checking the wrong scope. It also settles the design question it was hedging: there was
+# never a second working source for the child, so registry-absent IS coordinates-absent, and
+# fatal costs nothing.
 
-# Report the ACTUAL coordinate state rather than asserting one. The registry is not the only way
-# coordinates can arrive — an operator's shell, a wrapper or an EnvironmentFile may already have
-# exported them, which is exactly how the secret arrives. Claiming "NOT set" without looking would
-# repeat the mistake this change corrects (#293).
-_platform001_coordinate_state() {
-  if [ -n "$APPWRITE_ENDPOINT" ] && [ -n "$APPWRITE_DATASTORE_PROJECT_ID" ] \
-     && [ -n "$APPWRITE_UNFAO_BUCKET_ID" ]; then
-    echo "  Coordinates ARE present in the environment (exported outside this script) — continuing." >&2
-  else
-    echo "  Coordinates are NOT in the environment either — the run will fail at the datastore boundary." >&2
-    echo "  Note: the .env sourced earlier does not supply them; its values are not exported (#293)." >&2
-  fi
-}
-
-if [ -f "$APPWRITE_REGISTRY" ]; then
-  # Failures are reported, not swallowed (#293): a silent fallback here degrades to a path that
-  # may supply nothing, because the sourced .env coordinates are not exported either.
-  _reg_err="$(mktemp "${TMPDIR:-/tmp}/registry_to_env.XXXXXX")"
-  trap 'rm -f "$_reg_err"' EXIT
-  if _coords="$(python "$project_path/tools/credentials/registry_to_env.py" "$APPWRITE_REGISTRY" 2>"$_reg_err")"; then
-    while IFS= read -r _cl; do
-      [ -z "$_cl" ] && continue
-      export "${_cl%%=*}=${_cl#*=}"
-    done <<< "$_coords"
-    echo "PLATFORM-001: Appwrite coordinates read from the registry (secret stays the operator slot)."
-  else
-    echo "PLATFORM-001 WARNING: registry read FAILED — coordinates not set BY THE REGISTRY." >&2
-    echo "  registry: $APPWRITE_REGISTRY" >&2
-    echo "  python:   $(python -V 2>&1)  (registry_to_env.py needs 3.11+ for tomllib)" >&2
-    sed 's/^/  /' "$_reg_err" >&2
-    _platform001_coordinate_state
-  fi
-  rm -f "$_reg_err"; trap - EXIT
-else
-  echo "PLATFORM-001 WARNING: registry NOT FOUND at $APPWRITE_REGISTRY — coordinates not set BY THE REGISTRY." >&2
-  _platform001_coordinate_state
+_reg_err="$(mktemp "${TMPDIR:-/tmp}/registry_to_env.XXXXXX")"
+trap 'rm -f "$_reg_err"' EXIT
+if ! _coords="$(python "$project_path/tools/credentials/registry_to_env.py" "$APPWRITE_REGISTRY" 2>"$_reg_err")"; then
+  echo "FATAL: the coordinate registry exists but could not be read." >&2
+  echo "  registry: $APPWRITE_REGISTRY" >&2
+  echo "  python:   $(python -V 2>&1)  (registry_to_env.py needs 3.11+ for tomllib)" >&2
+  sed 's/^/  /' "$_reg_err" >&2
+  echo "  Fatal by design (#308): the registry is the ONLY source of coordinates." >&2
+  rm -f "$_reg_err"; exit 1
 fi
+rm -f "$_reg_err"; trap - EXIT
+
+# ── #309: one writer. `.env` must not also declare a coordinate the registry owns ────
+# Two writers to the same names is a data race whose winner is decided by line order:
+# reverse these blocks and the semantics invert silently, with no test failing. Per the
+# seam contract that is an error, not a precedence question — so it is reported, not
+# resolved.
+#
+# Deleting these keys from `.env` is safe: they were NEVER exported (see the note above),
+# so nothing downstream has ever received them from that file. Keep the SECRET there.
+_owned="$(echo "$_coords" | cut -d= -f1)"
+_conflicts=""
+if [ -f "$project_path/.env" ]; then
+  for _name in $_owned; do
+    if grep -qE "^[[:space:]]*(export[[:space:]]+)?${_name}=" "$project_path/.env"; then
+      _conflicts="$_conflicts $_name"
+    fi
+  done
+fi
+if [ -n "$_conflicts" ]; then
+  echo "FATAL: .env declares coordinates that the registry owns (#309)." >&2
+  echo "  file:     $project_path/.env" >&2
+  echo "  registry: $APPWRITE_REGISTRY" >&2
+  echo "  both declare:$_conflicts" >&2
+  echo "" >&2
+  echo "  Two writers to one name is a data race decided by line order, so this is an" >&2
+  echo "  error rather than a precedence question. Delete these lines from .env — they" >&2
+  echo "  were never exported, so nothing has ever received them from there. Keep" >&2
+  echo "  APPWRITE_DATASTORE_API_KEY: the secret is the one value .env still carries." >&2
+  exit 1
+fi
+
+while IFS= read -r _cl; do
+  [ -z "$_cl" ] && continue
+  export "${_cl%%=*}=${_cl#*=}"
+done <<< "$_coords"
+echo "Appwrite coordinates read from the registry (the only source); secret stays the operator slot."
 
 echo "Running $script_path/main.py "
 python $script_path/main.py "$@"

--- a/tests/test_unfao_launcher_environment.py
+++ b/tests/test_unfao_launcher_environment.py
@@ -1,0 +1,125 @@
+"""The un_fao launcher's environment contract: one source, and absence is fatal (#308, #309).
+
+Two rules, both learned the hard way:
+
+**#308 — an unresolvable registry is fatal, and fatal early.** The default registry path is
+a relative hop to a sibling checkout of views-appwrite. On a different layout, in CI, or in
+a container it is simply absent. Warning and continuing does not save the run; it moves the
+failure to the datastore boundary minutes later, where it describes a symptom instead of a
+cause, in front of whoever is least equipped to trace it back to a checkout layout.
+
+**#309 — the registry is the only source of coordinates.** `.env` and the registry writing
+the same names is a data race whose winner is decided by line order: reverse the blocks and
+the semantics invert silently, with no test failing.
+
+These tests pin the rules against the launcher, which is production infrastructure and not
+otherwise covered by anything executable.
+"""
+from pathlib import Path
+
+import pytest
+
+pytestmark = [pytest.mark.beige]
+
+RUN_SH = (
+    Path(__file__).resolve().parent.parent / "postprocessors" / "un_fao" / "run.sh"
+)
+
+
+def _run_sh() -> str:
+    return RUN_SH.read_text(encoding="utf-8")
+
+
+def test_missing_registry_is_fatal_before_any_conda_or_pip_work():
+    """#308's acceptance criterion: exit non-zero *before any work begins*.
+
+    Position matters as much as behaviour. A fatal check placed after the conda/pip block
+    still wastes an environment build, and on a fresh machine that is minutes.
+    """
+    text = _run_sh()
+    fatal_at = text.find('if [ ! -f "$APPWRITE_REGISTRY" ]')
+    assert fatal_at != -1, "a missing registry must be fatal (#308)"
+
+    for later in ("conda activate", "pip install", "conda shell.bash hook"):
+        position = text.find(later)
+        assert position == -1 or fatal_at < position, (
+            f"the fatal registry check must come BEFORE {later!r} — otherwise the run "
+            f"builds an environment it is about to throw away (#308)"
+        )
+
+
+def test_the_fatal_message_names_the_path_and_the_override():
+    text = _run_sh()
+    assert "APPWRITE_REGISTRY=/path/to" in text, (
+        "the failure must name the override variable — the person hitting this is on a "
+        "machine with a different layout and needs the escape hatch, not a diagnosis"
+    )
+    assert "looked for:" in text, "the failure must name the path actually tried"
+
+
+def test_an_unreadable_registry_is_also_fatal():
+    """Existing-but-unparseable is the same outcome as absent: no coordinates."""
+    text = _run_sh()
+    assert "could not be read" in text, (
+        "a registry that exists but fails to parse must be fatal too — half a source is "
+        "not a source (#308)"
+    )
+
+
+def test_env_declaring_a_registry_owned_coordinate_is_fatal():
+    """#309: two writers to one name is an error, not a precedence question."""
+    text = _run_sh()
+    assert "both declare:" in text, (
+        "a coordinate declared in BOTH .env and the registry must fail loud naming the "
+        "variable and both sources (#309)"
+    )
+    assert "_conflicts" in text, "the conflict detection must exist, not just be described"
+
+
+def test_the_secret_is_still_exported_by_name_and_never_via_set_a():
+    """The one value .env may still carry. `set -a` would corrupt it (#293)."""
+    text = _run_sh()
+    assert "export APPWRITE_DATASTORE_API_KEY" in text, (
+        "the secret must still be exported by name — #293 exists because it was not"
+    )
+    # Check for USE, not mention: the file deliberately explains in a comment why `set -a`
+    # is wrong, and a naive substring search flags that explanation as the offence. That is
+    # C-57 — to a regex a commented line is indistinguishable from a live one — and this
+    # test made the mistake on its first draft.
+    live_set_a = [
+        line for line in text.splitlines()
+        if "set -a" in line and not line.strip().startswith("#")
+    ]
+    assert not live_set_a, (
+        f"`set -a` is used, not merely explained: {live_set_a}. It exports unquoted "
+        f"*_NAME values truncated at the first space (#293)"
+    )
+
+
+def test_the_293_correction_survived_the_rewrite():
+    """A removal must name what it was carrying (þing-02, S25).
+
+    The #293 comment records that `source` without `export` meant there was no carrier
+    for the secret at all between two dates — a real production failure, honestly
+    documented. Rewrites lose that kind of thing silently.
+    """
+    text = _run_sh()
+    assert "#293" in text, "the #293 correction must survive edits to this file"
+
+
+def test_the_false_coordinate_state_claim_is_gone():
+    """The helper it replaced asserted something untrue; it must not come back.
+
+    `_platform001_coordinate_state()` announced "Coordinates ARE present in the
+    environment (exported outside this script)" on the strength of a SHELL variable that
+    `source .env` sets and nothing exports — so the python child never saw it. It was
+    written to avoid asserting an unverified environment fact and did exactly that by
+    checking the wrong scope.
+    """
+    text = _run_sh()
+    assert "_platform001_coordinate_state" not in text or "REMOVED HERE" in text, (
+        "the coordinate-state helper checked shell variables rather than exported ones "
+        "and reported a false 'coordinates ARE present' — it must not be reinstated "
+        "without fixing that (#308/#309)"
+    )
+    assert "Coordinates ARE present in the environment (exported outside this script)" not in text


### PR DESCRIPTION
## ⚠️ Read this first — it will abort on your machine

This aborts the un_fao launcher on any machine whose `.env` declares coordinates the registry owns. **Yours declares 12.**

The cleanup is **provably a no-op**: those keys were never exported, so nothing downstream has ever received them from that file (#293 established this). Tested on a copy — what survives is `APPWRITE_DATASTORE_API_KEY`, both curation lists, and `VIEWS_DATAFACTORY`.

```
sed -i -E '/^[[:space:]]*(export[[:space:]]+)?APPWRITE_(ENDPOINT|DATASTORE_PROJECT_ID|PROD_FORECASTS_.*|METADATA_DATABASE_.*|UNFAO_(BUCKET|COLLECTION)_(ID|NAME))=/d' .env
```

`.env` not touched by this PR.

## #308 — a missing registry is fatal, and fatal *early*

The default registry path is a relative hop to a sibling `views-appwrite` checkout. On a different layout, in CI, or in a container it is simply absent.

Warning-and-continuing never saved the run — it moved the failure to the datastore boundary minutes later, describing a symptom instead of a cause, in front of whoever is least equipped to trace it back to a checkout layout.

Existence is checked **at the top**, before conda and before pip (no interpreter needed). The parse is checked after conda, where 3.11 exists, and is equally fatal. Position is pinned by a test, because a fatal check placed after the environment build still wastes minutes on a fresh machine.

## #309 — the registry is the only source

`.env` and the registry writing the same names is a data race decided by line order: reverse the blocks and the semantics invert silently, with no test failing. Now reported, not resolved — per the seam contract it is an error, not a precedence question. The secret remains the one value `.env` carries, exported by name.

## I found a false claim in my own code from two days ago

`_platform001_coordinate_state()`, which I added on 2026-07-31, announced:

> *"Coordinates ARE present in the environment (exported outside this script) — continuing."*

**That was false.** It tested **shell** variables — which `source .env` sets — but nothing exports them, so the python child never saw them. Verified:

```
source .env; export GITHUB_TOKEN APPWRITE_DATASTORE_API_KEY
  shell var APPWRITE_ENDPOINT set?  YES
  reaches the python child?         NO
```

It was written specifically to avoid asserting an unverified environment fact, and asserted one by checking the wrong scope.

**This also settles the objection I raised against #308's ordering.** I argued that making it fatal might kill a run that had coordinates from elsewhere. There was no elsewhere — no second source ever reached the child. Registry-absent *is* coordinates-absent, and fatal costs nothing. Removed, with the reason recorded in place so it is not reinstated.

## Not done, deliberately

#309 also asks for a `tools/platform_env.sh` extraction. **One consumer exists today**, and extracting a shared file for one consumer is premature — WET before DRY. It becomes right when a second launcher needs it. Recorded on the issue rather than skipped silently, so #309 stays open.

## Verification

| | |
|---|---|
| `APPWRITE_REGISTRY=/nonexistent` | exit **1**, before any conda or pip activity |
| clean `.env` (secret only) / absent `.env` | pass |
| the real `.env` | conflicts, naming all 12 |
| ruff | clean |
| committed-state suite | 7243 passed, 1 failed — **#297 only**, pre-existing |

7 tests pin: position-before-conda, both fatal paths, the conflict failure, the secret export, no *live* `set -a`, and the #293 correction surviving a rewrite.

> One of those tests initially failed by matching `set -a` inside the **comment explaining why not to use it** — C-57, committed by the author who has cited C-57 four times this week. Fixed to check use rather than mention.

**Pre-existing, untouched:** `tools/audit/shell_health.sh` reports FAIL by matching its own message strings — same on `development`.

Closes #308. Leaves #309 open for the extraction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)