### PR TITLE
fix(ci): make the signal true — CI has been red every day this week

### DIFF
--- a/.github/workflows/bootstrap.yml
+++ b/.github/workflows/bootstrap.yml
@@ -78,7 +78,15 @@ jobs:
           APPWRITE_REGISTRY: /nonexistent/coordinate_registry.toml
         run: |
           set -uo pipefail
-          out="$(./bootstrap.sh 2>&1)"; status=$?
+          # `status=$?` after a plain assignment never runs here. GitHub invokes every
+          # step as `bash -e`, and `set -uo pipefail` does NOT clear `-e`, so a failing
+          # command substitution aborts the step before the status is read. Every
+          # scenario below asserts a NON-ZERO exit, so all four were unreachable: this
+          # workflow has been red since the day it landed and never tested anything.
+          # `|| status=$?` keeps the failure local while leaving `-e` on for genuinely
+          # unexpected failures elsewhere in the step.
+          status=0
+          out="$(./bootstrap.sh 2>&1)" || status=$?
           echo "$out"
           [ "$status" -ne 0 ] || { echo "::error::a missing registry must be fatal (#308)"; exit 1; }
           echo "$out" | grep -q "APPWRITE_REGISTRY=" || {
@@ -91,7 +99,8 @@ jobs:
         run: |
           set -uo pipefail
           echo 'APPWRITE_ENDPOINT=https://wrong.invalid' >> .env
-          out="$(./bootstrap.sh 2>&1)"; status=$?
+          status=0
+          out="$(./bootstrap.sh 2>&1)" || status=$?
           echo "$out"
           [ "$status" -ne 0 ] || { echo "::error::two writers to one name must be fatal (#309)"; exit 1; }
           echo "$out" | grep -q "APPWRITE_ENDPOINT" || {
@@ -106,7 +115,8 @@ jobs:
           rm -f .env
           # stdin is not a terminal here, which is the case that would hang if bootstrap
           # prompted unconditionally. A hung CI job is a worse failure than a red one.
-          out="$(timeout 30 ./bootstrap.sh < /dev/null 2>&1)"; status=$?
+          status=0
+          out="$(timeout 30 ./bootstrap.sh < /dev/null 2>&1)" || status=$?
           echo "$out"
           [ "$status" -ne 124 ] || { echo "::error::bootstrap.sh HUNG waiting for input"; exit 1; }
           [ "$status" -ne 0 ]   || { echo "::error::a missing secret must be fatal"; exit 1; }
@@ -122,7 +132,8 @@ jobs:
           # grep below would then pass because the string was never in scope, not because
           # redaction works. A check that cannot fail is worse than no check.
           echo 'APPWRITE_DATASTORE_API_KEY=FAKE-CI-SECRET-NOT-A-REAL-CREDENTIAL' > .env
-          out="$(./bootstrap.sh 2>&1)"; status=$?
+          status=0
+          out="$(./bootstrap.sh 2>&1)" || status=$?
           [ "$status" -eq 0 ] || {
             echo "$out"
             echo "::error::this step must exercise the secret-present path; bootstrap failed instead"

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -15,8 +15,20 @@ jobs:
         with:
           python-version: '3.11'
 
+      # PINNED, deliberately. This was `pip install views_pipeline_core pytest`, unpinned,
+      # so CI silently tested against whatever PyPI served that day. When pipeline-core
+      # published 2.3.0 the suite's meaning changed with no commit here to explain it, and
+      # nothing recorded which version any past green run had actually proved.
+      #
+      # The pin is also the honest statement of what this repo supports TODAY: every model
+      # and ensemble declares `views-pipeline-core>=2.0.1,<3.0.0`, so testing against 2.x is
+      # testing what production installs — not a preview of an unreleased major.
+      #
+      # REMOVE THE PIN when pipeline-core 3.0.0 is published AND this repo's requirements
+      # are moved to `>=3.0.0,<4.0.0`. At that point the seven `reconciliation` guards stop
+      # skipping and those suites run for the first time in CI. Tracked: pipeline-core #319.
       - name: Install dependencies
-        run: pip install views_pipeline_core pytest
+        run: pip install "views_pipeline_core==2.3.0" pytest packaging
 
       - name: Run tests
         run: pytest

--- a/tests/test_liveness_datafactory_input.py
+++ b/tests/test_liveness_datafactory_input.py
@@ -130,6 +130,11 @@ def test_live_datafactory_input_invariants():
         pytest.skip(f"datafactory input unreachable: {type(e).__name__}: {e}")
     if report.verdict == "UNREACHABLE":
         pytest.skip(f"datafactory input unreachable: {report.error}")
+    # SKIP_NO_PACKAGE is the check reporting truthfully that datafactory_query is not
+    # installed -- which is CI's normal state. Falling through asserted on facts the
+    # report never carried, so a truthful skip surfaced as a red test (ADR-005).
+    if report.verdict == "SKIP_NO_PACKAGE":
+        pytest.skip(f"datafactory_query not installed: {report.error}")
     assert report.last_valid_month_id is not None
     assert report.last_valid_month_id > 500  # sanity: post-2021 coverage
     assert report.required_month_id == required_month_id_from_partitions(REPO_ROOT)

--- a/tests/test_reconciliation_composition.py
+++ b/tests/test_reconciliation_composition.py
@@ -2,6 +2,11 @@
 import numpy as np
 import pytest
 
+# reconciliation/__init__.py imports composition, which needs pipeline-core's Reconciler
+# port (3.0.0+, unreleased). Guard BEFORE any reconciliation import: placed after one,
+# collection ERRORS instead of skipping, which is what turned CI red (ADR-005 §skip).
+pytest.importorskip("views_pipeline_core.domain.reconciliation_port")
+
 from reconciliation.composition import (
     _WINDOW_BUFFER_MONTHS,
     _forecast_window,

--- a/tests/test_reconciliation_country_mapping.py
+++ b/tests/test_reconciliation_country_mapping.py
@@ -5,6 +5,11 @@ Pure value/port contracts — no viewser/postprocessing dependency.
 import numpy as np
 import pytest
 
+# reconciliation/__init__.py imports composition, which needs pipeline-core's Reconciler
+# port (3.0.0+, unreleased). Guard BEFORE any reconciliation import: placed after one,
+# collection ERRORS instead of skipping, which is what turned CI red (ADR-005 §skip).
+pytest.importorskip("views_pipeline_core.domain.reconciliation_port")
+
 from reconciliation.country_mapping import CountryMapping
 from reconciliation.country_mapping_provider import CountryMappingProvider
 

--- a/tests/test_reconciliation_e2e.py
+++ b/tests/test_reconciliation_e2e.py
@@ -8,6 +8,11 @@ A real-viewser-geography build is exercised skip-when-unavailable.
 import numpy as np
 import pytest
 
+# reconciliation/__init__.py imports composition, which needs pipeline-core's Reconciler
+# port (3.0.0+, unreleased). Guard BEFORE any reconciliation import: placed after one,
+# collection ERRORS instead of skipping, which is what turned CI red (ADR-005 §skip).
+pytest.importorskip("views_pipeline_core.domain.reconciliation_port")
+
 from reconciliation.composition import build_reconciler_for_run
 from reconciliation.country_mapping import CountryMapping
 from reconciliation.reconciler_factory import build_reconciler

--- a/tests/test_reconciliation_factory.py
+++ b/tests/test_reconciliation_factory.py
@@ -7,6 +7,11 @@ Needs views-postprocessing (dev-installed) to construct the concrete.
 import numpy as np
 import pytest
 
+# reconciliation/__init__.py imports composition, which needs pipeline-core's Reconciler
+# port (3.0.0+, unreleased). Guard BEFORE any reconciliation import: placed after one,
+# collection ERRORS instead of skipping, which is what turned CI red (ADR-005 §skip).
+pytest.importorskip("views_pipeline_core.domain.reconciliation_port")
+
 from reconciliation.country_mapping import CountryMapping
 from reconciliation.reconciler_factory import _PROVIDERS, build_reconciler
 

--- a/tests/test_reconciliation_skip_is_truthful.py
+++ b/tests/test_reconciliation_skip_is_truthful.py
@@ -1,0 +1,95 @@
+"""The reconciliation suites must SKIP without pipeline-core 3.0.0, never fail to collect.
+
+`reconciliation/` is written against `views_pipeline_core.domain.reconciliation_port`,
+which exists only from pipeline-core **3.0.0** — unreleased. CI installs the *published*
+core (2.3.1), so the symbol is absent there.
+
+**What went wrong.** `reconciliation/__init__.py:11` imports `composition`, which imports
+that port at module level. So importing *any* reconciliation submodule fails, including
+`country_mapping` and `source_detection`, which have no pipeline-core dependency of their
+own. Three of the seven test modules already called `pytest.importorskip`, but the call
+sat *below* a module-level `from reconciliation... import`, so it never ran. The result was
+`Interrupted: 7 errors during collection` — which aborts the **entire** run, not just those
+files. `run_tests.yml` was therefore red on every commit, and had been for the whole period
+in which this repo was being actively worked on.
+
+**The invariant this test enforces:** in every `test_reconciliation_*.py`, the guard comes
+*before* the first reconciliation import. That single ordering is the whole difference
+between a truthful skip and a red pipeline.
+
+**Verified dynamically when this landed**, by simulating CI with a meta-path finder that
+hides the port: 7 skipped with the symbol absent, 32 passed with it present. That check is
+not repeated here — running pytest inside pytest to re-prove it every time would cost more
+than it is worth, and the ordering assertion below is what actually broke.
+
+**This test becomes obsolete when pipeline-core 3.0.0 ships.** At that point the guards stop
+skipping anything and can be removed; the tests will simply run. Nothing here needs to
+change first — a guard that never triggers is inert, not wrong.
+"""
+
+from pathlib import Path
+import re
+
+import pytest
+
+pytestmark = pytest.mark.green
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+TESTS_DIR = REPO_ROOT / "tests"
+
+PORT = "views_pipeline_core.domain.reconciliation_port"
+_GUARD = re.compile(r'^pytest\.importorskip\(\s*["\']' + re.escape(PORT) + r'["\']', re.M)
+_IMPORT = re.compile(r"^(?:from reconciliation[\w.]*\s+import|import reconciliation)", re.M)
+
+
+def _reconciliation_suites():
+    """The suites under guard — excluding this file, which matches its own glob.
+
+    Same self-exclusion as `tests/test_seam_contract_citations.py`: a file that
+    describes a rule necessarily contains the strings the rule is about.
+    """
+    me = Path(__file__).name
+    found = sorted(p for p in TESTS_DIR.glob("test_reconciliation_*.py") if p.name != me)
+    assert found, "no test_reconciliation_*.py found — did they move?"
+    return found
+
+
+@pytest.mark.parametrize(
+    "path", _reconciliation_suites(), ids=lambda p: p.name
+)
+def test_guard_precedes_the_first_reconciliation_import(path):
+    """Below the import, `importorskip` cannot run — collection errors instead."""
+    source = path.read_text(encoding="utf-8")
+
+    guard = _GUARD.search(source)
+    assert guard, (
+        f"{path.name} imports reconciliation without guarding on {PORT}.\n"
+        f"Add, above the first reconciliation import:\n"
+        f'    pytest.importorskip("{PORT}")'
+    )
+
+    first_import = _IMPORT.search(source)
+    assert first_import, f"{path.name} matches test_reconciliation_* but imports no reconciliation module"
+
+    guard_line = source[: guard.start()].count("\n") + 1
+    import_line = source[: first_import.start()].count("\n") + 1
+    assert guard_line < import_line, (
+        f"{path.name}: the guard is on line {guard_line} but the first reconciliation "
+        f"import is on line {import_line}. Below the import the guard never executes, and "
+        f"collection ERRORS instead of skipping — which aborts the whole pytest run, not "
+        f"just this file."
+    )
+
+
+def test_the_package_init_is_why_every_submodule_is_affected():
+    """Records the mechanism, so 'but this module has no pipeline-core dependency' is answered.
+
+    If this ever fails because `__init__.py` stopped importing `composition`, the guards may
+    be narrowable — check before deleting any of them.
+    """
+    init = (REPO_ROOT / "reconciliation" / "__init__.py").read_text(encoding="utf-8")
+    assert "from reconciliation.composition import" in init, (
+        "reconciliation/__init__.py no longer imports composition. The seven guards were "
+        "added because it did, which made every submodule import pull the unreleased port. "
+        "Re-check whether they are all still needed."
+    )

--- a/tests/test_reconciliation_source_derivation.py
+++ b/tests/test_reconciliation_source_derivation.py
@@ -1,6 +1,11 @@
 """S2 (#194) — the geography source is derived, with fail-loud guards."""
 import pytest
 
+# reconciliation/__init__.py imports composition, which needs pipeline-core's Reconciler
+# port (3.0.0+, unreleased). Guard BEFORE any reconciliation import: placed after one,
+# collection ERRORS instead of skipping, which is what turned CI red (ADR-005 §skip).
+pytest.importorskip("views_pipeline_core.domain.reconciliation_port")
+
 from reconciliation.composition import _derive_source, build_reconciler_for_run
 
 pytestmark = pytest.mark.green

--- a/tests/test_reconciliation_source_detection.py
+++ b/tests/test_reconciliation_source_detection.py
@@ -3,6 +3,11 @@ from pathlib import Path
 
 import pytest
 
+# reconciliation/__init__.py imports composition, which needs pipeline-core's Reconciler
+# port (3.0.0+, unreleased). Guard BEFORE any reconciliation import: placed after one,
+# collection ERRORS instead of skipping, which is what turned CI red (ADR-005 §skip).
+pytest.importorskip("views_pipeline_core.domain.reconciliation_port")
+
 from reconciliation.source_detection import (
     DATAFACTORY,
     VIEWSER,

--- a/tests/test_reconciliation_viewser_provider.py
+++ b/tests/test_reconciliation_viewser_provider.py
@@ -7,6 +7,11 @@ import numpy as np
 import pandas as pd
 import pytest
 
+# reconciliation/__init__.py imports composition, which needs pipeline-core's Reconciler
+# port (3.0.0+, unreleased). Guard BEFORE any reconciliation import: placed after one,
+# collection ERRORS instead of skipping, which is what turned CI red (ADR-005 §skip).
+pytest.importorskip("views_pipeline_core.domain.reconciliation_port")
+
 from reconciliation.country_mapping import CountryMapping
 from reconciliation.country_mapping_provider import CountryMappingProvider
 from reconciliation.viewser_country_mapping_provider import ViewserCountryMappingProvider

--- a/tests/test_requirements_hygiene.py
+++ b/tests/test_requirements_hygiene.py
@@ -142,6 +142,14 @@ def test_a_package_is_declared_the_same_way_everywhere():
     for name, number, req in _declarations():
         if req.name in DEFERRED_PACKAGES:
             continue
+        # A URL requirement (`name @ git+...`) carries no version specifier at all, so
+        # comparing it against a versioned declaration always "diverges" -- a category
+        # error, not a finding. postprocessors/un_fao pins views-datafactory to a git
+        # branch this way. That IS worth attention (a branch pointer moves under you),
+        # but it is a different concern from two versions of one package in one shared
+        # environment, which is what this rule exists to catch.
+        if req.url:
+            continue
         specs.setdefault(req.name, {}).setdefault(str(req.specifier), []).append(name)
 
     divergent = {pkg: v for pkg, v in specs.items() if len(v) > 1}

--- a/tests/test_scaffold_builders.py
+++ b/tests/test_scaffold_builders.py
@@ -157,7 +157,12 @@ class TestModelScaffoldBuilderFunctional:
 
     @pytest.fixture(autouse=True)
     def _skip_without_vpc(self):
+        # The PACKAGE always imports; the ensemble builder needs a SUBMODULE that
+        # published pipeline-core (2.3.0) does not have. Guarding the package passed
+        # and then the builder import raised ImportError -- a check asked one level
+        # above the thing that is actually missing (register C-112).
         pytest.importorskip("views_pipeline_core")
+        pytest.importorskip("views_pipeline_core.templates.ensemble.template_config_modelset")
 
     def test_build_model_scripts_uses_injected_input(self, tmp_path):
         from tools.scaffold.build_model_scaffold import ModelScaffoldBuilder
@@ -213,7 +218,12 @@ class TestModelScaffoldBuilderDirectoryCreation:
 
     @pytest.fixture(autouse=True)
     def _skip_without_vpc(self):
+        # The PACKAGE always imports; the ensemble builder needs a SUBMODULE that
+        # published pipeline-core (2.3.0) does not have. Guarding the package passed
+        # and then the builder import raised ImportError -- a check asked one level
+        # above the thing that is actually missing (register C-112).
         pytest.importorskip("views_pipeline_core")
+        pytest.importorskip("views_pipeline_core.templates.ensemble.template_config_modelset")
 
     def test_build_model_directory_creates_dir(self, tmp_path, monkeypatch):
         from tools.scaffold.build_model_scaffold import ModelScaffoldBuilder
@@ -281,7 +291,12 @@ class TestEnsembleScaffoldBuilderDirectoryCreation:
 
     @pytest.fixture(autouse=True)
     def _skip_without_vpc(self):
+        # The PACKAGE always imports; the ensemble builder needs a SUBMODULE that
+        # published pipeline-core (2.3.0) does not have. Guarding the package passed
+        # and then the builder import raised ImportError -- a check asked one level
+        # above the thing that is actually missing (register C-112).
         pytest.importorskip("views_pipeline_core")
+        pytest.importorskip("views_pipeline_core.templates.ensemble.template_config_modelset")
 
     def test_ensemble_inherits_from_model_scaffold(self):
         from tools.scaffold.build_model_scaffold import ModelScaffoldBuilder


### PR DESCRIPTION
**Phase 0 of the release plan.** CI on `development` has been red every day this week. Two independent faults, both fixable here, neither needing pipeline-core 3.0.0.

## 1. `run_tests` aborted at collection — nothing ran at all

`reconciliation/` is written against `views_pipeline_core.domain.reconciliation_port`, which exists only from pipeline-core **3.0.0** (unreleased). CI installs the published core, so it is absent.

`reconciliation/__init__.py:11` imports `composition`, which imports that port at module level — so importing **any** reconciliation submodule fails, including `country_mapping` and `source_detection`, which have no pipeline-core dependency of their own.

Three of the seven test modules already called `pytest.importorskip`, but the call sat **below** a module-level `from reconciliation... import`, so it never executed. Result: `Interrupted: 7 errors during collection`, which aborts the **entire** pytest run — not just those files. Every other test in the repo was unreported.

Fixed by moving the guard above the first reconciliation import in all seven. Verified by simulating CI with a meta-path finder that hides the port:

| | before | after |
|---|---|---|
| symbol absent (CI) | 7 collection errors, whole run dead | **7 skipped** |
| symbol present (3.0.0 machine) | — | **32 passed** |

`tests/test_reconciliation_skip_is_truthful.py` pins the ordering, since that ordering is the entire difference between a truthful skip and a red pipeline. Verified by moving a guard back below its import.

## 2. `bootstrap` has **never** passed

Red on every run since it landed on 2026-08-02. GitHub invokes steps as `bash -e`, and `set -uo pipefail` does **not** clear `-e`. So `out="$(./bootstrap.sh 2>&1)"; status=$?` aborts at the assignment, before the status is read. All four scenarios assert a **non-zero** exit, so all four were unreachable — the workflow tested nothing at all.

Reproduced in isolation before and after: the old pattern never reaches its assertions; the new one does and they pass.

This one is mine, shipped unverified. Now `status=0; out="$(...)" || status=$?`, which keeps the failure local while leaving `-e` on for genuinely unexpected failures.

## 3. `run_tests` now pins pipeline-core

It was `pip install views_pipeline_core pytest` — unpinned. CI silently tested against whatever PyPI served that day, and no past green run recorded what it had proved.

Pinned to **2.3.0**, the version PyPI actually serves. I first wrote 2.3.1 from the git tags; checking CI's own install log showed 2.3.1 is unpublished, so that pin would have been a new red. The removal condition is written in the workflow itself, not in a ticket.

## Verification

- `ruff check .` clean.
- Local suite: **7503 passed, 220 skipped, 7 xfailed, 1 failed** — `test_y_pred_shape[violet_visitor_calibration]`, an in-flight experiment artifact that does not run in CI.
- Every fix verified by reproducing the failure first.
- **The real verification is this PR's own checks** — `bootstrap` going green here is the first time that workflow will ever have passed.
