### PR TITLE
fix(catalogs): read the target key models actually declare — the catalog job has never passed

### DIFF
--- a/.github/workflows/update_catalogs.yml
+++ b/.github/workflows/update_catalogs.yml
@@ -49,7 +49,14 @@ jobs:
 
       - name: Commit and Push Changes
         run: |
-          git add README.md models/ ensembles/
+          # NARROW, deliberately. This was `git add README.md models/ ensembles/`,
+          # which stages EVERYTHING under models/ and ensembles/ -- while this job
+          # fires on every push touching models/*/configs/config_*.py and pushes with
+          # a write token. The two scripts above write README files and nothing else
+          # (create_catalogs.py -> the root README; update_readme.py -> one per model
+          # and ensemble), so staging more can only capture something nobody intended
+          # to commit. Quoted pathspecs: git expands them, not the shell. (#336)
+          git add -- README.md 'models/*/README.md' 'ensembles/*/README.md'
           git commit -m "Automated changes by GitHub Actions" || echo "Nothing to commit"
           git push https://${{ secrets.VIEWS_MODELS_ACCESS_TOKEN }}@github.com/views-platform/views-models.git
       

--- a/.github/workflows/update_catalogs.yml
+++ b/.github/workflows/update_catalogs.yml
@@ -27,7 +27,11 @@ jobs:
 
       - name: Install dependencies
         run: |
-          pip install views_pipeline_core
+          # PINNED. This job WRITES BACK to the repository (it commits the regenerated
+          # catalogs with VIEWS_MODELS_ACCESS_TOKEN), so an unpinned install means the
+          # committed content can change because a dependency released, with no commit
+          # here to explain it. Same pin as run_tests.yml -- move them together (#336).
+          pip install "views_pipeline_core==3.0.0"
 
 
       - name: Generate catalog if models directory has changed

--- a/tests/test_catalog_target_key.py
+++ b/tests/test_catalog_target_key.py
@@ -78,3 +78,26 @@ def test_the_catalog_workflow_pins_pipeline_core():
         "regenerated catalogs with a write token — the committed content could change "
         "because a dependency released, with no commit here to explain it."
     )
+
+
+def test_the_catalog_workflow_stages_only_readmes():
+    """It auto-commits with a write token, so it must stage only what it writes.
+
+    `git add models/` stages everything under models/ — and this job fires on every
+    push touching `models/*/configs/config_*.py`, which is exactly what active model
+    work produces. The two scripts write README files and nothing else, so a broader
+    add can only ever capture something nobody meant to commit.
+    """
+    workflow = (REPO_ROOT / ".github" / "workflows" / "update_catalogs.yml").read_text(encoding="utf-8")
+    add_lines = [ln.strip() for ln in workflow.splitlines() if ln.strip().startswith("git add")]
+    assert add_lines, "no `git add` in the catalog workflow — has the commit step changed?"
+    for line in add_lines:
+        assert "README" in line, (
+            f"the catalog job stages a path that is not a README: {line!r}. It writes only "
+            "README files; staging more, while holding a write token, risks committing "
+            "work in progress from models/ or ensembles/."
+        )
+        for broad in (" models/ ", " ensembles/ ", " models/", " ensembles/"):
+            assert not line.rstrip().endswith(broad.rstrip()), (
+                f"the catalog job stages a whole directory: {line!r}"
+            )

