### PR TITLE
fix(deps): drop the unearned views-frames declaration from two ensembles

### DIFF
--- a/ensembles/skinny_love/requirements.txt
+++ b/ensembles/skinny_love/requirements.txt
@@ -1,2 +1,1 @@
 views-pipeline-core>=2.0.0,<3.0.0
-views-frames>=1.7.0,<2.0.0

--- a/ensembles/white_mustang/requirements.txt
+++ b/ensembles/white_mustang/requirements.txt
@@ -1,2 +1,1 @@
 views-pipeline-core>=2.0.0,<3.0.0
-views-frames>=1.7.0,<2.0.0


### PR DESCRIPTION
## What

`skinny_love` and `white_mustang` were the only two files in this repo declaring views-frames, at `>=1.7.0,<2.0.0`. **Neither imports it** — the sole mention of `views_frames` anywhere in either directory is the requirements line itself.

## Why removal rather than a bump to `>=1.10.2,<2`

`envs/views_ensemble` — the environment both ensembles build, shared with 11 others — **does not have views-frames installed at all**, and `skinny_love` completed a run on 2026-07-22 (wandb `atomic-jazz-101`, `state=finished`) in exactly that environment. The dependency is not merely unimported; it is demonstrably unnecessary.

Declaring a dependency you do not import means maintaining a version bound by hand in a file nobody reads. That is how this one reached `>=1.7.0` while the platform floor moved to `>=1.10.2`. The right answer to "should these be bumped" is that they should not exist.

**No behaviour change** — the package was not installed before this commit either.

## One finding worth recording, because it contradicts the assumption behind the platform-wide floor bump

**views-frames does not reach the models transitively.** pipeline-core added `views-frames = "^1.10.2"` on 2026-06-24 — in **version 3.0.0**. Every model and ensemble here pins `views-pipeline-core>=2.0.0,<3.0.0`, which excludes it. Verified against the built env, not inferred.

So no `>=1.10.2` floor update is owed by views-models. After this PR, the repo declares views-frames nowhere.

## Where views-frames *is* genuinely imported here

`reconciliation/` (3 files — which have **no requirements.txt at all**) and `postprocessors/un_fao/configs/config_queryset.py`. Neither touched in this PR; the un_fao manifest is being edited in the maintainer's working tree.

## Verification

- `ruff check .` clean.
- Ensemble / requirements / config suites: **4156 passed, 208 skipped, 3 xfailed**.
