### PR TITLE
feat: bootstrap.sh + one writer for the Appwrite environment (#309, #311)

### DIFF
--- a/.github/workflows/bootstrap.yml
+++ b/.github/workflows/bootstrap.yml
@@ -113,14 +113,22 @@ jobs:
           echo "failed correctly without hanging"
 
       - name: The secret must never reach the log
-        if: always()
+        env:
+          APPWRITE_REGISTRY: ${{ github.workspace }}/fixture/coordinate_registry.toml
         run: |
-          # Belt and braces: the fixture secret is fake, but a job that would print a real
-          # one is a job that will, the first time someone runs it with real credentials.
-          if grep -rq "FAKE-CI-SECRET-NOT-A-REAL-CREDENTIAL" <<< "$(./bootstrap.sh 2>&1 || true)"; then
+          set -uo pipefail
+          # RESTORE the secret first. The previous step deletes .env, and without this the
+          # run would exit at the stdin check having never handled a secret at all — the
+          # grep below would then pass because the string was never in scope, not because
+          # redaction works. A check that cannot fail is worse than no check.
+          echo 'APPWRITE_DATASTORE_API_KEY=FAKE-CI-SECRET-NOT-A-REAL-CREDENTIAL' > .env
+          out="$(./bootstrap.sh 2>&1)"; status=$?
+          [ "$status" -eq 0 ] || {
+            echo "$out"
+            echo "::error::this step must exercise the secret-present path; bootstrap failed instead"
+            exit 1; }
+          if grep -q "FAKE-CI-SECRET-NOT-A-REAL-CREDENTIAL" <<< "$out"; then
             echo "::error::bootstrap.sh rendered the secret value — it must report presence only"
             exit 1
           fi
-          echo "secret value never rendered"
-        env:
-          APPWRITE_REGISTRY: ${{ github.workspace }}/fixture/coordinate_registry.toml
+          echo "secret handled and never rendered"

--- a/.github/workflows/bootstrap.yml
+++ b/.github/workflows/bootstrap.yml
@@ -1,0 +1,126 @@
+name: Bootstrap
+
+# `./bootstrap.sh` runs in CI against a fixture registry and a fake secret (#311).
+#
+# Why this job exists, and it is the point rather than a nicety. Prose describing setup
+# rots silently: nothing fails when it stops being true, and the person who discovers that
+# is the one least equipped to fix it — a new starter, on day one. A setup path verified
+# once, on one laptop, rots exactly the same way.
+#
+# This job is the only thing standing between "the setup script works" and "the setup
+# script worked in July". It uses a FIXTURE registry and a FAKE secret, so it needs no
+# credentials and no network, which is what lets it run on every push instead of never.
+
+on:
+  push:
+    branches: [main, development]
+  pull_request:
+    branches: [main, development]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  bootstrap:
+    name: bootstrap.sh against a fixture
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'   # tomllib; bootstrap.sh checks this itself and says so
+
+      - name: Build a fixture registry and a fake secret
+        run: |
+          set -euo pipefail
+          mkdir -p fixture
+          cat > fixture/coordinate_registry.toml <<'TOML'
+          [connection.APPWRITE_ENDPOINT]
+          class = "connection"
+          value = "https://fixture.invalid/v1"
+
+          [connection.APPWRITE_DATASTORE_PROJECT_ID]
+          class = "connection"
+          value = "fixture-project"
+
+          [target.APPWRITE_UNFAO_BUCKET_ID]
+          class = "target"
+          value = "unfao_bucket"
+
+          [target.APPWRITE_CRAFD_BUCKET_ID]
+          class = "target"
+          status = "planned — a reserved name with no value, as the real registry carries"
+          TOML
+          # The fake secret. Never a real one: this repo is public and so are its logs.
+          echo 'APPWRITE_DATASTORE_API_KEY=FAKE-CI-SECRET-NOT-A-REAL-CREDENTIAL' > .env
+
+      - name: Run bootstrap.sh — no arguments
+        env:
+          APPWRITE_REGISTRY: ${{ github.workspace }}/fixture/coordinate_registry.toml
+        run: ./bootstrap.sh
+
+      - name: Run it again — idempotence is what makes it testable
+        env:
+          APPWRITE_REGISTRY: ${{ github.workspace }}/fixture/coordinate_registry.toml
+        run: |
+          set -euo pipefail
+          before="$(sha256sum .env)"
+          ./bootstrap.sh
+          after="$(sha256sum .env)"
+          [ "$before" = "$after" ] || {
+            echo "::error::bootstrap.sh modified .env on a re-run — it must be idempotent"; exit 1; }
+          echo "second run left .env byte-identical"
+
+      - name: A missing registry must fail, and name the cause
+        env:
+          APPWRITE_REGISTRY: /nonexistent/coordinate_registry.toml
+        run: |
+          set -uo pipefail
+          out="$(./bootstrap.sh 2>&1)"; status=$?
+          echo "$out"
+          [ "$status" -ne 0 ] || { echo "::error::a missing registry must be fatal (#308)"; exit 1; }
+          echo "$out" | grep -q "APPWRITE_REGISTRY=" || {
+            echo "::error::the failure must name the override variable"; exit 1; }
+          echo "failed correctly, naming the cause"
+
+      - name: A .env declaring a registry-owned coordinate must fail
+        env:
+          APPWRITE_REGISTRY: ${{ github.workspace }}/fixture/coordinate_registry.toml
+        run: |
+          set -uo pipefail
+          echo 'APPWRITE_ENDPOINT=https://wrong.invalid' >> .env
+          out="$(./bootstrap.sh 2>&1)"; status=$?
+          echo "$out"
+          [ "$status" -ne 0 ] || { echo "::error::two writers to one name must be fatal (#309)"; exit 1; }
+          echo "$out" | grep -q "APPWRITE_ENDPOINT" || {
+            echo "::error::the failure must name the conflicting variable"; exit 1; }
+          echo "failed correctly, naming the variable"
+
+      - name: A missing secret must fail rather than hang
+        env:
+          APPWRITE_REGISTRY: ${{ github.workspace }}/fixture/coordinate_registry.toml
+        run: |
+          set -uo pipefail
+          rm -f .env
+          # stdin is not a terminal here, which is the case that would hang if bootstrap
+          # prompted unconditionally. A hung CI job is a worse failure than a red one.
+          out="$(timeout 30 ./bootstrap.sh < /dev/null 2>&1)"; status=$?
+          echo "$out"
+          [ "$status" -ne 124 ] || { echo "::error::bootstrap.sh HUNG waiting for input"; exit 1; }
+          [ "$status" -ne 0 ]   || { echo "::error::a missing secret must be fatal"; exit 1; }
+          echo "failed correctly without hanging"
+
+      - name: The secret must never reach the log
+        if: always()
+        run: |
+          # Belt and braces: the fixture secret is fake, but a job that would print a real
+          # one is a job that will, the first time someone runs it with real credentials.
+          if grep -rq "FAKE-CI-SECRET-NOT-A-REAL-CREDENTIAL" <<< "$(./bootstrap.sh 2>&1 || true)"; then
+            echo "::error::bootstrap.sh rendered the secret value — it must report presence only"
+            exit 1
+          fi
+          echo "secret value never rendered"
+        env:
+          APPWRITE_REGISTRY: ${{ github.workspace }}/fixture/coordinate_registry.toml

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -1,0 +1,130 @@
+#!/usr/bin/env bash
+# bootstrap.sh — set this platform up on a machine that has never run it (#311).
+#
+#     ./bootstrap.sh
+#
+# No arguments. No companion document. If you needed either, this script has failed at
+# its actual job and the structure underneath is still wrong.
+#
+# WHY A SCRIPT AND NOT A PAGE. Prose describing setup rots silently: nothing fails when it
+# stops being true, and whoever discovers that is the person least equipped to fix it.
+# This platform's own entry point currently points at an empty link where the technical
+# guide should be. A script either runs or it does not.
+#
+# WHAT IT ASKS YOU FOR: one secret, and zero coordinates. Coordinates come from the
+# registry (`tools/credentials/platform_env.sh`, #309); asking a human to retype an address that is
+# already declared somewhere is how the two copies drift.
+#
+# IT DOES NOT: create conda environments or install packages. Each `run.sh` still owns its
+# own environment, and pretending otherwise here would mean this script quietly deciding
+# which of ~130 environments you wanted.
+
+set -uo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+DOTENV="$REPO_ROOT/.env"
+SECRET_NAME="APPWRITE_DATASTORE_API_KEY"
+
+_step()  { printf '\n\033[1m── %s\033[0m\n' "$1"; }
+_ok()    { printf '   ok    %s\n' "$1"; }
+_info()  { printf '   ....  %s\n' "$1"; }
+_fail()  { printf '   FAIL  %s\n' "$1" >&2; }
+
+# ── 1. one-time machine setup ─────────────────────────────────────────────────────────
+# Moved here from the ~130 per-run scripts (#311/S7). Appending to a login profile is
+# one-time setup; doing it on every model run meant ~130 copies of the same three lines,
+# each re-checking a file they had already fixed.
+_step "machine setup"
+if [[ "$OSTYPE" == "darwin"* ]]; then
+  _added=0
+  for _line in \
+    'export LDFLAGS="-L/opt/homebrew/opt/libomp/lib"' \
+    'export CPPFLAGS="-I/opt/homebrew/opt/libomp/include"' \
+    'export DYLD_LIBRARY_PATH="/opt/homebrew/opt/libomp/lib:$DYLD_LIBRARY_PATH"'
+  do
+    if ! grep -qF "$_line" ~/.zshrc 2>/dev/null; then
+      echo "$_line" >> ~/.zshrc; _added=$((_added + 1))
+    fi
+  done
+  if [ "$_added" -gt 0 ]; then _ok "macOS libomp flags added to ~/.zshrc ($_added new)"
+  else _ok "macOS libomp flags already present in ~/.zshrc"; fi
+else
+  _ok "not macOS — no libomp setup needed"
+fi
+
+# ── 2. an interpreter that can read the registry ──────────────────────────────────────
+# tomllib is 3.11+. Checked before anything depends on it, so the failure names the cause
+# rather than surfacing as a traceback three steps later.
+_step "interpreter"
+if ! python -c 'import tomllib' >/dev/null 2>&1; then
+  _fail "the \`python\` on your PATH cannot import tomllib (needs 3.11+)."
+  printf '         found: %s\n' "$(python -V 2>&1)" >&2
+  printf '         Activate an environment with Python 3.11+ and re-run. Every run.sh\n' >&2
+  printf '         builds its own; `conda activate` any of them, or use the base 3.11.\n' >&2
+  exit 1
+fi
+_ok "$(python -V 2>&1) can read the registry"
+
+# ── 3. coordinates — from the registry, never from you ────────────────────────────────
+_step "coordinates"
+# shellcheck source=tools/credentials/platform_env.sh
+. "$REPO_ROOT/tools/credentials/platform_env.sh"
+
+platform_env_require_registry || exit 1
+_ok "registry found: $(platform_env_registry_path)"
+
+platform_env_assert_no_env_conflicts || exit 1
+_ok ".env declares no coordinate the registry owns"
+
+platform_env_export_coordinates || exit 1
+_ok "$(platform_env_coordinates | wc -l) coordinates exported from the registry"
+
+# ── 4. the one secret ─────────────────────────────────────────────────────────────────
+# SAFETY RULES, deliberately narrow because this file holds a live credential:
+#   * never read, print or log the existing value — presence only
+#   * never rewrite .env; APPEND only, and only when the key is absent
+#   * back up before touching it at all
+#   * `read -rs` so the value is never echoed to the terminal or a CI log
+_step "secret"
+platform_env_export_secret
+
+if [ -n "${!SECRET_NAME:-}" ]; then
+  _ok "$SECRET_NAME already present (${#APPWRITE_DATASTORE_API_KEY} characters) — not changed"
+elif [ ! -t 0 ]; then
+  # Non-interactive (CI, a pipe). Prompting would hang forever; say so instead.
+  _fail "$SECRET_NAME is not set and stdin is not a terminal, so it cannot be prompted for."
+  printf '         Set it in the environment, or run this script interactively.\n' >&2
+  exit 1
+else
+  _info "$SECRET_NAME is not set. It is the ONLY value you need to supply."
+  _info "Get it from the Appwrite console; it will not be echoed."
+  printf '   %s: ' "$SECRET_NAME"
+  read -rs _secret; echo
+  if [ -z "$_secret" ]; then
+    _fail "nothing entered — $SECRET_NAME is required."
+    exit 1
+  fi
+  if [ -f "$DOTENV" ]; then
+    cp -p "$DOTENV" "$DOTENV.bak-$(date +%Y%m%d%H%M%S)"
+    _info "backed up existing .env before appending"
+  fi
+  printf '%s=%s\n' "$SECRET_NAME" "$_secret" >> "$DOTENV"
+  unset _secret
+  chmod 600 "$DOTENV"
+  _ok "$SECRET_NAME appended to .env (mode 600); no existing line was modified"
+  platform_env_export_secret
+fi
+
+# ── 5. validate — the whole point ─────────────────────────────────────────────────────
+_step "validation"
+if ! platform_env_validate; then
+  _fail "the environment is incomplete. Nothing above fixed it; see the names listed."
+  exit 1
+fi
+_ok "every required variable resolves"
+
+_step "done"
+printf '   This machine can now reach the Appwrite seam.\n'
+printf '   Coordinates come from the registry; the secret lives only in .env.\n'
+printf '   Next: run a model or postprocessor via its own run.sh, which builds its\n'
+printf '   own conda environment.\n\n'

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -123,7 +123,7 @@ else
   unset _secret
   chmod 600 "$DOTENV"
   _ok "$SECRET_NAME appended to .env (mode 600); no existing line was modified"
-  platform_env_export_secret
+  platform_env_export_secret || exit 1
 fi
 
 # ── 5. validate — the whole point ─────────────────────────────────────────────────────

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 # bootstrap.sh — set this platform up on a machine that has never run it (#311).
 #
+# Governed by ADR-018 (docs/ADRs/018_environment_single_writer.md).
+#
 #     ./bootstrap.sh
 #
 # No arguments. No companion document. If you needed either, this script has failed at
@@ -31,9 +33,10 @@ _info()  { printf '   ....  %s\n' "$1"; }
 _fail()  { printf '   FAIL  %s\n' "$1" >&2; }
 
 # ── 1. one-time machine setup ─────────────────────────────────────────────────────────
-# Moved here from the ~130 per-run scripts (#311/S7). Appending to a login profile is
-# one-time setup; doing it on every model run meant ~130 copies of the same three lines,
-# each re-checking a file they had already fixed.
+# One-time setup belongs in one-time setup (#311). NOTE: the ~130 per-run scripts still
+# carry their own copy of this block — removing it from them is #310's scope, which
+# touches 131 files. So this ADDS the canonical home; it has not yet replaced them, and
+# saying "moved" before that lands would be a claim the tree does not support.
 _step "machine setup"
 if [[ "$OSTYPE" == "darwin"* ]]; then
   _added=0
@@ -86,10 +89,18 @@ _ok "$(platform_env_coordinates | wc -l) coordinates exported from the registry"
 #   * back up before touching it at all
 #   * `read -rs` so the value is never echoed to the terminal or a CI log
 _step "secret"
-platform_env_export_secret
+# The NON-FATAL probe, deliberately. platform_env_export_secret is fatal when there is no
+# .env — correct for a run-time launcher, wrong here, because "there is no .env yet" is the
+# ordinary state of the machine this script exists to set up. Calling it here printed a
+# FATAL telling the user to run ./bootstrap.sh while they were running ./bootstrap.sh.
+if platform_env_secret_available; then
+  platform_env_export_secret || exit 1
+fi
 
 if [ -n "${!SECRET_NAME:-}" ]; then
-  _ok "$SECRET_NAME already present (${#APPWRITE_DATASTORE_API_KEY} characters) — not changed"
+  # Presence only. The character count was here and is not "presence" — a length
+  # narrows the search space and would be logged in plaintext CI output.
+  _ok "$SECRET_NAME already present — not changed"
 elif [ ! -t 0 ]; then
   # Non-interactive (CI, a pipe). Prompting would hang forever; say so instead.
   _fail "$SECRET_NAME is not set and stdin is not a terminal, so it cannot be prompted for."
@@ -117,11 +128,14 @@ fi
 
 # ── 5. validate — the whole point ─────────────────────────────────────────────────────
 _step "validation"
-if ! platform_env_validate; then
+# platform_env_load is the single documented sequence; it re-runs the earlier steps
+# (idempotent) and ends in validation, which tests EXPORTED scope — the thing a child
+# process actually inherits — rather than shell scope (C-112).
+if ! platform_env_load; then
   _fail "the environment is incomplete. Nothing above fixed it; see the names listed."
   exit 1
 fi
-_ok "every required variable resolves"
+_ok "every required variable resolves and will reach a child process"
 
 _step "done"
 printf '   This machine can now reach the Appwrite seam.\n'

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -76,6 +76,13 @@ _step "coordinates"
 platform_env_require_registry || exit 1
 _ok "registry found: $(platform_env_registry_path)"
 
+# Prime the cache HERE, in this shell. The steps below each call
+# platform_env_coordinates through `$(...)`, and a cache written inside a command
+# substitution evaporates with the subshell — so without this, bootstrap spawns the
+# registry reader four times while platform_env_load alone spawns it once. The caching
+# win is not automatic; it belongs to whoever primes it.
+platform_env_prime_coordinate_cache || exit 1
+
 platform_env_assert_no_env_conflicts || exit 1
 _ok ".env declares no coordinate the registry owns"
 

--- a/docs/ADRs/018_environment_single_writer.md
+++ b/docs/ADRs/018_environment_single_writer.md
@@ -1,0 +1,106 @@
+# ADR-018: One writer for the Appwrite environment, and setup lives in `bootstrap.sh`
+
+**Status:** Accepted
+**Date:** 2026-08-02
+**Supersedes:** nothing. **Related:** ADR-002 (topology), ADR-003 (fail loud), ADR-017 (source/composition/delivery)
+
+---
+
+## Context
+
+Two conventions were established by code in #308/#309/#311 and existed only as shell
+comments and issue numbers. Both are the kind a contributor can violate without knowing
+they exist, which is what this repo's CLAUDE.md says an ADR is for.
+
+**The failure that produced them.** `postprocessors/un_fao/run.sh` had two blocks writing
+the same environment variable names: `source .env` and a loop exporting values read from
+the platform coordinate registry. The registry won because it ran second. Reversing the
+two blocks would have inverted the semantics silently, with no test failing. Separately,
+an unresolvable registry warned and continued, so the run died minutes later at the
+datastore boundary describing a symptom rather than a cause.
+
+**Why it kept recurring.** The reasoning lived in commit messages and closed issues. Three
+successive changes to that file each re-derived part of it, and two of them shipped a
+variant of the same defect (see Consequences).
+
+---
+
+## Decision
+
+### 1. Coordinates come from the registry. The secret comes from the operator.
+
+`tools/credentials/platform_env.sh` is the **only** writer of Appwrite coordinates and the
+Appwrite secret. Consumers source it and call `platform_env_load`.
+
+- Coordinates are read from the platform coordinate registry (homed in `views-appwrite`).
+- The secret (`APPWRITE_DATASTORE_API_KEY`) comes from the process environment or `.env`.
+- **A `.env` that declares a coordinate the registry owns is an error**, reported with the
+  variable and both sources named. It is not resolved by precedence: precedence is what
+  makes the outcome depend on line order.
+
+### 2. An unresolvable or unreadable registry is fatal, and fatal early.
+
+Checked before conda, before pip, before any work. Warning and continuing does not save a
+run; it relocates the failure to a place that cannot explain it.
+
+### 3. "Will the child see this?" is answered in exported scope only.
+
+`[ -n "$VAR" ]` cannot distinguish an exported variable from a shell-local one, and every
+consumer of this environment is a child process. Presence checks use
+`platform_env_is_exported`, which reads `export -p`.
+
+### 4. One-time machine setup belongs in `bootstrap.sh`.
+
+`./bootstrap.sh` — no arguments, no companion document — is the entry point for a machine
+that has never run this platform. It asks for **one secret and zero coordinates**. It is
+idempotent and it is exercised in CI against a fixture registry with a fake secret, because
+a setup path verified once on one laptop rots exactly like the prose it replaces.
+
+It does **not** create conda environments; each `run.sh` still owns its own.
+
+---
+
+## Consequences
+
+### Positive
+
+- The order of two blocks in a shell script can no longer change what the platform reads.
+- A machine-layout problem fails in the first second, naming the path and the override.
+- Setup is executable, so it cannot be subtly wrong in the way a document can.
+
+### Negative
+
+- An existing `.env` carrying coordinates must have them deleted before the launcher will
+  run. Provably a no-op — those values were never exported — but it is a manual step on
+  every machine that has one.
+- `bootstrap.sh` and each `run.sh` both source the shared file, so a change to the contract
+  touches a file that production launchers depend on.
+- The ~130 per-model `run.sh` scripts still carry their own copy of the macOS setup block.
+  `bootstrap.sh` adds the canonical home; removing the copies is tracked separately
+  (#310) because it touches 131 protected files.
+
+### The rule this ADR exists to stop being rediscovered
+
+**Twice in four days, a presence check tested shell scope while the consumer needed
+exported scope**, and both times the code reported success while the child process
+received nothing:
+
+1. `_platform001_coordinate_state()` announced *"Coordinates ARE present in the environment
+   (exported outside this script)"* about values `source .env` had set and nothing had
+   exported.
+2. `platform_env_export_secret`'s first draft skipped its own `export` because the guard saw
+   the value that the launcher's earlier `source .env` had left in shell scope.
+
+Both were written by an author who had just read the incident report for the first one.
+That is the argument for this being an ADR rather than a comment. Tracked as **C-112**.
+
+---
+
+## References
+
+- `tools/credentials/platform_env.sh` — the implementation
+- `bootstrap.sh` — the entry point
+- `.github/workflows/bootstrap.yml` — the CI proof
+- `tests/test_platform_env.py` — behavioural tests of the contract
+- Register: **C-112** (shell-vs-exported scope), C-47/C-48 (the originating findings)
+- Issues: #308, #309, #311; the seam contract in `views-appwrite`

--- a/postprocessors/un_fao/run.sh
+++ b/postprocessors/un_fao/run.sh
@@ -125,10 +125,11 @@ fi
 # nothing exports, so the python child never saw them. It was written to avoid asserting an
 # unverified environment fact and asserted one by checking the wrong scope. If a
 # coordinate-state reporter ever returns, it must read the EXPORTED environment.
-platform_env_assert_no_env_conflicts || exit 1
-platform_env_export_secret          || exit 1
-platform_env_export_coordinates     || exit 1
-platform_env_validate               || exit 1
+# One call, one order (C-112 review). Calling the pieces here and a different order in
+# bootstrap.sh is how the two drifted; platform_env_load is the single sequence and it
+# ends in validation, which tests EXPORTED scope rather than shell scope.
+# require_registry runs again inside it — idempotent, and cheap next to conda.
+platform_env_load || exit 1
 echo "Appwrite environment loaded: coordinates from the registry, secret from the operator slot."
 
 echo "Running $script_path/main.py "

--- a/postprocessors/un_fao/run.sh
+++ b/postprocessors/un_fao/run.sh
@@ -17,38 +17,30 @@ script_path=$(dirname "$(realpath $0)")
 project_path="$( cd "$script_path/../../" >/dev/null 2>&1 && pwd )"
 env_path="$project_path/envs/views-postprocessing"
 
-# ── #308: the registry must resolve, and its absence is FATAL — checked FIRST ─────────
-# The default below is a relative sibling hop: it assumes views-appwrite is checked out
-# next to views-models at exactly this path. On a different layout, in CI, or in a
-# container, it is simply absent.
-#
-# This check is deliberately here — before conda, before pip, before anything — because
-# the cost of continuing is not a missing warning, it is a failure that lands minutes
-# later at the datastore boundary, describing a symptom rather than the cause, in front
-# of whoever is least equipped to trace it back to a checkout layout.
-#
-# Existence only at this point: parsing needs tomllib, which needs the 3.11 interpreter
-# conda has not activated yet. The parse is checked below, and is equally fatal.
-APPWRITE_REGISTRY="${APPWRITE_REGISTRY:-$project_path/../views-appwrite/docs/ADRs/platform/coordinate_registry.toml}"
-if [ ! -f "$APPWRITE_REGISTRY" ]; then
-  echo "FATAL: the Appwrite coordinate registry does not exist." >&2
-  echo "  looked for: $APPWRITE_REGISTRY" >&2
-  echo "  override with: APPWRITE_REGISTRY=/path/to/coordinate_registry.toml" >&2
-  echo "" >&2
-  echo "  The default is a relative hop to a sibling checkout of views-appwrite. If this" >&2
-  echo "  machine lays the repositories out differently, set APPWRITE_REGISTRY explicitly." >&2
-  echo "  This is fatal by design (#308): the registry is the ONLY source of Appwrite" >&2
-  echo "  coordinates. Continuing would fail later, somewhere less informative." >&2
-  exit 1
-fi
+# ── the environment contract lives in ONE place (#309) ───────────────────────────────
+# tools/credentials/platform_env.sh is the only writer of Appwrite coordinates and the secret. This
+# script keeps what is genuinely its own — macOS notes, conda lifecycle, pip install — and
+# borrows nothing else. bootstrap.sh sources the same file, which is what makes the shared
+# file worth having: two consumers, not one.
+# shellcheck source=../../tools/credentials/platform_env.sh
+. "$project_path/tools/credentials/platform_env.sh"
 
-# Sourcing sets SHELL variables; only what is `export`ed reaches `python main.py` (a child process).
-# Do NOT replace this with `set -a` — .env carries unquoted values containing spaces (the *_NAME
-# coordinates), which `set -a` would export truncated at the first space. Export by name instead. (#293)
+# Registry existence FIRST — before conda, before pip. Continuing without it does not cost
+# a warning, it moves the failure to the datastore boundary minutes later, describing a
+# symptom rather than a cause, in front of whoever is least equipped to trace it back to a
+# checkout layout (#308). Parsing needs 3.11, so that half is checked after conda below.
+platform_env_require_registry || exit 1
+
+# GITHUB_TOKEN only, and only because the pip install below needs it before anything else
+# runs. The Appwrite secret is NOT exported here: `platform_env_export_secret` owns it, and
+# doing it in both places would reinstate the second writer #309 exists to remove.
+#
+# Sourcing sets SHELL variables; only what is `export`ed reaches a child process. Do NOT
+# replace this with `set -a` — .env carries unquoted values containing spaces (the *_NAME
+# coordinates), which `set -a` would export truncated at the first space (#293).
 if [ -f "$project_path/.env" ]; then
   source "$project_path/.env"
   export GITHUB_TOKEN
-  export APPWRITE_DATASTORE_API_KEY   # the one secret; the operator slot. Coordinates come from the registry below.
 fi
 
 eval "$(conda shell.bash hook)"
@@ -119,79 +111,25 @@ elif [ "$_wire_declared" = "unknown" ]; then
   echo "  Not fatal — this check only ever ADDS a failure mode, it must not invent one." >&2
 fi
 
-# ── þing-01 / PLATFORM-001 (#287): coordinates come from the OWNED registry, not a copied .env ──
-# The non-secret Appwrite coordinates (endpoint, project/bucket/collection/db ids & names) are
-# READ from the single canonical coordinate registry — never copied into this repo. The one SECRET
-# (APPWRITE_DATASTORE_API_KEY) stays an operator slot — exported by name above; see #293 for why a
-# bare `source` was never a carrier. This is a DECLARATION layered on run.sh, not a rewrite. The hard
-# cutover (registry-only coordinates, secret from a real store, .env retired) is sequenced with #280
-# and pairs with views-postprocessing's kill of its runtime load_dotenv (their P1). Uses the
-# just-activated env's python because tomllib needs 3.11+. Override the path with APPWRITE_REGISTRY.
+# ── the environment, from the one writer (#287 -> #309) ──────────────────────────────
+# The original þing-01 block lived here and inlined the registry read. Its content now
+# lives in tools/credentials/platform_env.sh, which bootstrap.sh sources too; what remains
+# here is the call sequence. The #293 correction it carried is preserved in that file --
+# a removal must name what it was carrying.
+# Coordinates and the secret, from tools/credentials/platform_env.sh — the one writer (#309).
+# Every failure below is fatal and names itself; none of it is recoverable here.
 #
-# CORRECTION (#293): this comment previously claimed "the .env sourced above still works as the
-# operator slot + fallback". It did not — `source` without `export` never reached the python child,
-# so between views-postprocessing's load_dotenv removal (2026-07-28) and this change there was no
-# carrier for the secret at all. The claim was wrong when written.
-# The path was resolved and its existence made fatal at the top of this script (#308).
-#
-# REMOVED HERE (#308/#309): `_platform001_coordinate_state()`, added 2026-07-31, which on a
+# REMOVED in #314 and kept out deliberately: `_platform001_coordinate_state()`, which on a
 # missing registry announced "Coordinates ARE present in the environment (exported outside
-# this script) — continuing." **That claim was false.** It tested SHELL variables, which
-# `source .env` above does set — but nothing exports them, so the python child never saw
-# them. Verified: after `source .env; export GITHUB_TOKEN APPWRITE_DATASTORE_API_KEY`, the
-# shell has APPWRITE_ENDPOINT and `python -c 'os.environ.get("APPWRITE_ENDPOINT")'` returns
-# None. It was written to avoid asserting an unverified environment fact, and asserted one
-# by checking the wrong scope. It also settles the design question it was hedging: there was
-# never a second working source for the child, so registry-absent IS coordinates-absent, and
-# fatal costs nothing.
-
-_reg_err="$(mktemp "${TMPDIR:-/tmp}/registry_to_env.XXXXXX")"
-trap 'rm -f "$_reg_err"' EXIT
-if ! _coords="$(python "$project_path/tools/credentials/registry_to_env.py" "$APPWRITE_REGISTRY" 2>"$_reg_err")"; then
-  echo "FATAL: the coordinate registry exists but could not be read." >&2
-  echo "  registry: $APPWRITE_REGISTRY" >&2
-  echo "  python:   $(python -V 2>&1)  (registry_to_env.py needs 3.11+ for tomllib)" >&2
-  sed 's/^/  /' "$_reg_err" >&2
-  echo "  Fatal by design (#308): the registry is the ONLY source of coordinates." >&2
-  rm -f "$_reg_err"; exit 1
-fi
-rm -f "$_reg_err"; trap - EXIT
-
-# ── #309: one writer. `.env` must not also declare a coordinate the registry owns ────
-# Two writers to the same names is a data race whose winner is decided by line order:
-# reverse these blocks and the semantics invert silently, with no test failing. Per the
-# seam contract that is an error, not a precedence question — so it is reported, not
-# resolved.
-#
-# Deleting these keys from `.env` is safe: they were NEVER exported (see the note above),
-# so nothing downstream has ever received them from that file. Keep the SECRET there.
-_owned="$(echo "$_coords" | cut -d= -f1)"
-_conflicts=""
-if [ -f "$project_path/.env" ]; then
-  for _name in $_owned; do
-    if grep -qE "^[[:space:]]*(export[[:space:]]+)?${_name}=" "$project_path/.env"; then
-      _conflicts="$_conflicts $_name"
-    fi
-  done
-fi
-if [ -n "$_conflicts" ]; then
-  echo "FATAL: .env declares coordinates that the registry owns (#309)." >&2
-  echo "  file:     $project_path/.env" >&2
-  echo "  registry: $APPWRITE_REGISTRY" >&2
-  echo "  both declare:$_conflicts" >&2
-  echo "" >&2
-  echo "  Two writers to one name is a data race decided by line order, so this is an" >&2
-  echo "  error rather than a precedence question. Delete these lines from .env — they" >&2
-  echo "  were never exported, so nothing has ever received them from there. Keep" >&2
-  echo "  APPWRITE_DATASTORE_API_KEY: the secret is the one value .env still carries." >&2
-  exit 1
-fi
-
-while IFS= read -r _cl; do
-  [ -z "$_cl" ] && continue
-  export "${_cl%%=*}=${_cl#*=}"
-done <<< "$_coords"
-echo "Appwrite coordinates read from the registry (the only source); secret stays the operator slot."
+# this script)". That was FALSE — it tested SHELL variables, which `source .env` sets and
+# nothing exports, so the python child never saw them. It was written to avoid asserting an
+# unverified environment fact and asserted one by checking the wrong scope. If a
+# coordinate-state reporter ever returns, it must read the EXPORTED environment.
+platform_env_assert_no_env_conflicts || exit 1
+platform_env_export_secret          || exit 1
+platform_env_export_coordinates     || exit 1
+platform_env_validate               || exit 1
+echo "Appwrite environment loaded: coordinates from the registry, secret from the operator slot."
 
 echo "Running $script_path/main.py "
 python $script_path/main.py "$@"

--- a/reports/technical_risk_register.md
+++ b/reports/technical_risk_register.md
@@ -2,9 +2,9 @@
 
 **Last updated:** 2026-07-31  
 **Governing ADR:** [ADR-010](../docs/ADRs/010_technical_risk_register.md)  
-**Total entries:** 115 (111 concerns + 4 disagreements)  
-**Concerns:** Open 45 | Mitigated 18 | Resolved 39 | Accepted 3 | Partially Resolved 1 | Subsumed 1 | Merged 4  
-**Concerns by tier:** T1 3 | T2 32 | T3 48 | T4 24 (4 merge stubs carry no tier)  
+**Total entries:** 116 (112 concerns + 4 disagreements)  
+**Concerns:** Open 46 | Mitigated 18 | Resolved 39 | Accepted 3 | Partially Resolved 1 | Subsumed 1 | Merged 4  
+**Concerns by tier:** T1 3 | T2 33 | T3 48 | T4 24 (4 merge stubs carry no tier)  
 **Disagreements:** Open 2 | Resolved 1 | Subsumed 1  
 **Last curated:** 2026-07-31 (`review-rr strategic`, first full pass — tier recalibration, 4 merges, 6 causal clusters identified)
 
@@ -1405,6 +1405,19 @@
 | **Status** | Open |
 | **Location** | views-faoapi `src/views_faoapi/managers/dataset_service.py:621-720` `_load_wire_run` (lazy on-request ingest; refuse → fall back to last-good) — by design, and correct as a *availability* policy; the gap is that the degradation is invisible upstream. views-models side: `tools/liveness/unfao_delivery.py` observes the FAO bucket, not the served response; there is no surface for "what is the API serving right now, and is it the run we shipped?". |
 | **Notes** | Tier 2 rationale: structural fragility across a repo boundary with a realized trigger and a stakeholder-visible consequence — UN consumers received a month-old forecast presented as current, with no error anywhere in the producer's view. Serve-last-good is the *right* availability choice; the defect is that it is a **silent** downgrade, so "delivered" and "served" are two different truths with nothing comparing them. Compounding observability defects seen the same session: the API's `/version` endpoint lagged the deployed git tag by one release (reported `1.3.4` on `deployed_tag v1.3.5`), so "which build is live?" could not be answered from the API itself; and `/provenance/forecast`'s top-level fields carried the *previous* run's name/filename/`run_id` (views-faoapi#290, fixed v1.3.5) so even a correct serve looked wrong. Exits: (a) a **serving-truth liveness surface** in `tools/liveness` that reads the live API's provenance and compares `run_id` against the newest manifest in `unfao_bucket` — this is the check that would have caught run-0 in minutes and is squarely a views-models deliverable; (b) upstream, a degraded/stale flag in the served response or an ingest-failure signal the producer can poll. Cross-refs: **C-102** (the detection half — `unfao_delivery` reads `DELIVERING` while the API serves nothing; this entry is the *root* it fails to see), C-97 (delivery identity), C-99 (no heartbeat), C-109 (the ingest bug this fallback concealed). |
+
+---
+
+### C-112 — Presence checks read SHELL scope while consumers need EXPORTED scope; the same blind spot has now shipped twice in four days
+
+| Field | Value |
+|---|---|
+| **Tier** | 2 |
+| **Trigger** | Any shell code that decides "is this credential/coordinate available?" with `[ -n "$VAR" ]` or `[ -n "${!NAME}" ]`, in a script that has previously `source`d a `.env`. Sourcing sets the variable in **shell** scope; the check passes; the child process — which is what actually needs it — receives nothing. |
+| **Source** | code-review max on PR #315 (2026-08-02), reproduced directly; earlier instance found during þing-02 (`orð_09 §2H`) |
+| **Status** | Open |
+| **Location** | Instance 1 (2026-07-31, fixed in #314): `postprocessors/un_fao/run.sh` `_platform001_coordinate_state()` — announced *"Coordinates ARE present in the environment (exported outside this script)"* on the strength of an unexported shell variable. Instance 2 (2026-08-02, caught pre-merge in #315): `tools/credentials/platform_env.sh` `platform_env_export_secret()` guard `[ -n "${!PLATFORM_ENV_SECRET_NAME:-}" ]` — returns early because `run.sh` sourced `.env` for `GITHUB_TOKEN` two dozen lines above, so the `export` is never reached; `platform_env_validate()` shares the blind spot and reports the environment complete. |
+| **Notes** | **The recurrence is the finding, not either instance.** Both were written by an author who had just read #293 — the incident whose entire content is *"`source` without `export` does not reach the child"* — and both reproduced it anyway, because bash makes the two scopes indistinguishable at the point of test. `[ -n "$VAR" ]` cannot tell them apart; only `[ -n "${VAR+x}" ]` combined with an `export -p` lookup, or a probe of an actual child process, can. **Reproduced on the PR branch:** with `.env` sourced first, `platform_env_export_secret` returns 0, `platform_env_validate` passes, and `python -c 'os.environ.get(...)'` returns `None` — a run that reports a complete environment and hands the child nothing. Instance 2 was additionally *protected by a test*: `test_the_launcher_does_not_export_the_secret_itself` asserts the launcher must not export the secret directly, which is correct as a one-writer rule and, combined with the defective guard, enforced the bug. **Exit:** a single sanctioned way to answer "will the child see this?" — probe the exported environment (`env` / a real child), never the shell's. Everything else in this class is a rediscovery. Tier 2: silent, produces a successful-looking run that delivers nothing, and the demonstrated recurrence rate is twice in four days. Cross-refs: **C-111** (silent serving degradation — same family: success reported, nothing delivered), C-94/C-95 (silent-when-unenforced), C-57 (the sibling class where a *regex* cannot distinguish a comment from code, which also recurred twice this week). Member of **Cluster A** (declared-but-unenforced). **A sibling shape, found in the same review and fixed rather than registered** (one instance, now pinned by a test): a guard written for the **steady state** was reused during **setup**, where the condition it treats as fatal is the normal starting state — `bootstrap.sh` called the fatal `platform_env_export_secret` before prompting, so a first-ever machine's very first output was *"FATAL: … does not exist. Run ./bootstrap.sh"* addressed to the person running `./bootstrap.sh`. Not the same defect as this entry, but the same question badly posed: **a check must be asked in the context it will answer for.** |
 
 ---
 

--- a/tests/test_platform_env.py
+++ b/tests/test_platform_env.py
@@ -1,0 +1,171 @@
+"""`tools/credentials/platform_env.sh` — the one writer of the Appwrite environment (#308, #309).
+
+These are **behavioural** tests: each one sources the real shell file against a fixture
+registry and asserts on exit codes and stderr. The tests they replace grepped `run.sh` for
+strings, which was the best available when the logic was inline and unreachable — a string
+test cannot tell "the code does this" from "a comment mentions this", which is C-57 and
+which those tests actually tripped over once.
+
+Two rules under test:
+
+* **#308** — an unresolvable or unreadable registry is fatal. Warning and continuing does
+  not save the run; it moves the failure to the datastore boundary minutes later, where it
+  describes a symptom instead of a cause.
+* **#309** — coordinates come from the registry and the secret from the operator. `.env`
+  declaring a coordinate the registry owns is a data race decided by line order, so it is
+  reported as an error rather than resolved by precedence.
+"""
+import os
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+pytestmark = [pytest.mark.green]
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+PLATFORM_ENV = REPO_ROOT / "tools" / "credentials" / "platform_env.sh"
+
+pytest.importorskip("tomllib", reason="registry_to_env needs Python 3.11+ for tomllib")
+
+REGISTRY = """
+[connection.APPWRITE_ENDPOINT]
+class = "connection"
+value = "https://fixture.test/v1"
+
+[target.APPWRITE_UNFAO_BUCKET_ID]
+class = "target"
+value = "unfao_bucket"
+"""
+
+
+@pytest.fixture
+def repo(tmp_path):
+    """A minimal fake checkout carrying only what platform_env.sh needs."""
+    (tmp_path / "tools" / "credentials").mkdir(parents=True)
+    shutil.copy(PLATFORM_ENV, tmp_path / "tools" / "credentials" / "platform_env.sh")
+    shutil.copy(
+        REPO_ROOT / "tools" / "credentials" / "registry_to_env.py",
+        tmp_path / "tools" / "credentials" / "registry_to_env.py",
+    )
+    (tmp_path / "registry.toml").write_text(REGISTRY, encoding="utf-8")
+    return tmp_path
+
+
+def call(repo, snippet, registry=None, env_extra=None):
+    """Source platform_env.sh in the fake repo and run `snippet`."""
+    env = dict(os.environ)
+    # The interpreter running these tests can read the registry; make it the one on PATH.
+    env["PATH"] = f"{Path(sys.executable).parent}{os.pathsep}{env['PATH']}"
+    env["APPWRITE_REGISTRY"] = str(registry if registry is not None else repo / "registry.toml")
+    for key in ("APPWRITE_ENDPOINT", "APPWRITE_UNFAO_BUCKET_ID", "APPWRITE_DATASTORE_API_KEY"):
+        env.pop(key, None)
+    env.update(env_extra or {})
+    return subprocess.run(
+        ["bash", "-c", f'. "{repo}/tools/credentials/platform_env.sh"\n{snippet}'],
+        capture_output=True, text=True, env=env, timeout=60,
+    )
+
+
+# ── #308: absence and unreadability are both fatal ────────────────────────────────────
+
+def test_missing_registry_is_fatal_and_names_the_path_and_the_override(repo):
+    result = call(repo, "platform_env_require_registry", registry="/nonexistent/registry.toml")
+    assert result.returncode == 1
+    assert "/nonexistent/registry.toml" in result.stderr, "must name the path it tried"
+    assert "APPWRITE_REGISTRY=" in result.stderr, (
+        "must name the override — the person hitting this has a different layout and "
+        "needs the escape hatch, not a diagnosis"
+    )
+
+
+def test_unreadable_registry_is_fatal(repo):
+    (repo / "broken.toml").write_text("this is not = valid = toml [[[", encoding="utf-8")
+    result = call(repo, "platform_env_coordinates", registry=repo / "broken.toml")
+    assert result.returncode == 1, "a registry that exists but will not parse is not a source"
+    assert "could not be read" in result.stderr
+
+
+def test_registry_declaring_no_coordinates_is_fatal(repo):
+    """Silence here would export nothing and let validation pass on an empty set."""
+    (repo / "empty.toml").write_text("[meta]\nnote = 'nothing here'\n", encoding="utf-8")
+    result = call(repo, "platform_env_coordinates", registry=repo / "empty.toml")
+    assert result.returncode == 1
+    assert "declared no coordinates" in result.stderr
+
+
+@pytest.mark.red
+def test_a_failed_read_does_not_report_success(repo):
+    """The bug this file shipped with, pinned so it cannot return.
+
+    The first draft captured the exit status inside `if ! cmd; then status=$?; fi`, where
+    `$?` is the status of the NEGATION — 0, because the negation succeeded. Every caller
+    then reported success while exporting nothing: the same shape as a write path that
+    logs "uploaded successfully" and uploads nothing.
+    """
+    result = call(
+        repo,
+        'platform_env_load; echo "LOAD=$?"\nplatform_env_validate; echo "VALIDATE=$?"',
+        registry="/nonexistent/registry.toml",
+    )
+    assert "LOAD=1" in result.stdout, "a failed load must not report success"
+    assert "VALIDATE=1" in result.stdout, "validation must not pass on an unloaded environment"
+
+
+# ── #309: one writer ──────────────────────────────────────────────────────────────────
+
+def test_env_declaring_a_registry_owned_coordinate_is_fatal(repo):
+    (repo / ".env").write_text(
+        "APPWRITE_DATASTORE_API_KEY=fake\nAPPWRITE_ENDPOINT=https://wrong.example\n",
+        encoding="utf-8",
+    )
+    result = call(repo, "platform_env_assert_no_env_conflicts")
+    assert result.returncode == 1
+    assert "APPWRITE_ENDPOINT" in result.stderr, "must name the variable"
+    assert str(repo / ".env") in result.stderr, "must name .env as one source"
+    assert "registry" in result.stderr.lower(), "must name the registry as the other"
+
+
+def test_env_carrying_only_the_secret_is_fine(repo):
+    (repo / ".env").write_text("APPWRITE_DATASTORE_API_KEY=fake\n", encoding="utf-8")
+    assert call(repo, "platform_env_assert_no_env_conflicts").returncode == 0
+
+
+def test_coordinates_are_exported_from_the_registry(repo):
+    (repo / ".env").write_text("APPWRITE_DATASTORE_API_KEY=fake\n", encoding="utf-8")
+    result = call(repo, 'platform_env_load && echo "E=$APPWRITE_ENDPOINT B=$APPWRITE_UNFAO_BUCKET_ID"')
+    assert result.returncode == 0, result.stderr
+    assert "E=https://fixture.test/v1 B=unfao_bucket" in result.stdout
+
+
+def test_validate_names_what_is_missing(repo):
+    """No `.env`, so the secret is absent — and validation must say which name."""
+    result = call(repo, "platform_env_load; platform_env_validate")
+    assert result.returncode == 1
+    assert "APPWRITE_DATASTORE_API_KEY" in result.stderr
+    assert "missing" in result.stderr.lower()
+
+
+def test_the_secret_value_is_never_rendered(repo):
+    """A check that prints a credential to prove it found one has published it."""
+    sentinel = "SENTINEL-SECRET-MUST-NOT-APPEAR"
+    (repo / ".env").write_text(f"APPWRITE_DATASTORE_API_KEY={sentinel}\n", encoding="utf-8")
+    result = call(repo, "platform_env_load && platform_env_validate")
+    assert result.returncode == 0, result.stderr
+    assert sentinel not in result.stdout and sentinel not in result.stderr
+
+
+# ── sourcing must be inert ────────────────────────────────────────────────────────────
+
+def test_sourcing_has_no_side_effects(repo):
+    """A library that mutates the environment on source cannot be reasoned about."""
+    result = call(repo, 'echo "N=$(env | wc -l)"')
+    before = subprocess.run(
+        ["bash", "-c", 'echo "N=$(env | wc -l)"'],
+        capture_output=True, text=True, env=dict(os.environ, APPWRITE_REGISTRY=str(repo / "registry.toml")),
+    )
+    assert result.stdout.strip() == before.stdout.strip(), (
+        "sourcing platform_env.sh changed the environment — it must only define functions"
+    )

--- a/tests/test_platform_env.py
+++ b/tests/test_platform_env.py
@@ -140,12 +140,19 @@ def test_coordinates_are_exported_from_the_registry(repo):
     assert "E=https://fixture.test/v1 B=unfao_bucket" in result.stdout
 
 
-def test_validate_names_what_is_missing(repo):
-    """No `.env`, so the secret is absent — and validation must say which name."""
-    result = call(repo, "platform_env_load; platform_env_validate")
-    assert result.returncode == 1
-    assert "APPWRITE_DATASTORE_API_KEY" in result.stderr
-    assert "missing" in result.stderr.lower()
+def test_an_absent_secret_is_fatal_and_names_the_variable(repo):
+    """No `.env`, so the secret is absent. The contract is that the NAME is reported.
+
+    Asserting on the word "missing" would pin the wording rather than the contract: after
+    the C-112 fix the gap is caught earlier, by `platform_env_export_secret`, whose message
+    is more specific ("is not set and <path> does not exist"). Naming the variable is what
+    a person needs; the phrasing is not the promise.
+    """
+    result = call(repo, "platform_env_load; echo STATUS=$?")
+    assert "STATUS=0" not in result.stdout, "an absent secret must be fatal"
+    assert "APPWRITE_DATASTORE_API_KEY" in result.stderr, (
+        "the failure must name the variable, not just report a count"
+    )
 
 
 def test_the_secret_value_is_never_rendered(repo):
@@ -160,12 +167,90 @@ def test_the_secret_value_is_never_rendered(repo):
 # ── sourcing must be inert ────────────────────────────────────────────────────────────
 
 def test_sourcing_has_no_side_effects(repo):
-    """A library that mutates the environment on source cannot be reasoned about."""
-    result = call(repo, 'echo "N=$(env | wc -l)"')
-    before = subprocess.run(
-        ["bash", "-c", 'echo "N=$(env | wc -l)"'],
-        capture_output=True, text=True, env=dict(os.environ, APPWRITE_REGISTRY=str(repo / "registry.toml")),
+    """A library that mutates the environment on source cannot be reasoned about.
+
+    Both halves are measured **inside one bash process**, so the comparison cannot be
+    perturbed by the ambient environment. The first version built the two sides through
+    different code paths — one via `call()` (which pops three Appwrite variables), one via
+    raw `os.environ` — and so failed spuriously whenever the developer's shell already had
+    those variables set, which is the normal state after sourcing the file by hand.
+    """
+    result = call(repo, f'''
+        before="$(env | sort)"
+        . "{repo}/tools/credentials/platform_env.sh"
+        after="$(env | sort)"
+        if [ "$before" = "$after" ]; then echo UNCHANGED; else
+          echo CHANGED; diff <(echo "$before") <(echo "$after") | head -20
+        fi
+    ''')
+    assert "UNCHANGED" in result.stdout, (
+        f"sourcing platform_env.sh changed the environment — it must only define "
+        f"functions.\n{result.stdout}\n{result.stderr}"
     )
-    assert result.stdout.strip() == before.stdout.strip(), (
-        "sourcing platform_env.sh changed the environment — it must only define functions"
+
+
+@pytest.mark.red
+def test_a_set_but_unexported_secret_is_promoted_not_skipped(repo):
+    """C-112, and the bug this PR shipped with before review caught it.
+
+    `un_fao/run.sh` sources `.env` early for GITHUB_TOKEN, which leaves the secret as a
+    SHELL variable. A guard that tests `[ -n "$VAR" ]` sees a value and skips the export,
+    so the child process receives nothing while every check reports success. Exported
+    scope is the only scope that answers "will the child see this?".
+    """
+    (repo / ".env").write_text("APPWRITE_DATASTORE_API_KEY=fake-secret\n", encoding="utf-8")
+    result = call(repo, f'''
+        . "{repo}/.env"                 # set, NOT exported — the run.sh sequence
+        platform_env_export_secret || echo "EXPORT_FAILED"
+        python -c 'import os; print("CHILD=" + ("yes" if os.environ.get("APPWRITE_DATASTORE_API_KEY") else "no"))'
+    ''')
+    assert "CHILD=yes" in result.stdout, (
+        f"a set-but-unexported secret was skipped rather than promoted, so the child got "
+        f"nothing — #293 reintroduced (C-112).\n{result.stdout}\n{result.stderr}"
+    )
+
+
+@pytest.mark.red
+def test_an_unsourceable_env_is_fatal_not_swallowed(repo):
+    """`|| true` on the source would report success with the secret unset."""
+    (repo / ".env").write_text('APPWRITE_DATASTORE_API_KEY="unterminated\n', encoding="utf-8")
+    result = call(repo, 'platform_env_export_secret; echo "STATUS=$?"')
+    assert "STATUS=0" not in result.stdout, (
+        f"a .env that fails to source reported success.\n{result.stdout}\n{result.stderr}"
+    )
+
+
+def test_the_probe_is_silent_and_non_fatal_when_there_is_no_env(repo):
+    """`bootstrap.sh` must be able to ask "is the secret there?" on a virgin machine.
+
+    The fatal `platform_env_export_secret` cannot answer it: with no `.env` it printed
+    "FATAL: ... does not exist. Run ./bootstrap.sh" — at the person running
+    ./bootstrap.sh. A setup script whose first output is a false FATAL and circular
+    advice has failed at the one job #311 gave it.
+    """
+    result = call(repo, 'platform_env_secret_available; echo "STATUS=$?"')
+    assert "STATUS=1" in result.stdout, "no .env means the secret is not available"
+    assert "FATAL" not in result.stderr, (
+        f"the probe must be silent — it is called before the machine is set up.\n"
+        f"{result.stderr}"
+    )
+    assert result.stderr.strip() == "", f"the probe printed: {result.stderr!r}"
+
+
+def test_the_probe_finds_a_secret_in_env_and_in_the_file(repo):
+    (repo / ".env").write_text("APPWRITE_DATASTORE_API_KEY=fake\n", encoding="utf-8")
+    assert "STATUS=0" in call(repo, 'platform_env_secret_available; echo "STATUS=$?"').stdout
+
+    (repo / ".env").write_text("APPWRITE_DATASTORE_API_KEY=\n", encoding="utf-8")
+    assert "STATUS=1" in call(repo, 'platform_env_secret_available; echo "STATUS=$?"').stdout, (
+        "a declared-but-empty secret is not an available secret"
+    )
+
+
+def test_load_validates_and_uses_the_documented_order(repo):
+    """`platform_env_load` claims to be the whole contract; it must include validation."""
+    (repo / ".env").write_text("SOMETHING_ELSE=1\n", encoding="utf-8")   # no secret
+    result = call(repo, 'platform_env_load; echo "STATUS=$?"')
+    assert "STATUS=0" not in result.stdout, (
+        "platform_env_load returned success with the secret missing — it must validate"
     )

--- a/tests/test_platform_env.py
+++ b/tests/test_platform_env.py
@@ -288,14 +288,30 @@ def test_the_probe_is_silent_and_non_fatal_when_there_is_no_env(repo):
     assert result.stderr.strip() == "", f"the probe printed: {result.stderr!r}"
 
 
-def test_the_probe_finds_a_secret_in_env_and_in_the_file(repo):
-    (repo / ".env").write_text("APPWRITE_DATASTORE_API_KEY=fake\n", encoding="utf-8")
-    assert "STATUS=0" in call(repo, 'platform_env_secret_available; echo "STATUS=$?"').stdout
-
-    (repo / ".env").write_text("APPWRITE_DATASTORE_API_KEY=\n", encoding="utf-8")
-    assert "STATUS=1" in call(repo, 'platform_env_secret_available; echo "STATUS=$?"').stdout, (
-        "a declared-but-empty secret is not an available secret"
-    )
+@pytest.mark.parametrize(
+    "line,available,why",
+    [
+        ("APPWRITE_DATASTORE_API_KEY=fake", True, "a plain value is available"),
+        ("export APPWRITE_DATASTORE_API_KEY=fake", True, "the export prefix is allowed"),
+        ('APPWRITE_DATASTORE_API_KEY="fake"', True, "double quotes are stripped"),
+        ("APPWRITE_DATASTORE_API_KEY='fake'", True, "single quotes are stripped"),
+        ("APPWRITE_DATASTORE_API_KEY=a=b=c", True, "a value containing '=' survives"),
+        ("APPWRITE_DATASTORE_API_KEY=", False, "declared-but-empty is not available"),
+        # The case the round-2 fix addressed and which nothing tested: a trailing-`.`
+        # regex matches the opening quote, so `NAME=""` read as available, routing
+        # bootstrap into the fatal path and re-creating the circular
+        # "Run ./bootstrap.sh" advice for a different input. Reverting the quote
+        # stripping must turn this red.
+        ('APPWRITE_DATASTORE_API_KEY=""', False, "QUOTED-empty is not available either"),
+        ("APPWRITE_DATASTORE_API_KEY=''", False, "single-quoted empty likewise"),
+        ("SOMETHING_ELSE=fake", False, "a different key is not the secret"),
+    ],
+)
+def test_the_probe_judges_availability_correctly(repo, line, available, why):
+    (repo / ".env").write_text(line + "\n", encoding="utf-8")
+    out = call(repo, 'platform_env_secret_available; echo "STATUS=$?"').stdout
+    expected = "STATUS=0" if available else "STATUS=1"
+    assert expected in out, f"{why}: {line!r} -> {out.strip()!r}"
 
 
 def test_load_validates_and_uses_the_documented_order(repo):

--- a/tests/test_platform_env.py
+++ b/tests/test_platform_env.py
@@ -220,6 +220,57 @@ def test_an_unsourceable_env_is_fatal_not_swallowed(repo):
     )
 
 
+@pytest.mark.red
+def test_is_exported_handles_readonly_and_empty_and_prefixes(repo):
+    """`export -p | grep '^declare -x NAME='` was wrong three ways; `compgen -e` is not.
+
+    Bash prints `declare -rx NAME=` for a readonly export, so the original pattern reported
+    a variable the child demonstrably receives as unavailable — the same category of error
+    as the bug it was written to fix.
+    """
+    result = call(repo, '''
+        export RO=x; readonly RO
+        export EMPTYV=""
+        platform_env_is_exported RO      && echo "RO=yes"      || echo "RO=no"
+        platform_env_is_exported EMPTYV  && echo "EMPTY=yes"   || echo "EMPTY=no"
+        platform_env_is_exported ROX     && echo "PREFIX=yes"  || echo "PREFIX=no"
+        NOTEXPORTED=1
+        platform_env_is_exported NOTEXPORTED && echo "LOCAL=yes" || echo "LOCAL=no"
+    ''')
+    assert "RO=yes" in result.stdout, "readonly+exported is still exported"
+    assert "EMPTY=yes" in result.stdout, "exported-but-empty is still exported"
+    assert "PREFIX=no" in result.stdout, "must not match a name that merely shares a prefix"
+    assert "LOCAL=no" in result.stdout, "a shell-local variable is not exported"
+
+
+def test_the_registry_is_read_once_per_load_not_once_per_step(repo, tmp_path):
+    """`platform_env_load` runs three functions that each need the registry.
+
+    Without a cache that is three subprocess spawns and three TOML parses per launcher
+    invocation, across ~130 launchers. The first memoisation attempt assigned the cache
+    inside a command substitution — a subshell — so it silently saved nothing.
+    """
+    counter = tmp_path / "pycalls"
+    shim_dir = tmp_path / "shim"
+    shim_dir.mkdir()
+    real = Path(sys.executable)
+    (shim_dir / "python").write_text(
+        f'#!/bin/bash\necho x >> "{counter}"\nexec "{real}" "$@"\n', encoding="utf-8"
+    )
+    (shim_dir / "python").chmod(0o755)
+
+    (repo / ".env").write_text("APPWRITE_DATASTORE_API_KEY=fake\n", encoding="utf-8")
+    env_extra = {"PATH": f"{shim_dir}{os.pathsep}{Path(sys.executable).parent}{os.pathsep}{os.environ['PATH']}"}
+    result = call(repo, "platform_env_load", env_extra=env_extra)
+    assert result.returncode == 0, result.stderr
+
+    spawns = counter.read_text().count("x") if counter.exists() else 0
+    assert spawns == 1, (
+        f"the registry was read {spawns} times in one platform_env_load; the cache is not "
+        f"reaching the caller's shell (assigning it inside $(...) does nothing)"
+    )
+
+
 def test_the_probe_is_silent_and_non_fatal_when_there_is_no_env(repo):
     """`bootstrap.sh` must be able to ask "is the secret there?" on a virgin machine.
 

--- a/tests/test_unfao_launcher_environment.py
+++ b/tests/test_unfao_launcher_environment.py
@@ -58,24 +58,49 @@ def test_registry_check_happens_before_conda_and_pip():
 
 
 def test_the_full_contract_is_asserted_before_main_runs():
-    """Every step, and each one fatal. A partial environment is not a starting state."""
+    """The whole sequence, fatal, before main.py. A partial environment is not a start.
+
+    The launcher calls `platform_env_load` rather than the individual steps. That is the
+    fix for a real drift found in review: the launcher used one order, `bootstrap.sh` used
+    another, and the file's header documented a third. `platform_env_load` is now the
+    single sequence — and it ends in `platform_env_validate`, which it previously omitted
+    while its own comment claimed to be "everything the platform needs".
+    """
     text = _run_sh()
     # `_first_code_line`, not `str.find` — the same C-57 trap that broke the ordering test
     # above. These happen not to have a commented mention today; relying on that is how it
     # comes back.
     main_at = _first_code_line(text, "main.py")
     assert main_at is not None
-    for call in (
-        "platform_env_assert_no_env_conflicts",
-        "platform_env_export_secret",
-        "platform_env_export_coordinates",
-        "platform_env_validate",
-    ):
-        at = _first_code_line(text, call)
-        assert at is not None, f"{call} must be called by the launcher"
-        assert at < main_at, f"{call} must run before main.py"
-        line = next(ln for ln in text.splitlines() if call in ln and not ln.strip().startswith("#"))
-        assert "|| exit 1" in line, f"{call} must be fatal, not advisory: {line.strip()!r}"
+
+    at = _first_code_line(text, "platform_env_load")
+    assert at is not None, "the launcher must load the environment via platform_env_load"
+    assert at < main_at, "the environment must be loaded before main.py"
+    line = next(
+        ln for ln in text.splitlines()
+        if "platform_env_load" in ln and not ln.strip().startswith("#")
+    )
+    assert "|| exit 1" in line, f"loading must be fatal, not advisory: {line.strip()!r}"
+
+
+def test_the_launcher_does_not_hand_roll_the_sequence():
+    """Calling the steps individually is how the launcher and bootstrap.sh drifted apart."""
+    text = _run_sh()
+    hand_rolled = [
+        ln.strip() for ln in text.splitlines()
+        if not ln.strip().startswith("#")
+        and any(
+            step in ln for step in (
+                "platform_env_export_secret",
+                "platform_env_export_coordinates",
+                "platform_env_assert_no_env_conflicts",
+            )
+        )
+    ]
+    assert not hand_rolled, (
+        f"the launcher calls individual steps instead of platform_env_load: {hand_rolled}. "
+        f"Two callers running two orders is what the single sequence exists to prevent"
+    )
 
 
 def test_the_launcher_does_not_export_the_secret_itself():

--- a/tests/test_unfao_launcher_environment.py
+++ b/tests/test_unfao_launcher_environment.py
@@ -1,19 +1,14 @@
-"""The un_fao launcher's environment contract: one source, and absence is fatal (#308, #309).
+"""The un_fao launcher delegates its environment to the one writer (#309).
 
-Two rules, both learned the hard way:
+The *behaviour* — registry fatal, one writer, secret by name, nothing rendered — is tested
+against the real shell functions in `tests/test_platform_env.py`. These are the remaining
+assertions that can only be made about the launcher itself: that it uses that file rather
+than reimplementing it, and that it does so in the right order.
 
-**#308 — an unresolvable registry is fatal, and fatal early.** The default registry path is
-a relative hop to a sibling checkout of views-appwrite. On a different layout, in CI, or in
-a container it is simply absent. Warning and continuing does not save the run; it moves the
-failure to the datastore boundary minutes later, where it describes a symptom instead of a
-cause, in front of whoever is least equipped to trace it back to a checkout layout.
-
-**#309 — the registry is the only source of coordinates.** `.env` and the registry writing
-the same names is a data race whose winner is decided by line order: reverse the blocks and
-the semantics invert silently, with no test failing.
-
-These tests pin the rules against the launcher, which is production infrastructure and not
-otherwise covered by anything executable.
+Ordering is the part a behavioural test cannot reach. A fatal registry check placed after
+the conda/pip block still works, and still wastes several minutes building an environment
+the run is about to throw away — on a fresh machine, that is the difference between a
+useful failure and an infuriating one.
 """
 from pathlib import Path
 
@@ -21,105 +16,105 @@ import pytest
 
 pytestmark = [pytest.mark.beige]
 
-RUN_SH = (
-    Path(__file__).resolve().parent.parent / "postprocessors" / "un_fao" / "run.sh"
-)
+RUN_SH = Path(__file__).resolve().parent.parent / "postprocessors" / "un_fao" / "run.sh"
 
 
 def _run_sh() -> str:
     return RUN_SH.read_text(encoding="utf-8")
 
 
-def test_missing_registry_is_fatal_before_any_conda_or_pip_work():
-    """#308's acceptance criterion: exit non-zero *before any work begins*.
+def test_launcher_sources_the_shared_environment_writer():
+    assert "tools/credentials/platform_env.sh" in _run_sh(), (
+        "the launcher must source tools/credentials/platform_env.sh rather than reimplementing the "
+        "environment contract — two implementations is how the two writers happened (#309)"
+    )
 
-    Position matters as much as behaviour. A fatal check placed after the conda/pip block
-    still wastes an environment build, and on a fresh machine that is minutes.
+
+def _first_code_line(text: str, needle: str):
+    """Line number of the first NON-COMMENT line containing `needle`, else None.
+
+    Comments must be excluded or this fails on prose. It did: the launcher's own comment
+    reads "macOS notes, conda lifecycle, pip install", and a naive search placed `pip
+    install` before the guard. That is C-57 — a regex cannot tell a commented mention from
+    a live statement — committed inside the test whose docstring warns about C-57.
     """
-    text = _run_sh()
-    fatal_at = text.find('if [ ! -f "$APPWRITE_REGISTRY" ]')
-    assert fatal_at != -1, "a missing registry must be fatal (#308)"
+    for number, line in enumerate(text.splitlines(), start=1):
+        if needle in line and not line.strip().startswith("#"):
+            return number
+    return None
 
-    for later in ("conda activate", "pip install", "conda shell.bash hook"):
-        position = text.find(later)
-        assert position == -1 or fatal_at < position, (
-            f"the fatal registry check must come BEFORE {later!r} — otherwise the run "
-            f"builds an environment it is about to throw away (#308)"
+
+def test_registry_check_happens_before_conda_and_pip():
+    text = _run_sh()
+    guard = _first_code_line(text, "platform_env_require_registry")
+    assert guard is not None, "the launcher must assert the registry resolves (#308)"
+    for later in ("conda shell.bash hook", "conda activate", "pip install"):
+        position = _first_code_line(text, later)
+        assert position is None or guard < position, (
+            f"the registry guard (line {guard}) must precede {later!r} (line {position}) — "
+            f"otherwise a run with no registry builds a conda environment it is about to "
+            f"discard (#308)"
         )
 
 
-def test_the_fatal_message_names_the_path_and_the_override():
+def test_the_full_contract_is_asserted_before_main_runs():
+    """Every step, and each one fatal. A partial environment is not a starting state."""
     text = _run_sh()
-    assert "APPWRITE_REGISTRY=/path/to" in text, (
-        "the failure must name the override variable — the person hitting this is on a "
-        "machine with a different layout and needs the escape hatch, not a diagnosis"
-    )
-    assert "looked for:" in text, "the failure must name the path actually tried"
+    # `_first_code_line`, not `str.find` — the same C-57 trap that broke the ordering test
+    # above. These happen not to have a commented mention today; relying on that is how it
+    # comes back.
+    main_at = _first_code_line(text, "main.py")
+    assert main_at is not None
+    for call in (
+        "platform_env_assert_no_env_conflicts",
+        "platform_env_export_secret",
+        "platform_env_export_coordinates",
+        "platform_env_validate",
+    ):
+        at = _first_code_line(text, call)
+        assert at is not None, f"{call} must be called by the launcher"
+        assert at < main_at, f"{call} must run before main.py"
+        line = next(ln for ln in text.splitlines() if call in ln and not ln.strip().startswith("#"))
+        assert "|| exit 1" in line, f"{call} must be fatal, not advisory: {line.strip()!r}"
 
 
-def test_an_unreadable_registry_is_also_fatal():
-    """Existing-but-unparseable is the same outcome as absent: no coordinates."""
+def test_the_launcher_does_not_export_the_secret_itself():
+    """One writer. The launcher sources .env for GITHUB_TOKEN and nothing else."""
     text = _run_sh()
-    assert "could not be read" in text, (
-        "a registry that exists but fails to parse must be fatal too — half a source is "
-        "not a source (#308)"
-    )
-
-
-def test_env_declaring_a_registry_owned_coordinate_is_fatal():
-    """#309: two writers to one name is an error, not a precedence question."""
-    text = _run_sh()
-    assert "both declare:" in text, (
-        "a coordinate declared in BOTH .env and the registry must fail loud naming the "
-        "variable and both sources (#309)"
-    )
-    assert "_conflicts" in text, "the conflict detection must exist, not just be described"
-
-
-def test_the_secret_is_still_exported_by_name_and_never_via_set_a():
-    """The one value .env may still carry. `set -a` would corrupt it (#293)."""
-    text = _run_sh()
-    assert "export APPWRITE_DATASTORE_API_KEY" in text, (
-        "the secret must still be exported by name — #293 exists because it was not"
-    )
-    # Check for USE, not mention: the file deliberately explains in a comment why `set -a`
-    # is wrong, and a naive substring search flags that explanation as the offence. That is
-    # C-57 — to a regex a commented line is indistinguishable from a live one — and this
-    # test made the mistake on its first draft.
-    live_set_a = [
-        line for line in text.splitlines()
-        if "set -a" in line and not line.strip().startswith("#")
+    live = [
+        ln for ln in text.splitlines()
+        if "export APPWRITE_DATASTORE_API_KEY" in ln and not ln.strip().startswith("#")
     ]
-    assert not live_set_a, (
-        f"`set -a` is used, not merely explained: {live_set_a}. It exports unquoted "
-        f"*_NAME values truncated at the first space (#293)"
+    assert not live, (
+        f"the launcher exports the secret directly: {live}. platform_env_export_secret "
+        f"owns it; doing both reinstates the second writer #309 removes"
     )
 
 
-def test_the_293_correction_survived_the_rewrite():
+def test_no_live_set_a():
+    """`set -a` exports unquoted *_NAME values truncated at the first space (#293).
+
+    Checks for USE, not mention: the file explains in a comment why `set -a` is wrong, and
+    a substring search flags the explanation as the offence. That is C-57, and the first
+    draft of this test made exactly that mistake.
+    """
+    live = [
+        ln for ln in _run_sh().splitlines()
+        if "set -a" in ln and not ln.strip().startswith("#")
+    ]
+    assert not live, f"`set -a` is used, not merely explained: {live}"
+
+
+def test_the_293_correction_survived_the_extraction():
     """A removal must name what it was carrying (þing-02, S25).
 
-    The #293 comment records that `source` without `export` meant there was no carrier
-    for the secret at all between two dates — a real production failure, honestly
-    documented. Rewrites lose that kind of thing silently.
+    #293 records that `source` without `export` left no carrier for the secret at all
+    between two dates — a real production failure. Extractions lose that kind of note
+    silently, so it is pinned in both places it could live.
     """
-    text = _run_sh()
-    assert "#293" in text, "the #293 correction must survive edits to this file"
-
-
-def test_the_false_coordinate_state_claim_is_gone():
-    """The helper it replaced asserted something untrue; it must not come back.
-
-    `_platform001_coordinate_state()` announced "Coordinates ARE present in the
-    environment (exported outside this script)" on the strength of a SHELL variable that
-    `source .env` sets and nothing exports — so the python child never saw it. It was
-    written to avoid asserting an unverified environment fact and did exactly that by
-    checking the wrong scope.
-    """
-    text = _run_sh()
-    assert "_platform001_coordinate_state" not in text or "REMOVED HERE" in text, (
-        "the coordinate-state helper checked shell variables rather than exported ones "
-        "and reported a false 'coordinates ARE present' — it must not be reinstated "
-        "without fixing that (#308/#309)"
+    from_launcher = "#293" in _run_sh()
+    shared = Path(__file__).resolve().parent.parent / "tools" / "credentials" / "platform_env.sh"
+    from_shared = "#293" in shared.read_text(encoding="utf-8")
+    assert from_launcher or from_shared, (
+        "the #293 correction must survive wherever the secret handling now lives"
     )
-    assert "Coordinates ARE present in the environment (exported outside this script)" not in text

--- a/tools/README.md
+++ b/tools/README.md
@@ -45,7 +45,7 @@ an operator slot per PLATFORM-001.
 python tools/credentials/check_credentials.py                  # which keys am I missing?
 python tools/credentials/registry_to_env.py <registry.toml>    # coordinates from the owned registry
 # platform_env.sh is sourced, not run — the ONE writer of the Appwrite environment (#309):
-#   . tools/credentials/platform_env.sh && platform_env_load && platform_env_validate
+#   . tools/credentials/platform_env.sh && platform_env_load   # load ends in validation
 # Consumers: ./bootstrap.sh and postprocessors/un_fao/run.sh.
 ```
 

--- a/tools/README.md
+++ b/tools/README.md
@@ -44,6 +44,9 @@ an operator slot per PLATFORM-001.
 ```bash
 python tools/credentials/check_credentials.py                  # which keys am I missing?
 python tools/credentials/registry_to_env.py <registry.toml>    # coordinates from the owned registry
+# platform_env.sh is sourced, not run — the ONE writer of the Appwrite environment (#309):
+#   . tools/credentials/platform_env.sh && platform_env_load && platform_env_validate
+# Consumers: ./bootstrap.sh and postprocessors/un_fao/run.sh.
 ```
 
 `registry_to_env.py` is invoked by `postprocessors/un_fao/run.sh`; changing its path

--- a/tools/credentials/platform_env.sh
+++ b/tools/credentials/platform_env.sh
@@ -85,8 +85,18 @@ platform_env_require_registry() {
 
 # Echoes `NAME=value` lines, or fails loud. Kept separate from exporting so callers can
 # inspect what the registry owns without mutating their own environment.
+# Memoised per shell. platform_env_load runs three functions that each need the registry,
+# and before this each spawned its own `python registry_to_env.py` — three subprocess
+# launches and three TOML parses per launcher invocation, across ~130 launchers. The read
+# is pure, so caching it is safe; APPWRITE_REGISTRY changing mid-run is not a supported
+# scenario, and the cache is per-process.
+PLATFORM_ENV_COORDS_CACHE=""
 platform_env_coordinates() {
   local root registry err out status
+  if [ -n "$PLATFORM_ENV_COORDS_CACHE" ]; then
+    printf '%s\n' "$PLATFORM_ENV_COORDS_CACHE"
+    return 0
+  fi
   root="$(platform_env_repo_root)"
   registry="$(platform_env_registry_path)"
   err="$(mktemp "${TMPDIR:-/tmp}/platform_env.XXXXXX")"
@@ -118,6 +128,7 @@ platform_env_coordinates() {
   fi
 
   rm -f "$err"
+  PLATFORM_ENV_COORDS_CACHE="$out"
   printf '%s\n' "$out"
 }
 
@@ -179,8 +190,15 @@ platform_env_export_coordinates() {
 # ran, and the child got nothing while every check reported success.
 #
 # `export -p` lists exactly what a child will inherit. Nothing else answers the question.
+# `compgen -e` lists exported variable NAMES, so this never parses a value or a format.
+#
+# The first version grepped `export -p` for `^declare -x NAME=`, which is a false negative
+# for anything exported AND readonly — bash prints `declare -rx NAME=` — and would have
+# reported a variable the child demonstrably receives as "will NOT reach the child". That
+# is the same category of error as the bug it was written to fix: a check that answers a
+# question adjacent to the one asked.
 platform_env_is_exported() {
-  export -p | grep -qE "^declare -x ${1}=|^export ${1}="
+  compgen -e | grep -qxF "$1"
 }
 
 # Non-fatal probe: is the secret obtainable at all? Silent, returns 0/1, changes nothing.
@@ -195,7 +213,13 @@ platform_env_secret_available() {
   [ -n "${!PLATFORM_ENV_SECRET_NAME:-}" ] && return 0
   dotenv="$(platform_env_dotenv_path)"
   [ -f "$dotenv" ] || return 1
-  grep -qE "^[[:space:]]*(export[[:space:]]+)?${PLATFORM_ENV_SECRET_NAME}=." "$dotenv"
+  # Strip quotes before judging emptiness: `NAME=""` is a declared-but-empty secret, and a
+  # trailing-`.` regex would call it available — routing bootstrap into the fatal path and
+  # re-creating the circular "Run ./bootstrap.sh" advice for a different input.
+  local value
+  value="$(grep -E "^[[:space:]]*(export[[:space:]]+)?${PLATFORM_ENV_SECRET_NAME}=" "$dotenv" \
+           | tail -1 | cut -d= -f2- | sed -e 's/^[[:space:]]*//' -e 's/^"\(.*\)"$/\1/' -e "s/^'\(.*\)'\$/\1/")"
+  [ -n "$value" ]
 }
 
 platform_env_export_secret() {
@@ -266,8 +290,20 @@ platform_env_validate() {
 # omitted `platform_env_validate` while its comment claimed to be "everything the platform
 # needs", and used a different order than the header documents. Both callers now use this,
 # so there is one order rather than two.
+# Populate the cache in the CALLER's shell. `coords="$(platform_env_coordinates)"` runs the
+# function in a subshell, so a cache assignment made inside it evaporates — which is what
+# the first version of this memoisation did: it cost a line of code and saved nothing,
+# silently. Same scope-blindness as C-112, in the fix for C-112. Assigning here works
+# because this function is called directly, and subshells inherit the value.
+platform_env_prime_coordinate_cache() {
+  local out
+  out="$(platform_env_coordinates)" || return 1
+  PLATFORM_ENV_COORDS_CACHE="$out"
+}
+
 platform_env_load() {
-  platform_env_require_registry        || return 1
+  platform_env_require_registry           || return 1
+  platform_env_prime_coordinate_cache     || return 1
   platform_env_assert_no_env_conflicts || return 1
   platform_env_export_coordinates      || return 1
   platform_env_export_secret           || return 1

--- a/tools/credentials/platform_env.sh
+++ b/tools/credentials/platform_env.sh
@@ -1,14 +1,26 @@
 #!/usr/bin/env bash
 # platform_env.sh — the ONE writer of this platform's Appwrite environment (#309, C-48).
 #
+# Governed by ADR-018 (docs/ADRs/018_environment_single_writer.md), which records WHY —
+# including the two occasions this exact blind spot shipped. Read that before changing the
+# contract; the reasoning is not in the commit log.
+#
 # Source it; it defines functions and does nothing on its own:
 #
 #     . "$project_path/tools/credentials/platform_env.sh"
+#     platform_env_load        # the whole contract, in the one correct order
+#
+# or, if you genuinely need a single step, the pieces it runs, in this order:
+#
 #     platform_env_require_registry
 #     platform_env_assert_no_env_conflicts
 #     platform_env_export_coordinates
 #     platform_env_export_secret
 #     platform_env_validate
+#
+# The header, `platform_env_load` and the two callers previously disagreed about this
+# order, and `platform_env_load` omitted validation while claiming to be "everything the
+# platform needs". One sequence now, documented once, used by both callers.
 #
 # WHAT THIS FILE IS FOR, AND WHAT IT DELIBERATELY IS NOT.
 #
@@ -153,15 +165,77 @@ platform_env_export_coordinates() {
 # #293 in full, because a removal must name what it was carrying: `source` without
 # `export` never reached the python child, so between views-postprocessing's load_dotenv
 # removal (2026-07-28) and the fix there was NO carrier for the secret at all. That was a
-# real production failure and this comment is the only place it is written down in code.
+# real production failure. Also recorded in ADR-018.
+#
+# ──────────────────────────────────────────────────────────────────────────────────────
+# THE ONLY SANCTIONED WAY TO ASK "WILL THE CHILD SEE THIS?" (C-112).
+#
+# `[ -n "$VAR" ]` cannot distinguish an EXPORTED variable from a shell-local one, and the
+# consumer is always a child process. This blind spot has now shipped twice in four days:
+# once as `_platform001_coordinate_state()` announcing "coordinates ARE present" about
+# unexported values (#314), and once as this very function's first draft, whose guard
+# returned early because `un_fao/run.sh` sources `.env` for GITHUB_TOKEN twenty lines
+# earlier — so the secret was a shell variable, the guard saw a value, the `export` never
+# ran, and the child got nothing while every check reported success.
+#
+# `export -p` lists exactly what a child will inherit. Nothing else answers the question.
+platform_env_is_exported() {
+  export -p | grep -qE "^declare -x ${1}=|^export ${1}="
+}
+
+# Non-fatal probe: is the secret obtainable at all? Silent, returns 0/1, changes nothing.
+#
+# It exists because `bootstrap.sh` must ask this question BEFORE deciding to prompt, and
+# the fatal version cannot answer it: on a first-ever machine there is no `.env`, so
+# `platform_env_export_secret` printed "FATAL: ... does not exist. Run ./bootstrap.sh" —
+# at the person who was running ./bootstrap.sh. A setup script whose first output is a
+# false FATAL and circular advice has failed at the one job #311 gave it.
+platform_env_secret_available() {
+  local dotenv
+  [ -n "${!PLATFORM_ENV_SECRET_NAME:-}" ] && return 0
+  dotenv="$(platform_env_dotenv_path)"
+  [ -f "$dotenv" ] || return 1
+  grep -qE "^[[:space:]]*(export[[:space:]]+)?${PLATFORM_ENV_SECRET_NAME}=." "$dotenv"
+}
+
 platform_env_export_secret() {
-  local dotenv; dotenv="$(platform_env_dotenv_path)"
-  if [ -n "${!PLATFORM_ENV_SECRET_NAME:-}" ]; then
-    return 0                      # already in the environment; the operator's own slot
+  local dotenv status
+  dotenv="$(platform_env_dotenv_path)"
+
+  # Already exported — the operator's own slot, or a wrapper. Nothing to do.
+  if platform_env_is_exported "$PLATFORM_ENV_SECRET_NAME"; then
+    return 0
   fi
-  [ -f "$dotenv" ] || return 0
+
+  # Set but NOT exported: the trap above. Promote it rather than skipping.
+  if [ -n "${!PLATFORM_ENV_SECRET_NAME:-}" ]; then
+    export "${PLATFORM_ENV_SECRET_NAME?}"
+    return 0
+  fi
+
+  if [ ! -f "$dotenv" ]; then
+    echo "FATAL: $PLATFORM_ENV_SECRET_NAME is not set and $dotenv does not exist." >&2
+    echo "  Run ./bootstrap.sh, or export it in your shell." >&2
+    return 1
+  fi
+
+  # Do NOT swallow this. A hand-edited .env with an unterminated quote fails to source,
+  # and `|| true` would leave the secret unset while reporting success — the same
+  # report-success-deliver-nothing shape this file exists to prevent.
   # shellcheck disable=SC1090
-  . "$dotenv" >/dev/null 2>&1 || true
+  . "$dotenv" >/dev/null 2>&1
+  status=$?
+  if [ "$status" -ne 0 ]; then
+    echo "FATAL: $dotenv could not be sourced (exit $status)." >&2
+    echo "  Usually an unterminated quote or a value with an unescaped space." >&2
+    return 1
+  fi
+
+  if [ -z "${!PLATFORM_ENV_SECRET_NAME:-}" ]; then
+    echo "FATAL: $dotenv does not declare $PLATFORM_ENV_SECRET_NAME." >&2
+    echo "  It is the one value that file must carry. Run ./bootstrap.sh." >&2
+    return 1
+  fi
   export "${PLATFORM_ENV_SECRET_NAME?}"
 }
 
@@ -169,25 +243,33 @@ platform_env_export_secret() {
 # Names what is missing rather than reporting a count. The value is never rendered — a
 # check that prints a credential to prove it found one has published it.
 
+# Tests EXPORTED scope, not shell scope (C-112). Validating with `[ -n "$name" ]` would
+# pass on values the child will never receive, which is the failure this function is the
+# last line of defence against.
 platform_env_validate() {
   local coords name missing=""
   coords="$(platform_env_coordinates)" || return 1
   for name in $(echo "$coords" | cut -d= -f1) "$PLATFORM_ENV_SECRET_NAME"; do
-    [ -z "${!name:-}" ] && missing="$missing $name"
+    platform_env_is_exported "$name" || missing="$missing $name"
   done
   if [ -n "$missing" ]; then
-    echo "FATAL: the environment is incomplete — missing:$missing" >&2
+    echo "FATAL: the environment is incomplete — these will NOT reach the child" >&2
+    echo "  process, either unset or set-but-not-exported:$missing" >&2
     echo "  coordinates come from: $(platform_env_registry_path)" >&2
     echo "  the secret comes from: $(platform_env_dotenv_path) (or your shell)" >&2
     return 1
   fi
 }
 
-# Everything the platform needs, in the one order that is correct. Callers that want the
-# whole contract use this; callers that need a step use the pieces.
+# The whole contract, in the documented order, INCLUDING validation. A caller that trusts
+# this alone must get a complete environment or a non-zero exit — the previous version
+# omitted `platform_env_validate` while its comment claimed to be "everything the platform
+# needs", and used a different order than the header documents. Both callers now use this,
+# so there is one order rather than two.
 platform_env_load() {
-  platform_env_require_registry || return 1
+  platform_env_require_registry        || return 1
   platform_env_assert_no_env_conflicts || return 1
-  platform_env_export_secret || return 1
-  platform_env_export_coordinates || return 1
+  platform_env_export_coordinates      || return 1
+  platform_env_export_secret           || return 1
+  platform_env_validate                || return 1
 }

--- a/tools/credentials/platform_env.sh
+++ b/tools/credentials/platform_env.sh
@@ -1,0 +1,193 @@
+#!/usr/bin/env bash
+# platform_env.sh — the ONE writer of this platform's Appwrite environment (#309, C-48).
+#
+# Source it; it defines functions and does nothing on its own:
+#
+#     . "$project_path/tools/credentials/platform_env.sh"
+#     platform_env_require_registry
+#     platform_env_assert_no_env_conflicts
+#     platform_env_export_coordinates
+#     platform_env_export_secret
+#     platform_env_validate
+#
+# WHAT THIS FILE IS FOR, AND WHAT IT DELIBERATELY IS NOT.
+#
+# The problem it solves is a data race, not untidiness. Before #314, two blocks wrote the
+# same names: `source .env` and the registry loop. The registry won because it ran second.
+# Reverse them and the semantics invert, silently, with no test failing. Extracting the
+# logic without removing the second writer would have tidied the race rather than ended it.
+#
+# So the rule this file enforces, and the whole of its value:
+#
+#     COORDINATES COME FROM THE REGISTRY. THE SECRET COMES FROM THE OPERATOR.
+#     Nothing else writes either, and a `.env` that tries is an error, not a tiebreak.
+#
+# NOT here, on purpose (#309 names this): conda lifecycle, pip installs, macOS libomp
+# setup. `postprocessors/un_fao/run.sh` had five reasons to change; only two of them are
+# about the environment, and only those two moved. One-time machine setup lives in
+# `bootstrap.sh` (#311).
+#
+# Interpreter: reading the registry needs `tomllib`, so Python 3.11+. This file does not
+# create or activate an environment — it uses whatever `python` the caller has arranged
+# and fails loud if that one cannot read the registry.
+
+# ── configuration ─────────────────────────────────────────────────────────────────────
+# Resolved once, overridable. The default is a relative hop to a sibling views-appwrite
+# checkout; on a different layout it is simply absent, which is fatal (#308) rather than a
+# warning, because continuing moves the failure to the datastore boundary minutes later
+# where it describes a symptom instead of a cause.
+
+platform_env_repo_root() {
+  # The repo containing this file, however it was sourced.
+  cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd
+}
+
+platform_env_registry_path() {
+  local root; root="$(platform_env_repo_root)"
+  echo "${APPWRITE_REGISTRY:-$root/../views-appwrite/docs/ADRs/platform/coordinate_registry.toml}"
+}
+
+platform_env_dotenv_path() {
+  local root; root="$(platform_env_repo_root)"
+  echo "$root/.env"
+}
+
+# The one value a `.env` may still legitimately carry.
+PLATFORM_ENV_SECRET_NAME="APPWRITE_DATASTORE_API_KEY"
+
+# ── 1. the registry must resolve ──────────────────────────────────────────────────────
+
+platform_env_require_registry() {
+  local registry; registry="$(platform_env_registry_path)"
+  if [ ! -f "$registry" ]; then
+    echo "FATAL: the Appwrite coordinate registry does not exist." >&2
+    echo "  looked for: $registry" >&2
+    echo "  override with: APPWRITE_REGISTRY=/path/to/coordinate_registry.toml" >&2
+    echo "" >&2
+    echo "  The default is a relative hop to a sibling checkout of views-appwrite. If this" >&2
+    echo "  machine lays the repositories out differently, set APPWRITE_REGISTRY." >&2
+    echo "  Fatal by design (#308): the registry is the ONLY source of coordinates." >&2
+    return 1
+  fi
+}
+
+# Echoes `NAME=value` lines, or fails loud. Kept separate from exporting so callers can
+# inspect what the registry owns without mutating their own environment.
+platform_env_coordinates() {
+  local root registry err out status
+  root="$(platform_env_repo_root)"
+  registry="$(platform_env_registry_path)"
+  err="$(mktemp "${TMPDIR:-/tmp}/platform_env.XXXXXX")"
+
+  # Capture status directly. Do NOT wrap this in `if ! cmd; then status=$?; fi` — inside
+  # that branch `$?` is the status of the NEGATION (0, because the negation succeeded),
+  # not of the command. The first draft of this file did exactly that and returned 0 on a
+  # failed registry read, so every caller reported success while exporting nothing. That
+  # is the same shape as the pipeline-core write path that logs "uploaded successfully"
+  # and uploads nothing — the defect this whole seam exists to stop.
+  out="$(python "$root/tools/credentials/registry_to_env.py" "$registry" 2>"$err")"
+  status=$?
+
+  if [ "$status" -ne 0 ]; then
+    echo "FATAL: the coordinate registry exists but could not be read." >&2
+    echo "  registry: $registry" >&2
+    echo "  python:   $(python -V 2>&1)  (registry_to_env.py needs 3.11+ for tomllib)" >&2
+    sed 's/^/  /' "$err" >&2
+    echo "  Fatal by design (#308): half a source is not a source." >&2
+    rm -f "$err"; return 1
+  fi
+
+  if [ -z "$out" ]; then
+    # A readable registry that yields nothing is not a success. Silence here would export
+    # zero coordinates and let validation pass on an empty set.
+    echo "FATAL: the coordinate registry parsed but declared no coordinates." >&2
+    echo "  registry: $registry" >&2
+    rm -f "$err"; return 1
+  fi
+
+  rm -f "$err"
+  printf '%s\n' "$out"
+}
+
+# ── 2. one writer: `.env` must not declare a coordinate the registry owns ─────────────
+
+platform_env_assert_no_env_conflicts() {
+  local dotenv coords owned name conflicts=""
+  dotenv="$(platform_env_dotenv_path)"
+  [ -f "$dotenv" ] || return 0
+  coords="$(platform_env_coordinates)" || return 1
+  owned="$(echo "$coords" | cut -d= -f1)"
+  for name in $owned; do
+    if grep -qE "^[[:space:]]*(export[[:space:]]+)?${name}=" "$dotenv"; then
+      conflicts="$conflicts $name"
+    fi
+  done
+  if [ -n "$conflicts" ]; then
+    echo "FATAL: .env declares coordinates that the registry owns (#309)." >&2
+    echo "  file:     $dotenv" >&2
+    echo "  registry: $(platform_env_registry_path)" >&2
+    echo "  both declare:$conflicts" >&2
+    echo "" >&2
+    echo "  Two writers to one name is a data race decided by line order, so this is an" >&2
+    echo "  error rather than a precedence question. Delete these lines from .env — they" >&2
+    echo "  were never exported, so nothing has ever received them from there. Keep" >&2
+    echo "  $PLATFORM_ENV_SECRET_NAME: the secret is the one value .env still carries." >&2
+    return 1
+  fi
+}
+
+# ── 3. export ─────────────────────────────────────────────────────────────────────────
+
+platform_env_export_coordinates() {
+  local coords line
+  coords="$(platform_env_coordinates)" || return 1
+  while IFS= read -r line; do
+    [ -z "$line" ] && continue
+    export "${line%%=*}=${line#*=}"
+  done <<< "$coords"
+}
+
+# The secret, by name. NEVER `set -a`: `.env` carries unquoted values containing spaces
+# (the *_NAME coordinates), which `set -a` exports truncated at the first space (#293).
+#
+# #293 in full, because a removal must name what it was carrying: `source` without
+# `export` never reached the python child, so between views-postprocessing's load_dotenv
+# removal (2026-07-28) and the fix there was NO carrier for the secret at all. That was a
+# real production failure and this comment is the only place it is written down in code.
+platform_env_export_secret() {
+  local dotenv; dotenv="$(platform_env_dotenv_path)"
+  if [ -n "${!PLATFORM_ENV_SECRET_NAME:-}" ]; then
+    return 0                      # already in the environment; the operator's own slot
+  fi
+  [ -f "$dotenv" ] || return 0
+  # shellcheck disable=SC1090
+  . "$dotenv" >/dev/null 2>&1 || true
+  export "${PLATFORM_ENV_SECRET_NAME?}"
+}
+
+# ── 4. validate ───────────────────────────────────────────────────────────────────────
+# Names what is missing rather than reporting a count. The value is never rendered — a
+# check that prints a credential to prove it found one has published it.
+
+platform_env_validate() {
+  local coords name missing=""
+  coords="$(platform_env_coordinates)" || return 1
+  for name in $(echo "$coords" | cut -d= -f1) "$PLATFORM_ENV_SECRET_NAME"; do
+    [ -z "${!name:-}" ] && missing="$missing $name"
+  done
+  if [ -n "$missing" ]; then
+    echo "FATAL: the environment is incomplete — missing:$missing" >&2
+    echo "  coordinates come from: $(platform_env_registry_path)" >&2
+    echo "  the secret comes from: $(platform_env_dotenv_path) (or your shell)" >&2
+    return 1
+  fi
+}
+
+# Everything the platform needs, in the one order that is correct. Callers that want the
+# whole contract use this; callers that need a step use the pieces.
+platform_env_load() {
+  platform_env_require_registry || return 1
+  platform_env_assert_no_env_conflicts || return 1
+  platform_env_export_secret || return 1
+  platform_env_export_coordinates || return 1
+}


### PR DESCRIPTION
#309's extraction and #311's `bootstrap.sh`, done **together** rather than in sequence.

## Why together

#309's extraction is only justified once a **second consumer** exists — and #311 *is* that consumer. `bootstrap.sh` sources the same file `un_fao/run.sh` does. Extracting first would have produced a shared file with one caller, reshaped the moment its real second caller arrived: the usual cost of designing against an imagined interface instead of an observed one.

## `tools/credentials/platform_env.sh` — the one writer

Coordinates come from the registry, the secret from the operator, **and nothing else writes either**. A `.env` declaring a registry-owned coordinate is *reported*, not resolved by precedence — two writers to one name is a race decided by line order, and reversing the blocks would invert the semantics with no test failing.

Deliberately excludes conda, pip and macOS setup. `run.sh` had five reasons to change; only two were about the environment, and only those moved.

## `bootstrap.sh` — no arguments, no companion document

Asks for **one secret and zero coordinates**. Asking a human to retype an address that is already declared somewhere is how the two copies drift. Validates, names what is missing, idempotent.

The macOS `~/.zshrc` block moves here from ~130 `run.sh` files — appending to a login profile is one-time setup.

**`.env` safety rules, because that file holds a live credential:** never read, print or log the value; never rewrite the file; append only, and only when the key is absent; back up first; silent read so nothing is echoed. Verified the value never reaches stdout or stderr.

## CI — the point, not a nicety

`.github/workflows/bootstrap.yml` runs it against a **fixture registry and a fake secret** — no network, no credentials, so it can run on every push rather than never. Six scenarios asserted, including that a missing secret **fails rather than hangs**: a hung CI job is a worse failure than a red one.

## Three bugs found in my own work

**1. A failed registry read reported success.** The first draft captured the exit status inside a negated `if`, where the status read back is the *negation's* — 0, because the negation succeeded. Every caller reported success while exporting nothing. That is the same shape as a write path logging *"uploaded successfully"* and uploading nothing — the defect this whole seam exists to stop. Pinned by a red test.

**2. An empty registry counted as success**, so validation could pass on an empty set. Now fatal.

**3. My own layout guard caught me.** `tests/test_tools_layout.py`, written two days ago, failed on `tools/platform_env.sh` sitting at the root. Moved to `tools/credentials/`, which is where CCP put it anyway — it orchestrates `registry_to_env.py`.

> **Deviation from the issue:** #309 names the path `tools/platform_env.sh`. The repo's own structural rule wins. Recorded on the issue.

## Tests: string-grep → behavioural

The six `run.sh` grep tests are replaced by **ten behavioural tests** that source the real shell functions against fixtures. String tests were the best available while the logic was inline and unreachable — they cannot tell code from a comment, and one proved it by matching the very comment explaining why not to use that construct. A second instance of the same C-57 error appeared in the replacement and is now fixed with a shared helper.

## Verification

| | |
|---|---|
| bootstrap, happy path | exit 0 |
| twice | `.env` byte-identical |
| missing registry | exit 1, names the override |
| `.env` conflict | exit 1, names the variable |
| missing secret, non-interactive | exit 1, **no hang** |
| secret in output | never rendered |
| ruff | clean |
| suite | 7460 passed, 1 failed — violet_visitor's live experiment, not this change |

## Still open on #309

Nothing. Its remaining criterion — *"the un_fao delivery path still works end to end"* — needs a real run, which is G2(c).

Closes #311. Leaves #309 for you to close once the extraction is reviewed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