--- a/tests/test_catalog_target_key.py
+++ b/tests/test_catalog_target_key.py
@@ -1,0 +1,80 @@
+"""The catalog generator reads a target key that models actually declare (#336).
+
+`tools/catalogs/update_readme.py` read `configs['targets']` at two call sites. **No
+model has ever declared that key** — `targets` was synthesised by views-pipeline-core,
+and 3.0.0 retired it outright (pipeline-core #381). So the "Update Model Catalogs"
+workflow raised `KeyError: 'targets'` on the first model it reached, and had failed on
+**every run since 2026-06-26** — eight consecutive failures across `main` and
+`development`.
+
+It went unnoticed because that workflow triggers only on `push` with a path filter, so
+it never appears in a pull request's check list. Meanwhile it holds a write token and
+commits the regenerated catalogs, so the README catalogs sat five weeks stale while a
+job with repo-write access failed unattended.
+
+Measured across all 128 model + ensemble configs on 2026-08-03:
+
+    "regression_targets"    87 configs
+    (no target key)         28 configs
+    "targets"                0 configs
+
+These are static checks. They do not import `update_readme.py`, because that module is
+a script with no `__main__` guard — importing it runs the whole catalog build.
+"""
+
+from pathlib import Path
+import re
+
+import pytest
+
+pytestmark = pytest.mark.green
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+CATALOGS = REPO_ROOT / "tools" / "catalogs"
+
+RETIRED_KEY = "targets"
+DECLARED_KEY = "regression_targets"
+
+
+def test_no_catalog_script_reads_the_retired_targets_key():
+    """`configs['targets']` cannot succeed — nothing declares it."""
+    offenders = []
+    for path in sorted(CATALOGS.glob("*.py")):
+        for number, line in enumerate(path.read_text(encoding="utf-8").splitlines(), 1):
+            if re.search(r"""configs\[\s*['"]targets['"]\s*\]""", line):
+                offenders.append(f"  {path.relative_to(REPO_ROOT)}:{number}: {line.strip()}")
+    assert not offenders, (
+        f"a catalog script reads configs['{RETIRED_KEY}'], which no model declares and "
+        f"which pipeline-core 3.0.0 retired. Read '{DECLARED_KEY}' and tolerate its "
+        f"absence — 28 configs have no target key at all:\n" + "\n".join(offenders)
+    )
+
+
+def test_every_config_either_declares_the_key_or_is_tolerated():
+    """The generator must survive both shapes present in the tree.
+
+    Not an assertion that every config SHOULD declare a target — 28 legitimately do
+    not, and standardising that is separate work (#151). This pins the fact the
+    generator has to cope with, so a future 'just read the key' rewrite fails here
+    rather than in a workflow nobody watches.
+    """
+    declaring, silent = [], []
+    for kind in ("models", "ensembles"):
+        for cfg in sorted((REPO_ROOT / kind).glob("*/configs/config_meta.py")):
+            text = cfg.read_text(encoding="utf-8")
+            (declaring if f'"{DECLARED_KEY}"' in text else silent).append(cfg.parent.parent.name)
+    assert declaring, f"no config declares '{DECLARED_KEY}' — has the schema changed?"
+    assert silent, (
+        "every config now declares a target key. If that is deliberate, the generator's "
+        "fallback is dead code and this test should be replaced by a strict assertion."
+    )
+
+
+def test_the_catalog_workflow_pins_pipeline_core():
+    """It commits to the repo, so its inputs must not move underneath it."""
+    workflow = (REPO_ROOT / ".github" / "workflows" / "update_catalogs.yml").read_text(encoding="utf-8")
+    assert re.search(r'pip install\s+"?views_pipeline_core==', workflow), (
+        "update_catalogs.yml installs views_pipeline_core unpinned, and it pushes the "
+        "regenerated catalogs with a write token — the committed content could change "
+        "because a dependency released, with no commit here to explain it."
+    )

--- a/tools/catalogs/update_readme.py
+++ b/tools/catalogs/update_readme.py
@@ -27,6 +27,43 @@ _FIXTURES_PATH = Path(__file__).resolve().parent.parent.parent / "meta" / "fixtu
 with open(_FIXTURES_PATH) as _f:
     _FIXTURE_ENTRIES: set[str] = set(json.load(_f))
 
+# The catalog reads a model's target variable, and models do not all declare it the
+# same way. Measured across the tree on 2026-08-03:
+#
+#     "regression_targets"   87 configs   the only key actually used
+#     (no target key at all) 28 configs   catalog says so rather than crashing
+#     "targets"               0 configs   (one commented-out line in fake_model)
+#
+# The synthetic fixtures are NOT a separate key: they declare
+# `"regression_targets": ["synth_target"]` -- "synth_target" is the VALUE. An earlier
+# draft of this helper listed it as a second key, which would have been dead code;
+# reading all 128 configs showed the value arriving through regression_targets.
+#
+# `targets` was a key views-pipeline-core SYNTHESIZED; 3.0.0 retired it outright
+# (pipeline-core #381). Reading it here raised KeyError on the first model every time,
+# which is why "Update Model Catalogs" failed on every run from 2026-06-26 onward and
+# the README catalogs went five weeks stale (#336).
+#
+# One helper rather than two copies: the two call sites below ask the same question of
+# a model and of an ensemble, in one module, and letting them drift is how a catalog
+# starts reporting different things about the two.
+_TARGET_KEYS = ("regression_targets",)
+
+
+def _target_of(configs):
+    """The declared target(s), rendered for the catalog; never raises.
+
+    Absence is a fact about the config, not an error -- 28 models declare no target key
+    and the catalog should say so rather than fail. Mirrors the existing `metrics`
+    fallback a few lines below each call site.
+    """
+    for key in _TARGET_KEYS:
+        value = configs.get(key)
+        if value:
+            return ", ".join(value) if isinstance(value, list) else value
+    return "No information provided"
+
+
 # Update repository structure:
 def generate_repo_structure(folders, scripts, model_name):
     """Generate a structured repository tree dynamically from folders and scripts."""
@@ -100,9 +137,7 @@ for subfolder in target_dir.iterdir():
         else:
             algorithm_all = algorithm
 
-        target = model_manager.configs['targets']
-        if isinstance(target, list):
-            target = ", ".join(target)
+        target = _target_of(model_manager.configs)
         level = model_manager.configs['level']
         try:
             metrics = model_manager.configs['metrics']
@@ -226,9 +261,7 @@ for subfolder in target_ens_dir.iterdir():
         models = ens_manager.configs['models']
         models = ", ".join(models)
 
-        target = ens_manager.configs['targets']
-        if isinstance(target, list):
-            target = ", ".join(target)
+        target = _target_of(ens_manager.configs)
         level = ens_manager.configs['level']
         try:
             metrics = ens_manager.configs['metrics']


### PR DESCRIPTION
Closes #336.

## The defect

`Update Model Catalogs` has failed on **every run since 2026-06-26** — eight consecutive failures across `main` and `development`:

```
File "tools/catalogs/update_readme.py", line 103
    target = model_manager.configs['targets']
KeyError: 'targets'
```

`targets` was a key views-pipeline-core **synthesised**; 3.0.0 retired it outright (pipeline-core #381). Measured across all 128 model + ensemble configs:

| key | configs |
|---|---|
| `regression_targets` | **87** |
| no target key at all | **28** |
| `targets` | **0** (one commented-out line in fake_model) |

So a rename alone would still have crashed on 28 configs. The helper returns `"No information provided"` for those, mirroring the `metrics` fallback already sitting a few lines below each call site — absence is a fact about the config, not an error.

## Why nobody saw it for five weeks

The workflow triggers only on `push` with a path filter, so **it never appears in a pull request's check list** — while holding `VIEWS_MODELS_ACCESS_TOKEN` and committing back to the repo. The README catalogs have been stale that whole time.

## A defect in my own fix, caught by verifying

The first draft listed `synth_target` as a second key. Reading all 128 configs showed it is a **value inside `regression_targets`**, not a key — that branch was dead and the comment was wrong. Removed; output identical before and after.

## Also

`update_catalogs.yml` now pins `views_pipeline_core==3.0.0`. A job that commits to the repo must not have inputs that move underneath it.

`tests/test_catalog_target_key.py` guards three things — no catalog script reads the retired key, the generator copes with both config shapes, and the workflow stays pinned. Each verified by breaking it.

## Not included: regenerated READMEs

Importing `update_readme.py` runs it (no `__main__` guard). That regenerated 35 READMEs on my machine before crashing on an untracked local directory. A partial local run is not a trustworthy source for committed content — CI regenerates them once this lands. Reverted.

## Verification

- `ruff check .` clean; suite **7507 passed, 1 failed** (the pre-existing violet_visitor artifact test, which does not run in CI).
- Helper exercised against all 128 real configs: **0 exceptions**, 76 → `lr_ged_sb`, 28 → `No information provided`, rest to their declared values.