### PR TITLE
docs(ADR): split ADR-017 into 017 + 019 + 020 + a living delivery map

### DIFF
--- a/docs/ADRs/000_use_of_adrs.md
+++ b/docs/ADRs/000_use_of_adrs.md
@@ -57,6 +57,21 @@ Do **not** write ADRs for:
 
 Decisions are never deleted. If a decision changes, it is **superseded**, not erased.
 
+**Splitting an ADR is not a supersession.** An ADR that has grown to hold several decisions changing
+at different rates may be **split for containment** — its parts moved into new ADRs that cite each
+other — provided **no decision is reversed**. The original keeps its number and records where the
+material went. This is a re-organisation, and marking it Superseded would retire a number that other
+documents cite while nothing was actually overturned.
+
+*Why the rule exists:* a decision should be retirable **whole**. If one document holds three
+decisions, changing one of them means amputating a third of it — and what remains is neither the old
+decision nor a clean new one. (Precedent: ADR-017 was split into 017/019/020 plus
+`docs/forecast_delivery_map.md` on 2026-08-04.)
+
+**A document that is designed to change is not an ADR at all.** If a page shrinks or grows as the
+system moves — a map of what exists today, an inventory, a burn-down — it belongs in `docs/`, and ADRs
+cite it. The rule above is what makes that distinction load-bearing rather than stylistic.
+
 ---
 
 ## Consequences

--- a/docs/ADRs/017_source_composition_delivery.md
+++ b/docs/ADRs/017_source_composition_delivery.md
@@ -1,12 +1,30 @@
 # ADR-017: Forecast Sources, Composition, and Delivery — separating what a model *is*, what it's *built from*, and *where it goes*
 
 **Status:** **Accepted** (2026-07-27) — **amended 2026-08-04**
-**Amendment 1 (2026-08-04):** the delivery declaration gets a concrete file format, and the two questions §12 left open — *where a delivery unit lives* and *how heavy it is* — are **decided**. Nothing in §3's three axes, §4e's derived production status, or §5's maturity rules changed. What changed is that a delivery can now carry **more than one source** (a grid-cell ensemble and the country-level ensemble it reconciles against), and that the file is split into what it *does* and what it *requires*. New: §4f (the file), §5's three added rules, §13 (errors must descend).
-**Date:** 2026-07-02 — **revised 2026-07-27** (grounded top-to-bottom in the real cross-repo flow; operational mechanics written from scratch; decided-vs-open made explicit. The core decision is unchanged.)
-**Accepted on the basis that** it aligns with pipeline-core's *Lean Platform End-State Roadmap* (`views-pipeline-core/documentation/plans/2026-07-27_lean_platform_end_state_roadmap.md`), which owns the sequencing/retirement this ADR's §1 direction-of-travel defers. The two documents adopt each other's vocabulary and read as one system.
+**Revised 2026-08-04 — split for containment.** This document had grown to ~13 pages and held four
+things that change at four different rates. Three moved out, and **no decision was reversed**:
+
+| moved | to | why |
+|---|---|---|
+| §1, the map of today's system | `docs/forecast_delivery_map.md` | it shrinks as legacy retires; ADRs do not |
+| the delivery file format | **ADR-019** | it will be revised as `deliveries/` is used |
+| "errors must descend" | **ADR-020** | it governs the whole repo, not delivery |
+
+What stays here is the part that should not need to change: the three axes, derived production status,
+the maturity rules, and the shelf write-gate. Per ADR-000 this is a **re-organisation, not a
+supersession** — 017 keeps its number and its decisions.
+
 **Deciders:** Simon (maintainer) — Accepted 2026-07-27
 **Consulted:** platform contributors
 **Informed:** all contributors
+
+---
+
+> **A note on names.** Every model, ensemble, consumer, region and target named in this document is an
+> **example**. They are real names where possible, because concrete examples are easier to read than
+> placeholders — but which source feeds which consumer changes, consumers are added and retired, and
+> buckets get renamed. Nothing here is a declaration about a particular name. The rules are about the
+> **shape**; the names are illustration.
 
 ---
 
@@ -32,124 +50,51 @@ Then "in production" stops being a label anyone types. It becomes a fact the sys
 
 ---
 
-## 1. How forecast delivery works *today* — the concrete map
+## 1. How forecast delivery works today
 
-**What this section does:** shows you, with real file paths, how a forecast actually gets from a model run to an API today — so the rest of the ADR has solid ground under it.
+**What this section does:** points at the map, rather than containing it.
 
-Two things make today's picture harder than it should be:
+How a forecast physically reaches a consumer today — the two stores, the two shelf dialects, the FAO
+line, and what is dying — is described in **`docs/forecast_delivery_map.md`**.
 
-- there are **two stores** — two different central places a forecast can land; and
-- there are **three producer mechanisms**, from three eras of the codebase, all alive at the same time. Which one runs depends on what shape a run produces: a pandas DataFrame, a PredictionFrame, or a PredictionFrame-ensemble.
-
-(The full mechanics are pinned in pipeline-core `tests/test_managers/test_delivery_characterization.py`. Here we keep only what the *delivery* story needs.)
-
-This is a lot of accumulated legacy — there's no pretending otherwise. To keep it readable, every piece below carries a tag: **[LEGACY]** (alive only until retired), **[CURRENT]** (the working present), or **[TARGET]** (where everything is converging). And §1 deliberately *ends* on the direction of travel — so you leave this section seeing a transition, not a permanent mess.
-
-> **Two words, kept distinct throughout this document.** Both are "stores" in plain English, which is exactly what trips people up:
-> - **"store"** = the **OLD** `views-forecasts` central store — feeds the public API, pandas-only door, **[LEGACY]** (the "pile nobody opens").
-> - **"shelf"** = the **NEW** Appwrite `production_forecasts` bucket — feeds FAO, metadata-tagged, **[CURRENT]**.
->
-> They are two different places. Wherever this ADR says *store* it means the old one; *shelf* means the new one.
-
-### The monthly run — this is what actually ships today. `[LEGACY]`
-
-`monthly_run.sh` is a hand-run list. It runs 4 **legacy DataFrame ensembles** (`pink_ponyclub`, `skinny_love`, `rude_boy`, `first_love`), each with `-m`.
-
-(`-m` = `--monthly`; it bundles train + forecast + report + prediction_store.)
-
-Each run goes through **one** method — `_save_predictions` → `PredictionIOManager`. (Not a set of "saver" objects — that's a different path, below.) That one method writes the forecast three ways:
-
-```
-monthly ensemble run (-m)  ->  PredictionIOManager        [LEGACY]
-  ├─ local disk: pandas-parquet (legacy list-in-cell)
-  ├─ legacy "views-forecasts" store  (df.forecasts.to_store)   [LEGACY]
-  │    -> external API  api.viewsforecasting.org   [MAIN PUBLIC LINE]
-  │       (prio-data/views_api, external)
-  └─ Appwrite SHELF: production_forecasts,  type="ensemble"    [LEGACY dialect]
-```
-
-There *is* a "savers" path — the single-model PredictionFrame path, with the composed `LocalParquetSaver` / `ViewsForecastsSaver` / `AppwriteSaver` trio (model.py:572). But that is a **different, conditional** mechanism `[CURRENT]`, and it is **not** what the monthly ensembles use.
-
-### `rusty_bucket` is a different animal again. `[TARGET]`
-
-`rusty_bucket` is a **PredictionFrame ensemble (PFE)** — the shape everything is converging toward. It uses *neither* path above. It does two things:
-
-- writes `save_pf` (npy/npz) to local disk; and
-- with the store on, publishes **wire shards** to the *same shelf*, tagged **`type="sampled_forecast_*"`**.
-
-Those wire shards are defined by **views-postprocessing's ADR-013** (its Sampled-Forecast Wire Contract). This is the *contract dialect*, kept deliberately separate from the legacy `type="ensemble"` dialect.
-
-> *Note on numbering:* throughout this document, **"ADR-013" always means views-postprocessing's ADR-013** (the wire contract) — a *different repo's* ADR. It is **not** this repo's ADR-013 (`013_regression_target_name_agnosticism.md`). Written **vpp ADR-013** where confusion is likely.
-
-### So the one shelf holds two disjoint dialects
-
-- legacy documents tagged `type="ensemble"`, and
-- contract shards tagged `type="sampled_forecast_*"`.
-
-They never overlap. That separation is the vpp ADR-013 §11.4 transition invariant.
-
-### The FAO line has two legs, and they share that one shelf
-
-```
-LIVE legacy leg:  shelf type="ensemble"  ->  vpp UNFAO manager
-    filters {category:forecast, type:ensemble}   (unfao.py:35)
-    reads "ensemble":"rusty_bucket"              (unfao.py:109)
-    enrich (GAUL) -> validate -> unfao_bucket, name="un_fao"
-    gated: UPLOAD_ENABLED = False
-      ->  views-faoapi serves unfao_bucket, name="un_fao"
-
-DORMANT contract leg:  shelf type="sampled_forecast_*"
-    ->  vpp wire/source_selection: newest manifested run
-    ->  same enrich / validate -> same unfao_bucket
-```
-
-### The punchline — and it's exactly what this ADR is about
-
-Put those pieces together:
-
-- the **live** FAO leg reads `type="ensemble"`;
-- but the **declared** FAO source (`rusty_bucket`) is a PFE, so it only ever produces `type="sampled_forecast_*"`;
-- therefore **the live leg will never see `rusty_bucket`'s output.**
-
-Meanwhile, the 4 monthly ensembles *do* produce `type="ensemble"` — but they aren't the declared FAO source.
-
-So today's FAO delivery is a **live consumer leg pointed at a source that isn't scheduled, while that source's own output can only feed the leg that's switched off.** Both halves are quietly *waiting*. And you cannot see this crossed-wires state by reading any single config file. That invisibility is the whole cost of "no single place declares delivery."
-
-### Where each config lives today (real paths)
-
-- **A model's maturity-ish label:** `views-models/models/<m>/configs/config_deployment.py` → `deployment_status`.
-- **An ensemble's label + members:** `.../ensembles/<e>/configs/config_deployment.py` (the label) and `.../config_modelset.py` (the members).
-- **The FAO "which source feeds us" declaration:** `views-models/postprocessors/un_fao/configs/config_meta.py` — the single line `"ensemble": "rusty_bucket"`, read by the manager at `views-postprocessing/.../unfao/managers/unfao.py:109`.
-  - **The smell, exactly:** that file's own docstring says *"This config is for documentation purposes only, and modifying it will not affect the model."* That is **false** — that one line decides which forecast reaches the UN.
-- **The main public line's declaration:** *none exists.* It is emergent — `monthly_run.sh` + the legacy store + the external API.
-
-### Two stores, two roles
-
-- **The `views-forecasts` store** (the old one) — pandas-only front door (`df.forecasts.to_store`); feeds the public API. Unstructured, matched by fragile naming — the pile nobody opens. *(It also has two **non-delivery** roles this ADR doesn't govern — legacy-ensemble constituent transport, and a run-metadata registry — whose retirement is sequenced by the pipeline-core roadmap, §"Direction of travel".)*
-- **The Appwrite `production_forecasts` shelf** (the new one) — the two-dialect bucket above; feeds the FAO postprocessor. vpp ADR-013 makes its contract dialect addressable by *declared provenance* instead of filename.
-
-### Direction of travel — what's dying, and where it goes
-
-*(Context only. This convergence is owned by the views-frames migration + vpp ADR-013, and **sequenced by pipeline-core's Lean Platform End-State Roadmap** (2026-07-27) — **not decided by this ADR**. It's here so the mess above reads as transitional.)*
-
-- **DataFrame ensembles** (the 4 monthly) → **PredictionFrame / PFE** (the `rusty_bucket` shape).
-- **the `views-forecasts` store** (pandas-only door) → **the Appwrite shelf** (→ Hetzner, eventually).
-- **shelf dialect `type="ensemble"`** → **`type="sampled_forecast_*"`** (vpp ADR-013 §11.4).
-- **the legacy FAO leg** → **the contract FAO leg**.
-
-Everything converges on one shape: **frames-native producers → the shelf's contract dialect → contract-reading consumers.** This ADR is written for that **target** state. The legacy machinery is *grandfathered* — described here so it's visible, not endorsed. **When a legacy element retires, its `[LEGACY]` line here retires with it** — so this section is a shrinking list, by design.
+That page is deliberately **not** an ADR. It shrinks as legacy retires, and ADR-000 says decisions are
+*"never deleted… superseded, not erased"* — so a page designed to change cannot live under this
+document's rules. Read it first; everything below stands on it.
 
 ## 2. What's broken
 
-**What this section does:** names the specific failures the map above produces.
+**What this section does:** names the specific failures the map produces. Every number here was
+measured on 2026-08-04 and names how to re-check it.
 
-- **One label, three jobs.** `deployment_status` mixes *operational mode* (`shadow`/`deployed`), *lifecycle* (`deprecated`), and *role* (`baseline`) into one field — three different axes, one word. And it's almost **inert**: only `deprecated` actually does anything (the config sniffer refuses to run it). `deployed`, `shadow`, and `baseline` are indistinguishable on a run. *(Verified: no code anywhere branches `deployed`-vs-`shadow`; pinned by `tests/test_deployment_status_inert.py`.)*
-- **Delivery is hidden and mislabeled.** The one line that controls FAO delivery sits inside a config that claims to do nothing (§1). The main line's delivery isn't written down at all.
-- **The shelf has no write-gate.** Anything run with `-p`/`-m` *and* the production credentials lands on the shelf, tagged with its own name — a `candidate`, a branch fork, a debug run. Nothing structurally says "only the real production forecast belongs here." This is how the old store rotted into a pile.
-- **The one coherence rule that should catch trouble is dead.** pipeline-core's ensemble guard only fires on the impossible value `"production"`, so a `deployed` ensemble can silently contain `shadow` members — and `white_mustang` already does (`lavender_haze`, `blank_space`).
-- **Delivering a lone model needs a fake ensemble.** Only ensembles can be delivered, so a single model gets wrapped in a one-member "ensemble" — the tell of a missing shared abstraction.
+- **One label, three jobs.** `deployment_status` mixes *operational mode* (`shadow`/`deployed`),
+  *lifecycle* (`deprecated`) and *role* (`baseline`) into one field — three axes, one word.
+  **And it is inert.** Nothing anywhere branches `deployed`-vs-`shadow`; that is pinned in both
+  repositories by `tests/test_deployment_status_inert.py`, which greps this repo *and* the installed
+  `views_pipeline_core` for such a comparison and fails if one appears.
+  *Measured across all 131 sources:* **120 `shadow`, 6 `baseline`, 4 `deprecated`, 1 `deployed`.*
+- **The one `deployed` thing in the repository is incoherent.** That single `deployed` source is
+  `ensembles/white_mustang`, and both its members — `lavender_haze` and `blank_space` — are `shadow`.
+  A deployed ensemble made entirely of things that are not deployed.
+- **The rule that should catch that is dead.** pipeline-core's
+  `modules/validation/ensemble/check.py:159` reads
+  `if single_model_dp_status == "production" and ensemble_deployment_status != "production":` —
+  but `production` is not one of the four values this repo writes (`shadow`, `deployed`, `baseline`,
+  `deprecated`). The branch cannot fire. The guard has never once run.
+- **Delivery is hidden and mislabeled.** The one line controlling FAO delivery sits in
+  `postprocessors/un_fao/configs/config_meta.py`, whose docstring says *"This config is for
+  documentation purposes only, and modifying it will not affect the model."* The main public line's
+  delivery is not written down at all.
+- **The shelf has no write-gate.** Anything run with `-p`/`-m` *and* production credentials lands on
+  the shelf tagged with its own name — a candidate, a branch fork, a debug run. Nothing structurally
+  says "only the real production forecast belongs here." This is how the old store rotted into a pile.
+- **Only ensembles can be delivered.** The publish leg takes an `Ensemble`, not a source, so a lone
+  model cannot be delivered without wrapping it in a one-member ensemble.
+  *Stated as a constraint, not an observation:* no such wrapper exists today — the smallest ensemble in
+  the repository has two members. The constraint is real; the symptom has simply not been forced yet.
 
-**Seen in production (2026-07).** Turning the FAO delivery *on* was very hard. Not because forecasts silently failed — we knew they weren't deployed yet. It was hard because *how* to switch it on was undiscoverable to anyone who hadn't built it. That is the cost of delivery being declared nowhere.
+**Seen in production (2026-07).** Turning the FAO delivery *on* was very hard. Not because forecasts
+silently failed — we knew they were not deployed yet. It was hard because *how* to switch it on was
+undiscoverable to anyone who had not built it. That is the cost of delivery being declared nowhere.
 
 ## 3. The model — three axes, each in one concrete place
 
@@ -165,12 +110,79 @@ The three axes, and where each one lives:
 - **Composition** — an ensemble's members.
   *Where:* `ensembles/<e>/configs/config_modelset.py` — **already exists, unchanged.**
 - **Delivery** — a `sources → consumer` edge.
-  *Where:* one file per consumer, at `views-models/deliveries/<consumer>.py` — **never on the source**. The **filename is the consumer**; no key repeats it, so the two cannot disagree. Each consumer is registered once, with a tier, in `views-models/meta/consumers.py`.
-  *(This lifts today's buried `"ensemble"` line into a dedicated, honest file. §4f gives the format in full.)*
+  *Where:* one file per consumer, at `views-models/deliveries/<consumer>.py` — **never on the source**. The **filename is the consumer**; no key repeats it, so the two cannot disagree.
+  *(This lifts today's buried `"ensemble"` line into a dedicated, honest file. **ADR-019** gives the format.)*
 
   **Why *sources*, plural.** A consumer may need a grid-cell forecast **and** the country-level forecast it was reconciled against. Both are real products: summing grid-cell *draws* does not reproduce a country-level *distribution*, so a consumer computing national uncertainty needs the country model's own posterior, not a reconstruction. The delivery names both.
 
-So, in one line: a **model's** config declares only its maturity. An **ensemble's** config declares its maturity **plus** its members. Neither says anything about delivery or "deployed."
+So, in one line: a **model's** config declares only its maturity. An **ensemble's** config declares its
+maturity **plus** its members. Neither says anything about delivery or "deployed."
+
+### The three axes as three files
+
+Example names throughout; the shape is the point.
+
+```python
+# models/<model>/configs/config_maturity.py        <- AXIS 1: maturity
+def get_maturity_config():
+    return {"maturity": "graduate"}                #  candidate | graduate | retired
+```
+
+```python
+# ensembles/<ensemble>/configs/config_modelset.py  <- AXIS 2: composition
+def get_modelset_config():
+    return {"models": ["<model_a>", "<model_b>"]}   #  unchanged from today
+```
+
+```python
+# deliveries/<consumer>.py                         <- AXIS 3: delivery
+DELIVERY = Delivery(
+    send      = [pgm("<ensemble>")],
+    frequency = monthly,
+    tier      = prod,
+    intent    = live(),
+)                                                  #  full format: ADR-019
+```
+
+Three files, three questions, no overlap. A source never mentions a consumer; a delivery never sets a
+maturity; an ensemble never says where its output goes. That separation is the whole decision — and
+"is this in production?" is answered by reading the first and third together (§4e), never by a field.
+
+### The values each key can take
+
+| key | file | allowed values | set |
+|---|---|---|---|
+| `maturity` | `config_maturity.py` | `candidate`, `graduate`, `retired` | closed — 3 values |
+| `models` | `config_modelset.py` | model directory names | open — must resolve under `models/` |
+| `level` | `config_meta.py` | `cm`, `pgm` | closed — 2 values |
+| `reconciliation` | `config_meta.py` | `"pgm_cm_point"`, `None` | closed — 2 values |
+| `reconcile_with` | `config_meta.py` | a source name | open — required when `reconciliation` is set |
+| the delivery keys | `deliveries/<consumer>.py` | — | **ADR-019 §3** |
+
+**`maturity`'s three values replace four in use today — and the migration is decided here.** The field
+being replaced (`deployment_status`) holds `shadow`, `baseline`, `deployed`, `deprecated`; §2 records
+that only `deprecated` does anything.
+
+| today | becomes | note |
+|---|---|---|
+| `shadow` | `candidate` | the bulk of the fleet |
+| `deprecated` | `retired` | the only value with behaviour today |
+| `baseline` | *(nothing)* | a role, not a maturity — leaves this file (see above) |
+| `deployed` | `graduate` **only if R2 holds**, else `candidate` | see below |
+
+**Why `deployed` is not a straight rename.** Mapped naively it breaks R2 immediately: measured
+2026-08-04, exactly one source is `deployed` — an ensemble whose two members are both `shadow`. A
+straight rename makes it a `graduate` ensemble with `candidate` members, so **the migration would
+produce a violation of this ADR's own rule on the day it lands**. Hence the conditional: a `deployed`
+source becomes `graduate` only where its members already qualify, and `candidate` otherwise.
+
+Nothing is lost by that. `graduate` does not mean *is delivered* — it means *eligible* to be, and
+whether it is delivered is the third file's business. Today's single `deployed` source has no delivery
+edge at all, so demoting it to `candidate` changes no behaviour; it only stops the label asserting a
+readiness the members do not have.
+
+**`level` has exactly two values** across all 128 configs that declare it. This is what ADR-019's
+`pgm(...)` / `cm(...)` wrappers check against, and why there is no third wrapper.
 
 ## 4. How you actually operate it
 
@@ -182,7 +194,7 @@ So, in one line: a **model's** config declares only its maturity. An **ensemble'
 - **A single model → an endpoint:**
   1. `maturity: graduate` in the model's config;
   2. a file `deliveries/<endpoint>.py` whose `send` names that model;
-  3. `<endpoint>` registered in `meta/consumers.py` with `tier: prod`.
+  3. that file declares `tier = prod` (ADR-019 §3).
 - **An ensemble → an endpoint:** identical — `send` names the ensemble.
 - **A grid-cell ensemble reconciled against a country-level one → an endpoint:** `send` names **both**, and `REQUIRE.reconciled = True`. The pairing itself is not restated here; it already lives on the ensembles (`reconciliation` + `reconcile_with`), and §5's reconciliation rule checks that what you listed matches what they declare.
 - **A model, inside an ensemble → an endpoint:** add it to the ensemble's `config_modelset.py`; make both the model and the ensemble `graduate`; declare the ensemble's delivery edge. The model is now in production *transitively*.
@@ -202,15 +214,13 @@ The producer must **never** know its consumers. So the gate is split across two 
 - **Write → shelf** is gated by **maturity** (§4b) — the source's own config.
 - **Shelf → consumer** is gated by the **delivery declaration** — the delivery unit reads its *own* `config_delivery.py`, pulls only its declared source off the shelf (by declared identity, not by filename), and serves it.
 
-### 4d. Serving-time curation — the FAO approve / quarantine lists
-Two variables govern *which already-delivered artifacts* the FAO serving layer (views-faoapi) may return: `APPWRITE_UNFAO_APPROVED_FILE_IDS` and `APPWRITE_UNFAO_QUARANTINED_FILE_IDS`. Despite their `APPWRITE_` prefix, these are **eligibility data, not connection configuration** — they name which delivered artifacts are *servable*, an operator/curation decision, not how to reach the store. They therefore belong to **this** eligibility contract, not to the identity/secrets/config contract (**The Appwrite Seam Contract**, formerly `PLATFORM-001`), whose variable map lists them only as explicit exclusions with a pointer back here (þing-01, verdict D3; 6/6 assent — class is *declared*, never inferred from a prefix).
+### 4d. Serving-time curation
 
-- **`APPWRITE_UNFAO_APPROVED_FILE_IDS`** — an optional allowlist. When set (non-empty), *only* the listed Appwrite file IDs are servable — a newly delivered artifact is **not** served until explicitly approved (a break-glass gate; faoapi C-71). When empty/unset, selection is unrestricted and the newest fully-manifested run wins.
-- **`APPWRITE_UNFAO_QUARANTINED_FILE_IDS`** — a blocklist. Listed file IDs are never served, even if newest — how an operator withdraws a bad run.
+Which *already-delivered* artifacts a consumer may serve (the FAO approve / quarantine lists) is
+delivery-side, not axis-side. It moved to **ADR-019 §5**.
 
-**Who sets them:** the operator (the human who holds the keys, The Appwrite Seam Contract §5), by editing the deployment environment. They carry non-secret Appwrite file IDs, so they are committable/inspectable — never secret. **Who reads them:** views-faoapi at selection time. With manifest-first serving (faoapi #263) these lists are a *break-glass* control layered over the newest-wins default, not the primary selection mechanism.
-
-They meet **only at the shelf** — which now holds only `graduate` forecasts. A graduate-but-undelivered forecast sitting there is fine: it's finished, just not routed anywhere yet.
+The two meet only at the shelf — which now holds only `graduate` forecasts. A graduate-but-undelivered
+forecast sitting there is fine: it is finished, just not routed anywhere yet.
 
 ### 4e. "In production" is derived, never declared
 > A source is *in production* ⟺ its maturity is `graduate` **and** a delivery ships it (directly, or via a composite that contains it) to a **production-tier** consumer.
@@ -219,46 +229,14 @@ Nobody types "deployed." "Is this in production?" is worked out on demand from t
 
 *Analogy:* a sticky note reading *"light: ON"* can be wrong; but *checking that there's a working bulb **and** the switch is wired and flipped* cannot.
 
-### 4f. The delivery file, in full
+### 4f. What a delivery file looks like
 
-**What this section does:** shows the whole file, and explains why it has the shape it has. This is the file a research assistant is asked to fill in, so it is written to be filled in by someone who has never read the rest of this document.
+**ADR-019** decides the format: one file per consumer at `deliveries/<consumer>.py`, the filename
+carrying the consumer's identity, and the body split into what the delivery *does* and what it
+*requires*.
 
-```python
-# deliveries/un_ocha.py          <- the filename is the consumer
-
-DELIVERY = Delivery(
-    send      = [pgm("skinny_love"),
-                 cm("fat_smooch")],
-    frequency = monthly,
-    intent    = live(),
-)
-
-REQUIRE = Require(
-    reconciled = True,
-    targets    = ("lr_ged_sb", "lr_ged_ns", "lr_ged_os"),
-    coverage   = "land_gaul",
-    max_age    = months(2),
-)
-```
-
-Read aloud, that is: *"we send skinny_love and fat_smooch to OCHA, monthly, and it is switched on; they must be reconciled with each other, carry these three targets, cover land_gaul, and not be older than two months."* If that sentence is what you were told to do, the file is right.
-
-**Two blocks, and the difference between them is the point.**
-
-- **`DELIVERY` decides.** Change a line here and something different happens.
-- **`REQUIRE` refuses.** Change a line here and nothing different is produced — a different set of things is *rejected*.
-
-The rule, and it is testable: **removing a line from `REQUIRE` must never change what is produced, only what is allowed through.** If removing it changes the output, it was a setting and belongs above.
-
-This split exists for a concrete reason. Today the file that decides which forecast reaches the UN is `postprocessors/un_fao/configs/config_meta.py`, whose own docstring says *"This config is for documentation purposes only, and modifying it will not affect the model."* That sentence is false, and it is false because settings and descriptions were mixed in one place with nothing to tell them apart. Two blocks make the distinction impossible to lose.
-
-**`pgm(...)` and `cm(...)` are claims, not settings.** The level already lives on the ensemble (`"level": "pgm"`). Writing `pgm("skinny_love")` does not *set* anything — it states what you believe, and the system refuses if the ensemble disagrees. That is why `level` does not appear in `REQUIRE`: it is asserted at the point where you name the source, which is where a reader would look for it. The same shape extends — `admin1(...)` will exist the day an admin-1 source does, and not before.
-
-**`frequency` is required.** There is no safe default. An unlabelled delivery is either picked up by nothing — which is a silent non-delivery, the exact failure this ADR exists to prevent — or picked up by everything, which means a weekly runner ships monthly products. Requiring it also does something useful: `monthly_run.sh` stops being a hand-kept list of five paths and becomes a **filter** over declarations. What runs, and in what order, is then derived from the same declarations a human reads.
-
-**`intent` is declared; status is derived.** §4e already establishes that "in production" is worked out, never typed. `intent` is the other half: the thing you *do* type, kept deliberately in a different word so the two are never confused. A delivery is either `live()` or `paused(reason, since=...)` — and pausing **requires a reason and a date**, because §1's real disease was two halves quietly waiting with nobody able to see it. A paused delivery with a six-month-old date is then a visible fact rather than an absence.
-
-**Why not simply delete the file to turn a delivery off?** Because deleting it throws away the reason. `paused("OCHA bucket not in the registry yet — ask Simon", since="2026-08-04")` is a sentence the next person can act on. An absent file is not.
+It is a separate ADR because it will be revised as `deliveries/` is built and used, while the three
+axes above should not need to change at all.
 
 ## 5. Coherence rules (fail-loud)
 
@@ -271,12 +249,12 @@ This split exists for a concrete reason. Today the file that decides which forec
 
 **Delivery rules:**
 
-- **Tier rule** (needs the delivery edge — so it's checked at the delivery boundary): a delivery to a **production-tier** consumer requires its source to be `graduate`.
-- **Resolution rule:** every source a delivery names must resolve to a real source, and the consumer — taken from the **filename** — must exist in `meta/consumers.py`.
-- **Level rule:** `pgm("x")` fails unless `x` declares `"level": "pgm"`. The claim is checked against the source's own config; neither is authoritative over the other, they simply must agree.
-- **Reconciliation rule:** with `reconciled = True` and two or more sources, the `reconciliation` / `reconcile_with` declarations *among those sources* must form **one connected group covering every source listed**. A source in the delivery that reconciles with nothing, or with something outside the delivery, is an error naming both files.
-  With `reconciled = False` and two or more sources: **hard error.** Shipping several sources with no stated relationship between them is not currently supported — no use-case has emerged, and the failure it would allow (a country total that disagrees with the sum of its cells, silently) is worse than either source alone.
-- **Freshness rule:** a delivery whose `intent` is `live()` must declare `max_age`, and refuses to ship a run older than it. This is the rule whose absence let a partner receive nothing for five months while a complete forecast sat unshipped.
+- **Tier rule** (needs the delivery edge — so it is checked at the delivery boundary): a delivery to a
+  **production-tier** consumer requires its sources to be `graduate`.
+- **Resolution rule:** every source a delivery names must resolve to a real source.
+
+The rules specific to the delivery *file* — level claims, the reconciliation graph, freshness — are in
+**ADR-019 §4**, because they change with the format rather than with the model.
 
 The delivery boundary is the authoritative gate; the config-load checks just shorten the feedback loop. Because R1/R2 need no delivery knowledge, an incoherent ensemble is caught even while it sits undelivered.
 
@@ -335,7 +313,7 @@ Also: making the main line an explicit delivery unit adds new structure on the m
 ## 11. Implementation (phased — not big-bang)
 
 - **Phase 0 (this ADR):** the shared model. Zero code.
-- **Phase 1 — cheap, local, breaks nothing published:** revive the dead guard (R2); add `meta/consumers.py`; create `deliveries/` with **`un_fao.py` written first as a description of what already runs** — a characterisation, not a change — then lift FAO's `"ensemble"` line out of `config_meta.py`; derive `is_in_production`. *(Amendment 1: do this **before** views-models#333 clones `postprocessors/un_fao/` into `un_crafd/`, so the second consumer arrives as a declaration rather than as a second copy of an invisible edge.)*
+- **Phase 1 — cheap, local, breaks nothing published:** revive the dead guard (R2); create `deliveries/` (ADR-019) with **`un_fao.py` written first as a description of what already runs** — a characterisation, not a change — then lift FAO's `"ensemble"` line out of `config_meta.py`; derive `is_in_production`. *(Sequencing: do this **before** views-models#333 clones `postprocessors/un_fao/` into a second consumer directory, so consumer number two arrives as a declaration rather than as a second copy of an invisible edge.)*
 - **Phase 2 — cross-repo, deliberate:** the `deployment_status → maturity` rename + value remap + the pipeline-core contract + ADR-003; rename the file `config_deployment.py → config_maturity.py`; delete the silent log-stamp default.
   Do this with a **dual-vocabulary transition window** — the sniffer accepts both old and new values, warns on the old, and flips to new-only in a later major (the gid→id playbook). It **cannot** ride the pipeline-core 3.0 release, so it lands as a post-3.0 major or its own coordinated bump.
 - **Phase 3 — structural:** make the main public line an explicit delivery unit; add the **shelf write-gate** (only `graduate` writes).
@@ -352,12 +330,12 @@ Also: making the main line an explicit delivery unit adds new structure on the m
 - Gate split by boundary: maturity gates the write, delivery gates the serve; the producer never reads consumer config.
 - Maturity rules **R1** (no retired member in an active ensemble) + **R2** (graduate ensemble → all-graduate members).
 
-**Decided in Amendment 1 (2026-08-04):**
+**Decided — the delivery unit** (the detail is ADR-019):
 
 - **Delivery-unit home: `deliveries/<consumer>.py`.** Decided on legibility rather than architecture — the architecture was indifferent between this and `postprocessors/`, but the person filling one in is not. They arrive asking *"how do I send this to them?"*, not *"where are the postprocessors?"* — and `un_fao` does not post-process anything, it delivers.
-- **Delivery-unit weight: lightweight.** A delivery **declares**; it never transforms. Transformation stays in views-postprocessing, where the wire and the delivery rules already live. If a delivery file ever grows transformation logic we have rebuilt `postprocessors/` under a new name, and the rule above is how you notice.
-- **A delivery may name several sources**, and their relationship is asserted (`reconciled`), never configured here — the pairing already lives on the ensembles.
-- **Settings and assertions are separated syntactically** (`DELIVERY` vs `REQUIRE`, §4f), because conflating them is how a config ended up claiming it does nothing while deciding what reaches the UN.
+- **Delivery-unit weight: lightweight.** A delivery **declares**; it never transforms. If a delivery file ever grows transformation logic we have rebuilt `postprocessors/` under a new name.
+
+The file's shape, its keys and its rules are ADR-019's.
 
 **Deferred / open (stated plainly — not smuggled as decided):**
 - **Scheduled candidate / shadow ensembles** (e.g. a `views_shadow` endpoint run monthly): shared prod shelf tier-tagged, or a separate shadow shelf? *Revisit soon.*
@@ -365,49 +343,16 @@ Also: making the main line an explicit delivery unit adds new structure on the m
 - **`config_meta.py` cleanup:** the "documentation only" docstring must stop being a lie once delivery moves out.
 - **The guard's stale-log gap:** even the live `deprecated`-member check reads the member's *artifact-time log*, so a member deprecated *after* its artifacts were generated slips through (register-worthy, Tier-3).
 
-## 13. Errors must descend — and we must say where the stairs end
+## 13. Errors
 
-**What this section does:** states the rule that makes the rest of this ADR usable by the person who will actually use it, and is honest about the four places that rule stops working.
-
-**Who this is for.** The person filling in a delivery file is, realistically, a research assistant with a social-science background who is good at Python *compared to social scientists*. They will only ever edit **this** repository. They cannot publish a package, edit the coordinate registry, or open a pull request against an API repo. Designing for anyone else is designing for someone we do not have.
-
-**The rule.** When a delivery file is wrong, the error sends the reader **exactly one level down**, naming the file to open next. Never sideways, never into another repository, never in a circle.
-
-| what is wrong | where the error sends you |
-|---|---|
-| `pgm("skinny_love")` but it declares `cm` | `ensembles/skinny_love/configs/config_meta.py` |
-| `reconciled = True` but the partner is someone else | the same file — `reconcile_with` is on the next line |
-| `reconcile_with` names an ensemble that does not exist | `ensembles/` — and the closest name to what was typed |
-| an active ensemble contains a retired member (R1) | `config_modelset.py`, then `models/<member>/configs/` |
-
-Four steps, each one down, no loops. **Error messages are load-bearing architecture here, not politeness.** They are also the least-tested thing in any codebase, so each of these messages gets a test asserting it names the next file — otherwise the staircase quietly rots in its second month.
-
-### Where the stairs end
-
-Three of the checks cannot be answered inside this repository, and one failure has no message at all. Pretending otherwise would be the same dishonesty as a config that claims it does nothing.
-
-- **`coverage`** — the cell counts that define `land_gaul` live in views-postprocessing, beside the GAUL asset. They belong there.
-- **`targets`** — checked against the manifests of a real run in the shelf. Not a file; a network resource. *(And it cannot be moved earlier until a source's config truthfully describes what it emits — `rusty_bucket` today declares `lr_*_best` and produces `lr_ged_*`. Until that is fixed, an edit-time target check would fail a correct delivery file, and the first thing the repo would teach a newcomer is that its errors are wrong.)*
-- **A genuinely new consumer** — needs a bucket in the coordinate registry (views-appwrite) and a producer package (views-postprocessing). `meta/consumers.py` is in this repo; what it points at is not.
-- **A `live()` delivery that nothing ever runs.** No error exists, because nothing failed. This is not a locked door — it is a hole in the floor, and it is the failure that has actually happened. The `max_age` rule in §5 and the derived-status report in §7 are the floor.
-
-**What an error must do when the stairs end.** It must terminate in **a named person and a request they can send** — never in a task the reader cannot perform:
-
-```
-un_ocha is not a registered consumer.
-
-  Consumers live in meta/consumers.py. Registering one needs a bucket
-  address from the platform coordinate registry, which is in another
-  repository you are not expected to edit.
-
-  Ask Simon, or open an issue: "Register consumer un_ocha (bucket + API)".
-  Everything else in this file is fine — this is the only thing blocking it.
-```
-
-That last line is the difference between a handoff and a dead end. A locked door that also tells you the rest of your work is correct is a good place to stop; one that does not is where people give up and ask someone to do it for them, which is how delivery became undiscoverable in the first place (§2).
+When a config here is wrong, the error must send the reader **exactly one level down**, naming the
+next file — and where the reader cannot go further, name a person rather than a task they cannot
+perform. That rule governs the whole repository, not just delivery, so it is **ADR-020**.
 
 ## References
 
+- **ADR-019** (the delivery declaration) and **ADR-020** (errors must descend) — split out of this document 2026-08-04.
+- **`docs/forecast_delivery_map.md`** — how delivery works today; this ADR's §1 lives there.
 - ADR-001 (ontology), ADR-002 (topology), ADR-003 (authority — the `deployment_status` allowed-list), ADR-016 (the same derive-don't-declare instinct).
 - views-postprocessing **ADR-013** (the wire half; see §6).
 - pipeline-core **Lean Platform End-State Roadmap** (`documentation/plans/2026-07-27_lean_platform_end_state_roadmap.md`) — owns the sequencing/retirement this ADR's §1 direction-of-travel defers; the basis for this ADR's acceptance.

--- a/docs/ADRs/017_source_composition_delivery.md
+++ b/docs/ADRs/017_source_composition_delivery.md
@@ -1,6 +1,7 @@
 # ADR-017: Forecast Sources, Composition, and Delivery — separating what a model *is*, what it's *built from*, and *where it goes*
 
-**Status:** **Accepted** (2026-07-27)
+**Status:** **Accepted** (2026-07-27) — **amended 2026-08-04**
+**Amendment 1 (2026-08-04):** the delivery declaration gets a concrete file format, and the two questions §12 left open — *where a delivery unit lives* and *how heavy it is* — are **decided**. Nothing in §3's three axes, §4e's derived production status, or §5's maturity rules changed. What changed is that a delivery can now carry **more than one source** (a grid-cell ensemble and the country-level ensemble it reconciles against), and that the file is split into what it *does* and what it *requires*. New: §4f (the file), §5's three added rules, §13 (errors must descend).
 **Date:** 2026-07-02 — **revised 2026-07-27** (grounded top-to-bottom in the real cross-repo flow; operational mechanics written from scratch; decided-vs-open made explicit. The core decision is unchanged.)
 **Accepted on the basis that** it aligns with pipeline-core's *Lean Platform End-State Roadmap* (`views-pipeline-core/documentation/plans/2026-07-27_lean_platform_end_state_roadmap.md`), which owns the sequencing/retirement this ADR's §1 direction-of-travel defers. The two documents adopt each other's vocabulary and read as one system.
 **Deciders:** Simon (maintainer) — Accepted 2026-07-27
@@ -163,9 +164,11 @@ The three axes, and where each one lives:
   *(`baseline` is not a maturity — it's a role, already captured by the algorithm + `regression_point_baselines`. It leaves this file entirely.)*
 - **Composition** — an ensemble's members.
   *Where:* `ensembles/<e>/configs/config_modelset.py` — **already exists, unchanged.**
-- **Delivery** — a `source → consumer` edge.
-  *Where:* a delivery unit's `config_delivery.py` (e.g. `views-models/postprocessors/un_fao/configs/config_delivery.py`) — **never on the source**. Each consumer is also registered once, with a tier, in `views-models/meta/consumers.py`.
-  *(This lifts today's buried `"ensemble"` line into a dedicated, honest file.)*
+- **Delivery** — a `sources → consumer` edge.
+  *Where:* one file per consumer, at `views-models/deliveries/<consumer>.py` — **never on the source**. The **filename is the consumer**; no key repeats it, so the two cannot disagree. Each consumer is registered once, with a tier, in `views-models/meta/consumers.py`.
+  *(This lifts today's buried `"ensemble"` line into a dedicated, honest file. §4f gives the format in full.)*
+
+  **Why *sources*, plural.** A consumer may need a grid-cell forecast **and** the country-level forecast it was reconciled against. Both are real products: summing grid-cell *draws* does not reproduce a country-level *distribution*, so a consumer computing national uncertainty needs the country model's own posterior, not a reconstruction. The delivery names both.
 
 So, in one line: a **model's** config declares only its maturity. An **ensemble's** config declares its maturity **plus** its members. Neither says anything about delivery or "deployed."
 
@@ -178,9 +181,10 @@ So, in one line: a **model's** config declares only its maturity. An **ensemble'
 
 - **A single model → an endpoint:**
   1. `maturity: graduate` in the model's config;
-  2. a delivery unit's `config_delivery.py` = `{"source": "<model>", "consumer": "<endpoint>"}`;
+  2. a file `deliveries/<endpoint>.py` whose `send` names that model;
   3. `<endpoint>` registered in `meta/consumers.py` with `tier: prod`.
-- **An ensemble → an endpoint:** identical, with `"source": "<ensemble>"`.
+- **An ensemble → an endpoint:** identical — `send` names the ensemble.
+- **A grid-cell ensemble reconciled against a country-level one → an endpoint:** `send` names **both**, and `REQUIRE.reconciled = True`. The pairing itself is not restated here; it already lives on the ensembles (`reconciliation` + `reconcile_with`), and §5's reconciliation rule checks that what you listed matches what they declare.
 - **A model, inside an ensemble → an endpoint:** add it to the ensemble's `config_modelset.py`; make both the model and the ensemble `graduate`; declare the ensemble's delivery edge. The model is now in production *transitively*.
 
 ### 4b. How a forecast reaches the shelf — three guards
@@ -208,12 +212,53 @@ Two variables govern *which already-delivered artifacts* the FAO serving layer (
 
 They meet **only at the shelf** — which now holds only `graduate` forecasts. A graduate-but-undelivered forecast sitting there is fine: it's finished, just not routed anywhere yet.
 
-### 4d. "In production" is derived, never declared
+### 4e. "In production" is derived, never declared
 > A source is *in production* ⟺ its maturity is `graduate` **and** a delivery ships it (directly, or via a composite that contains it) to a **production-tier** consumer.
 
 Nobody types "deployed." "Is this in production?" is worked out on demand from those two facts, and never stored — so it can't lie, because there's no field to lie in.
 
 *Analogy:* a sticky note reading *"light: ON"* can be wrong; but *checking that there's a working bulb **and** the switch is wired and flipped* cannot.
+
+### 4f. The delivery file, in full
+
+**What this section does:** shows the whole file, and explains why it has the shape it has. This is the file a research assistant is asked to fill in, so it is written to be filled in by someone who has never read the rest of this document.
+
+```python
+# deliveries/un_ocha.py          <- the filename is the consumer
+
+DELIVERY = Delivery(
+    send      = [pgm("skinny_love"),
+                 cm("fat_smooch")],
+    frequency = monthly,
+    intent    = live(),
+)
+
+REQUIRE = Require(
+    reconciled = True,
+    targets    = ("lr_ged_sb", "lr_ged_ns", "lr_ged_os"),
+    coverage   = "land_gaul",
+    max_age    = months(2),
+)
+```
+
+Read aloud, that is: *"we send skinny_love and fat_smooch to OCHA, monthly, and it is switched on; they must be reconciled with each other, carry these three targets, cover land_gaul, and not be older than two months."* If that sentence is what you were told to do, the file is right.
+
+**Two blocks, and the difference between them is the point.**
+
+- **`DELIVERY` decides.** Change a line here and something different happens.
+- **`REQUIRE` refuses.** Change a line here and nothing different is produced — a different set of things is *rejected*.
+
+The rule, and it is testable: **removing a line from `REQUIRE` must never change what is produced, only what is allowed through.** If removing it changes the output, it was a setting and belongs above.
+
+This split exists for a concrete reason. Today the file that decides which forecast reaches the UN is `postprocessors/un_fao/configs/config_meta.py`, whose own docstring says *"This config is for documentation purposes only, and modifying it will not affect the model."* That sentence is false, and it is false because settings and descriptions were mixed in one place with nothing to tell them apart. Two blocks make the distinction impossible to lose.
+
+**`pgm(...)` and `cm(...)` are claims, not settings.** The level already lives on the ensemble (`"level": "pgm"`). Writing `pgm("skinny_love")` does not *set* anything — it states what you believe, and the system refuses if the ensemble disagrees. That is why `level` does not appear in `REQUIRE`: it is asserted at the point where you name the source, which is where a reader would look for it. The same shape extends — `admin1(...)` will exist the day an admin-1 source does, and not before.
+
+**`frequency` is required.** There is no safe default. An unlabelled delivery is either picked up by nothing — which is a silent non-delivery, the exact failure this ADR exists to prevent — or picked up by everything, which means a weekly runner ships monthly products. Requiring it also does something useful: `monthly_run.sh` stops being a hand-kept list of five paths and becomes a **filter** over declarations. What runs, and in what order, is then derived from the same declarations a human reads.
+
+**`intent` is declared; status is derived.** §4e already establishes that "in production" is worked out, never typed. `intent` is the other half: the thing you *do* type, kept deliberately in a different word so the two are never confused. A delivery is either `live()` or `paused(reason, since=...)` — and pausing **requires a reason and a date**, because §1's real disease was two halves quietly waiting with nobody able to see it. A paused delivery with a six-month-old date is then a visible fact rather than an absence.
+
+**Why not simply delete the file to turn a delivery off?** Because deleting it throws away the reason. `paused("OCHA bucket not in the registry yet — ask Simon", since="2026-08-04")` is a sentence the next person can act on. An absent file is not.
 
 ## 5. Coherence rules (fail-loud)
 
@@ -227,7 +272,11 @@ Nobody types "deployed." "Is this in production?" is worked out on demand from t
 **Delivery rules:**
 
 - **Tier rule** (needs the delivery edge — so it's checked at the delivery boundary): a delivery to a **production-tier** consumer requires its source to be `graduate`.
-- **Resolution rule:** a delivery's `source` and `consumer` must both resolve — a real source, and a consumer in the registry.
+- **Resolution rule:** every source a delivery names must resolve to a real source, and the consumer — taken from the **filename** — must exist in `meta/consumers.py`.
+- **Level rule:** `pgm("x")` fails unless `x` declares `"level": "pgm"`. The claim is checked against the source's own config; neither is authoritative over the other, they simply must agree.
+- **Reconciliation rule:** with `reconciled = True` and two or more sources, the `reconciliation` / `reconcile_with` declarations *among those sources* must form **one connected group covering every source listed**. A source in the delivery that reconciles with nothing, or with something outside the delivery, is an error naming both files.
+  With `reconciled = False` and two or more sources: **hard error.** Shipping several sources with no stated relationship between them is not currently supported — no use-case has emerged, and the failure it would allow (a country total that disagrees with the sum of its cells, silently) is worse than either source alone.
+- **Freshness rule:** a delivery whose `intent` is `live()` must declare `max_age`, and refuses to ship a run older than it. This is the rule whose absence let a partner receive nothing for five months while a complete forecast sat unshipped.
 
 The delivery boundary is the authoritative gate; the config-load checks just shorten the feedback loop. Because R1/R2 need no delivery knowledge, an incoherent ensemble is caught even while it sits undelivered.
 
@@ -244,7 +293,7 @@ Like a parcel: **vpp-013 standardises the packaging; ADR-017 writes the address.
 
 ## 7. The derived state has an instrument
 
-"Derived from what, verified how?" The declaration side is §4d. The *verification* side is code: `tools/liveness` (epic #238) observes every delivery surface — the shelf, `unfao_bucket`, the public API — with raw facts.
+"Derived from what, verified how?" The declaration side is §4e. The *verification* side is code: `tools/liveness` (epic #238) observes every delivery surface — the shelf, `unfao_bucket`, the public API — with raw facts.
 
 So "in production" is checkable end-to-end: **declared** (a delivery edge exists) **and observable** (its liveness surface is green). A declared-but-stalled delivery shows up as exactly that, instead of a label nobody can falsify.
 
@@ -286,7 +335,7 @@ Also: making the main line an explicit delivery unit adds new structure on the m
 ## 11. Implementation (phased — not big-bang)
 
 - **Phase 0 (this ADR):** the shared model. Zero code.
-- **Phase 1 — cheap, local, breaks nothing published:** revive the dead guard (R2); lift FAO's `"ensemble"` line out of `config_meta.py` into `config_delivery.py`; add `meta/consumers.py`; derive `is_in_production`.
+- **Phase 1 — cheap, local, breaks nothing published:** revive the dead guard (R2); add `meta/consumers.py`; create `deliveries/` with **`un_fao.py` written first as a description of what already runs** — a characterisation, not a change — then lift FAO's `"ensemble"` line out of `config_meta.py`; derive `is_in_production`. *(Amendment 1: do this **before** views-models#333 clones `postprocessors/un_fao/` into `un_crafd/`, so the second consumer arrives as a declaration rather than as a second copy of an invisible edge.)*
 - **Phase 2 — cross-repo, deliberate:** the `deployment_status → maturity` rename + value remap + the pipeline-core contract + ADR-003; rename the file `config_deployment.py → config_maturity.py`; delete the silent log-stamp default.
   Do this with a **dual-vocabulary transition window** — the sniffer accepts both old and new values, warns on the old, and flips to new-only in a later major (the gid→id playbook). It **cannot** ride the pipeline-core 3.0 release, so it lands as a post-3.0 major or its own coordinated bump.
 - **Phase 3 — structural:** make the main public line an explicit delivery unit; add the **shelf write-gate** (only `graduate` writes).
@@ -303,14 +352,59 @@ Also: making the main line an explicit delivery unit adds new structure on the m
 - Gate split by boundary: maturity gates the write, delivery gates the serve; the producer never reads consumer config.
 - Maturity rules **R1** (no retired member in an active ensemble) + **R2** (graduate ensemble → all-graduate members).
 
-**Deferred / open (stated plainly — not smuggled as decided):**
+**Decided in Amendment 1 (2026-08-04):**
 
-- **Delivery-unit home:** `postprocessors/` (exists) vs a new `deliveries/` folder vs both.
-- **Delivery-unit weight:** is every delivery unit a full postprocessor (like `un_fao`), or can it be lightweight when no transformation is needed?
+- **Delivery-unit home: `deliveries/<consumer>.py`.** Decided on legibility rather than architecture — the architecture was indifferent between this and `postprocessors/`, but the person filling one in is not. They arrive asking *"how do I send this to them?"*, not *"where are the postprocessors?"* — and `un_fao` does not post-process anything, it delivers.
+- **Delivery-unit weight: lightweight.** A delivery **declares**; it never transforms. Transformation stays in views-postprocessing, where the wire and the delivery rules already live. If a delivery file ever grows transformation logic we have rebuilt `postprocessors/` under a new name, and the rule above is how you notice.
+- **A delivery may name several sources**, and their relationship is asserted (`reconciled`), never configured here — the pairing already lives on the ensembles.
+- **Settings and assertions are separated syntactically** (`DELIVERY` vs `REQUIRE`, §4f), because conflating them is how a config ended up claiming it does nothing while deciding what reaches the UN.
+
+**Deferred / open (stated plainly — not smuggled as decided):**
 - **Scheduled candidate / shadow ensembles** (e.g. a `views_shadow` endpoint run monthly): shared prod shelf tier-tagged, or a separate shadow shelf? *Revisit soon.*
 - **Two stores today** (the legacy `views-forecasts` store for the public API + the Appwrite `production_forecasts` shelf): eventual consolidation, and the maintainer's "on Hetzner one day" intent — not now.
 - **`config_meta.py` cleanup:** the "documentation only" docstring must stop being a lie once delivery moves out.
 - **The guard's stale-log gap:** even the live `deprecated`-member check reads the member's *artifact-time log*, so a member deprecated *after* its artifacts were generated slips through (register-worthy, Tier-3).
+
+## 13. Errors must descend — and we must say where the stairs end
+
+**What this section does:** states the rule that makes the rest of this ADR usable by the person who will actually use it, and is honest about the four places that rule stops working.
+
+**Who this is for.** The person filling in a delivery file is, realistically, a research assistant with a social-science background who is good at Python *compared to social scientists*. They will only ever edit **this** repository. They cannot publish a package, edit the coordinate registry, or open a pull request against an API repo. Designing for anyone else is designing for someone we do not have.
+
+**The rule.** When a delivery file is wrong, the error sends the reader **exactly one level down**, naming the file to open next. Never sideways, never into another repository, never in a circle.
+
+| what is wrong | where the error sends you |
+|---|---|
+| `pgm("skinny_love")` but it declares `cm` | `ensembles/skinny_love/configs/config_meta.py` |
+| `reconciled = True` but the partner is someone else | the same file — `reconcile_with` is on the next line |
+| `reconcile_with` names an ensemble that does not exist | `ensembles/` — and the closest name to what was typed |
+| an active ensemble contains a retired member (R1) | `config_modelset.py`, then `models/<member>/configs/` |
+
+Four steps, each one down, no loops. **Error messages are load-bearing architecture here, not politeness.** They are also the least-tested thing in any codebase, so each of these messages gets a test asserting it names the next file — otherwise the staircase quietly rots in its second month.
+
+### Where the stairs end
+
+Three of the checks cannot be answered inside this repository, and one failure has no message at all. Pretending otherwise would be the same dishonesty as a config that claims it does nothing.
+
+- **`coverage`** — the cell counts that define `land_gaul` live in views-postprocessing, beside the GAUL asset. They belong there.
+- **`targets`** — checked against the manifests of a real run in the shelf. Not a file; a network resource. *(And it cannot be moved earlier until a source's config truthfully describes what it emits — `rusty_bucket` today declares `lr_*_best` and produces `lr_ged_*`. Until that is fixed, an edit-time target check would fail a correct delivery file, and the first thing the repo would teach a newcomer is that its errors are wrong.)*
+- **A genuinely new consumer** — needs a bucket in the coordinate registry (views-appwrite) and a producer package (views-postprocessing). `meta/consumers.py` is in this repo; what it points at is not.
+- **A `live()` delivery that nothing ever runs.** No error exists, because nothing failed. This is not a locked door — it is a hole in the floor, and it is the failure that has actually happened. The `max_age` rule in §5 and the derived-status report in §7 are the floor.
+
+**What an error must do when the stairs end.** It must terminate in **a named person and a request they can send** — never in a task the reader cannot perform:
+
+```
+un_ocha is not a registered consumer.
+
+  Consumers live in meta/consumers.py. Registering one needs a bucket
+  address from the platform coordinate registry, which is in another
+  repository you are not expected to edit.
+
+  Ask Simon, or open an issue: "Register consumer un_ocha (bucket + API)".
+  Everything else in this file is fine — this is the only thing blocking it.
+```
+
+That last line is the difference between a handoff and a dead end. A locked door that also tells you the rest of your work is correct is a good place to stop; one that does not is where people give up and ask someone to do it for them, which is how delivery became undiscoverable in the first place (§2).
 
 ## References
 

--- a/docs/ADRs/017_source_composition_delivery.md
+++ b/docs/ADRs/017_source_composition_delivery.md
@@ -1,6 +1,11 @@
 # ADR-017: Forecast Sources, Composition, and Delivery — separating what a model *is*, what it's *built from*, and *where it goes*
 
-**Status:** **Accepted** (2026-07-27) — **amended 2026-08-04**
+**Status:** **Accepted** (2026-07-27) — **revised 2026-08-04**
+**Date:** 2026-07-27 (revised 2026-08-04)
+**Deciders:** Simon (maintainer)
+**Consulted:** platform contributors
+**Informed:** all contributors
+
 **Revised 2026-08-04 — split for containment.** This document had grown to ~13 pages and held four
 things that change at four different rates. Three moved out, and **no decision was reversed**:
 
@@ -14,9 +19,6 @@ What stays here is the part that should not need to change: the three axes, deri
 the maturity rules, and the shelf write-gate. Per ADR-000 this is a **re-organisation, not a
 supersession** — 017 keeps its number and its decisions.
 
-**Deciders:** Simon (maintainer) — Accepted 2026-07-27
-**Consulted:** platform contributors
-**Informed:** all contributors
 
 ---
 
@@ -71,7 +73,10 @@ measured on 2026-08-04 and names how to re-check it.
   **And it is inert.** Nothing anywhere branches `deployed`-vs-`shadow`; that is pinned in both
   repositories by `tests/test_deployment_status_inert.py`, which greps this repo *and* the installed
   `views_pipeline_core` for such a comparison and fails if one appears.
-  *Measured across all 131 sources:* **120 `shadow`, 6 `baseline`, 4 `deprecated`, 1 `deployed`.*
+  *Measured 2026-08-04:* **117 `shadow`, 6 `baseline`, 4 `deprecated`, 1 `deployed`** — 128 files, across
+  132 source directories. *(Re-check with a pattern covering **both** quote styles: 81 of the 128 write
+  `{'deployment_status': 'shadow'}`, 47 write `{"deployment_status": "shadow"}`. A double-quote-only
+  grep reports 47 and silently omits the rest — register C-127.)*
 - **The one `deployed` thing in the repository is incoherent.** That single `deployed` source is
   `ensembles/white_mustang`, and both its members — `lavender_haze` and `blank_space` — are `shadow`.
   A deployed ensemble made entirely of things that are not deployed.
@@ -113,7 +118,20 @@ The three axes, and where each one lives:
   *Where:* one file per consumer, at `views-models/deliveries/<consumer>.py` — **never on the source**. The **filename is the consumer**; no key repeats it, so the two cannot disagree.
   *(This lifts today's buried `"ensemble"` line into a dedicated, honest file. **ADR-019** gives the format.)*
 
-  **Why *sources*, plural.** A consumer may need a grid-cell forecast **and** the country-level forecast it was reconciled against. Both are real products: summing grid-cell *draws* does not reproduce a country-level *distribution*, so a consumer computing national uncertainty needs the country model's own posterior, not a reconstruction. The delivery names both.
+  **Why *sources*, plural.** A consumer may need a grid-cell forecast **and** the country-level forecast
+  it was reconciled against. Both are real products, and one cannot be derived from the other: summing
+  grid-cell *draws* does not reproduce a country-level *distribution*, because the sum of marginals is
+  not the marginal of the sum unless the joint is preserved.
+
+  This matters here rather than being a statistical aside, because **the platform is
+  distribution-native**. Its PredictionFrame ensembles ship uncollapsed pooled draws and consumers
+  compute distributional quantities at serve time — highest-density intervals in one case today,
+  threshold-exceedance probabilities in another. A consumer computing national uncertainty therefore
+  needs the country-level model's own posterior, not a reconstruction of it. That is a claim about the
+  *kind* of product this platform ships, not about any particular ensemble or API.
+
+  So the delivery edge names **both** sources. ADR-019 gives that the syntax (`send` takes a list) and
+  cites this section rather than restating the argument.
 
 So, in one line: a **model's** config declares only its maturity. An **ensemble's** config declares its
 maturity **plus** its members. Neither says anything about delivery or "deployed."
@@ -167,8 +185,15 @@ that only `deprecated` does anything.
 |---|---|---|
 | `shadow` | `candidate` | the bulk of the fleet |
 | `deprecated` | `retired` | the only value with behaviour today |
-| `baseline` | *(nothing)* | a role, not a maturity — leaves this file (see above) |
+| `baseline` | `candidate` | the **role** leaves this file; the source still needs a maturity |
 | `deployed` | `graduate` **only if R2 holds**, else `candidate` | see below |
+
+**Two groups the table alone does not cover.** The six `baseline` sources keep their *role* — it already
+lives in the algorithm plus `regression_point_baselines`, which is why it leaves this file — and take
+`candidate` as their maturity, because nothing about being a baseline makes a source eligible to ship.
+And four source directories have **no `config_deployment.py` at all** (`models/cool_cat`,
+`models/teenage_dirtbag`, `models/test_model`, `ensembles/test_ensemble`), so they have nothing to
+migrate *from*; they get `config_maturity.py` created with `candidate`.
 
 **Why `deployed` is not a straight rename.** Mapped naively it breaks R2 immediately: measured
 2026-08-04, exactly one source is `deployed` — an ensemble whose two members are both `shadow`. A
@@ -226,6 +251,12 @@ forecast sitting there is fine: it is finished, just not routed anywhere yet.
 > A source is *in production* ⟺ its maturity is `graduate` **and** a delivery ships it (directly, or via a composite that contains it) to a **production-tier** consumer.
 
 Nobody types "deployed." "Is this in production?" is worked out on demand from those two facts, and never stored — so it can't lie, because there's no field to lie in.
+
+*One honest caveat about the second condition.* `tier` currently has exactly **one** value, `prod`
+(ADR-019 §3), so "to a **production-tier** consumer" is today equivalent to "at all". The definition is
+written for the general case and becomes discriminating the moment a second tier value exists — which
+is itself blocked on §12's open shadow-destination question. Until then, do not read the qualifier as a
+check that is running.
 
 *Analogy:* a sticky note reading *"light: ON"* can be wrong; but *checking that there's a working bulb **and** the switch is wired and flipped* cannot.
 

--- a/docs/ADRs/019_delivery_declaration.md
+++ b/docs/ADRs/019_delivery_declaration.md
@@ -1,0 +1,315 @@
+# ADR-019: The delivery declaration — one file per consumer
+
+**Status:** **Accepted** (2026-08-04)
+**Date:** 2026-08-04
+**Deciders:** Simon (maintainer)
+**Builds on:** **ADR-017**, which decides that delivery is a `sources → consumer` edge written on the
+destination. This ADR decides *what that file looks like*. ADR-017 can stand without this; this cannot
+stand without ADR-017.
+**Origin:** extracted from ADR-017 §4f/§4d/§5 when that document was split for containment.
+
+---
+
+> **A note on names.** Every model, ensemble, consumer, region and target named in this document is an
+> **example**. They are real names where possible, because concrete examples are easier to read than
+> placeholders — but which source feeds which consumer changes, consumers are added and retired, and
+> buckets get renamed. Nothing here is a declaration about a particular name. The rules are about the
+> **shape**; the names are illustration.
+
+---
+
+## Summary
+
+**The problem, in one breath.** ADR-017 says a delivery is an edge written on the destination. It does
+not say what the file contains — and the thing it replaces is one line, `"ensemble": "rusty_bucket"`,
+buried in `postprocessors/un_fao/configs/config_meta.py`, in a file whose own docstring says
+*"This config is for documentation purposes only, and modifying it will not affect the model."* That
+sentence is false. That one line decides which forecast reaches the UN.
+
+**The decision, in one breath.** One file per consumer at `deliveries/<consumer>.py`. The **filename
+is the consumer**. The body has two blocks: `DELIVERY`, which decides what happens, and `REQUIRE`,
+which decides only what is refused.
+
+---
+
+## 1. The file
+
+**An example**, not a specification of a real delivery. `un_ocha`, `skinny_love` and `land_gaul` are
+names that could exist; `fat_smooch` is invented, precisely so that nothing here reads as a statement
+about a delivery we actually make.
+
+```python
+# deliveries/<consumer>.py         <- the filename is the consumer
+# shown here as: deliveries/un_ocha.py
+
+DELIVERY = Delivery(               # DECIDES  — change a line, something different happens
+    send      = [pgm("skinny_love"),
+                 cm("fat_smooch")],
+    frequency = monthly,
+    tier      = prod,
+    intent    = live(),
+)
+
+REQUIRE = Require(                 # REFUSES  — change a line, a different set is rejected
+    reconciled = True,
+    targets    = ("lr_ged_sb", "lr_ged_ns", "lr_ged_os"),
+    coverage   = "land_gaul",
+    max_age    = months(2),
+)
+```
+
+Read aloud: *"we send skinny_love and fat_smooch to OCHA, monthly, to a production consumer, and it is
+switched on; they must be reconciled with each other, carry these three targets, cover land_gaul, and
+be no older than two months."*
+
+If that sentence is what you were told to do, the file is right. That is the whole test of this design.
+
+## 2. Two blocks, and the difference between them is the point
+
+- **`DELIVERY` decides.** Change a line and something different happens.
+- **`REQUIRE` refuses.** Change a line and nothing different is produced — a different set of things
+  is *rejected*.
+
+**The rule, and it is testable: removing a line from `REQUIRE` must never change what is produced,
+only what is allowed through.** If removing it changes the output, it was a setting and belongs above.
+
+This split exists for a specific reason. The file it replaces mixed a setting into a description and
+then described itself as inert. Two blocks make that mistake impossible to repeat, because the
+question *"does this change anything?"* is answered by which block a key is in.
+
+**`REQUIRE` may be omitted entirely** when there is nothing to assert. A block that is always present
+stops carrying information, and the first person to delete an empty one teaches everyone else to
+delete theirs. Specific rules are still required — see §4 — but they are required by the *shape of the
+delivery*, not by ceremony.
+
+## 3. The keys
+
+### Every key, and every value it can take
+
+**Closed** means the allowed values are listed here and anything else is an error. **Open** means the
+value is a name checked against something else, so no list can be complete.
+
+| key | block | allowed values | set | what changes if you change it |
+|---|---|---|---|---|
+| `send` | DELIVERY | a list of `pgm(<source>)`, `cm(<source>)` | closed *(the wrappers)* | **which** forecast the consumer receives |
+| `frequency` | DELIVERY | `monthly` | closed — 1 value | **which** scheduled run picks it up |
+| `tier` | DELIVERY | `prod` | closed — 1 value | **whether** sources must be `graduate` |
+| `intent` | DELIVERY | `live()`, `paused(reason, since=…)` | closed — 2 values | **whether** it ships at all |
+| `reconciled` | REQUIRE | `True`, `False` | closed — 2 values | which source *combinations* are refused |
+| `targets` | REQUIRE | a tuple of target names | **open** — checked against a run's manifests | a run missing one is refused |
+| `coverage` | REQUIRE | one region name | **open** — checked against views-postprocessing | a run with the wrong cell count is refused |
+| `max_age` | REQUIRE | `months(n)` | closed *(the wrapper)*, `n` free | an older run is refused |
+
+**Three of the closed sets have exactly one or two values today.** That is stated so it cannot be
+mistaken for a rich vocabulary that merely looks small in an example. Each is explained below, with
+what would add to it.
+
+**The two open sets are the two checks that leave this repository** — §4's *Where these run*, and
+ADR-020 §4's boundaries. They are open for the same reason: neither target names nor region cell
+counts are facts this repository owns.
+
+The DELIVERY / REQUIRE split from §2 is visible in the last column: the top four say *which* or
+*whether*; every one of the bottom four says *refused*. That is mechanical enough to test.
+
+### The level wrappers inside `send`
+
+| wrapper | means | exists? |
+|---|---|---|
+| `pgm(<source>)` | the source declares `"level": "pgm"` — grid cell | **yes**, 60 configs |
+| `cm(<source>)` | the source declares `"level": "cm"` — country-month | **yes**, 68 configs |
+| `admin1(<source>)` | *(not built)* | no admin-1 source exists |
+
+`cm` and `pgm` are the **only** two values `"level"` takes anywhere in this repository today. A third
+wrapper arrives with a third source, not before (§3, `send`).
+
+**`send` — one or more sources, each with its level claimed.**
+
+`pgm("skinny_love")` does not *set* the level. The level already lives on the ensemble
+(`"level": "pgm"`). Writing `pgm(...)` states what you believe, and the system refuses if the source
+disagrees. That is why `level` does not appear in `REQUIRE`: it is asserted where you name the source,
+which is where a reader looks for it. The shape extends — `admin1(...)` will exist the day an admin-1
+source does, and not before.
+
+**Why sources are plural.** A consumer may need a grid-cell forecast **and** the country-level forecast
+it was reconciled against. Both are real products. Summing grid-cell *draws* does not reproduce a
+country-level *distribution* — sum of marginals is not the marginal of the sum unless the joint is
+preserved — and **this platform is distribution-native**. Its PredictionFrame ensembles ship
+uncollapsed pooled draws, and consumers compute distributional quantities at serve time: HDI and MAP
+in one case today, threshold-exceedance probabilities in another. A consumer computing national
+uncertainty therefore needs the country-level model's own posterior, not a reconstruction of it.
+
+That is a claim about the *kind* of product this platform ships, not about any particular ensemble or
+API — and it is why `send` takes a list rather than a single source.
+
+It also answers the simpler case: a country-level-only delivery names one country-level source —
+`send = [cm("<some cm ensemble>")]`. Same key, different source, no schema change.
+
+**`frequency` — required, and today `monthly` is the only value.** There is no safe default. An unlabelled delivery is either picked up by
+nothing — a silent non-delivery, the exact failure ADR-017 exists to prevent — or picked up by
+everything, so a weekly runner ships monthly products.
+
+Requiring it does something further: **`monthly_run.sh` stops being a hand-kept list of five paths and
+becomes a filter over declarations.** What runs, and in what order, is then derived from the same
+declarations a human reads, rather than typed a second time. Today's order is an unstated data
+dependency (register C-122); this removes the need to state it.
+
+*Why a key with one value:* the alternative is no key, and then a second cadence — a weekly internal
+run, a quarterly partner — is a schema change touching every existing file rather than one new word.
+
+**`tier` — what kind of consumer this is. One value today: `prod`.**
+
+`prod` means an external partner, or anything the public sees. It does exactly one thing: **every
+source must be `graduate`** (ADR-017's maturity axis). That is the whole meaning of the key — it is
+the switch that turns the maturity gate on.
+
+*Stated plainly, because it would otherwise read as decided:* with one value, that gate is currently
+**unconditional** — every delivery requires graduate sources, so `tier` distinguishes nothing yet. That
+is a known temporary state, not a design.
+
+The key exists anyway, for two reasons. ADR-017 already reasons in terms of a *"production-tier
+consumer"* (§5), so the concept is in the accepted decision and needs somewhere to live. And a second
+value is **blocked on a question ADR-017 deliberately left open** (§12): a `candidate` source writes
+nowhere central today, and where a non-production forecast *should* land — a tier-tagged shared shelf,
+or a separate one — is not decided. A second tier value cannot be defined before its destination is.
+
+**Named trigger:** *add a second tier value when ADR-017 §12's shadow-destination question is answered.*
+It must arrive with a rule of its own. A tier that gates nothing is a label, and labels drift.
+
+**Why it lives on the delivery, not in a separate registry.** With one file per consumer, **the file set
+already is the consumer list**: `deliveries/` *is* the register of who we deliver to. A separate
+registry would hold exactly one fact the delivery file does not — the tier — so the tier lives here
+instead, where it is used.
+
+*What that costs, stated plainly:* there is no edit-time check that a consumer is real.
+"Is there an OCHA bucket?" is answered by the platform coordinate registry at run time — one repo away
+and later. ADR-020 §4 already records that boundary as a stair ending outside this repository, so this
+makes an existing limitation visible rather than adding a new one. If an edit-time check is later
+wanted, a registry can return; nothing here forecloses it.
+
+**`intent` — declared; status is derived.** ADR-017 §4e establishes that "in production" is worked out,
+never typed. `intent` is the other half: the thing you *do* type, kept in a different word so the two
+are never confused.
+
+*The complete set is two values. There is no third, and no bare `intent = live` without the call —
+`paused` must carry arguments, so both are constructors for symmetry.*
+
+- **`live()`** — the scheduled runner picks this delivery up at its `frequency`, and the file **must**
+  declare `max_age` (§4). Live is the only state with a freshness obligation, because it is the only
+  state where silence is a failure.
+- **`paused(reason, since=...)`** — the runner skips it. The reason and the date are **required**, and
+  they surface in the status report, so a pause is a visible fact with an age rather than an absence.
+
+The disease being treated is two halves quietly waiting with nobody able to see it. A paused delivery
+carrying a six-month-old date says so out loud.
+
+*Why not delete the file to turn a delivery off?* Because deleting throws away the reason.
+`paused("OCHA bucket not in the registry yet — ask Simon", since="2026-08-04")` is a sentence the next
+person can act on. An absent file is not.
+
+## 4. Coherence rules (fail-loud)
+
+These are ADR-017 §5's rules, specialised to the delivery file. ADR-017's maturity rules (R1/R2) are
+unchanged and remain there.
+
+- **Resolution.** Every source named must resolve to a real source. The consumer — taken from the
+  **filename** — must be a valid identifier; there is no key to disagree with it.
+- **Level.** `pgm("x")` fails unless `x` declares `"level": "pgm"`. Neither is authoritative over the
+  other; they must agree.
+- **Reconciliation.** With `reconciled = True` and two or more sources, the `reconciliation` /
+  `reconcile_with` declarations *among those sources* must form **one connected group covering every
+  source listed**. A source that reconciles with nothing, or with something outside the delivery, is
+  an error naming both files.
+  With `reconciled = False` and two or more sources: **hard error** — *"not currently supported; no
+  meaningful use-case has emerged."* Shipping several sources with no stated relationship silently
+  permits a country total that disagrees with the sum of its cells, which is worse than either source
+  alone.
+- **Freshness.** A delivery whose `intent` is `live()` **must** declare `max_age`, and refuses to ship
+  a run older than it. This is the rule whose absence let a partner receive nothing for five months
+  while a complete forecast sat unshipped (#320, C-121).
+- **Tier.** A delivery to a `prod` consumer requires every source to be `graduate` (ADR-017 §5).
+
+**Where these run.** All of them are answerable inside this repository, at edit time, except `targets`
+and `coverage` — see ADR-020 §4 and §6 below.
+
+## 5. Serving-time curation — the FAO approve / quarantine lists
+
+*(Moved unchanged from ADR-017 §4d; it is delivery-side, not axis-side.)*
+
+Two variables govern *which already-delivered artifacts* the FAO serving layer may return:
+`APPWRITE_UNFAO_APPROVED_FILE_IDS` and `APPWRITE_UNFAO_QUARANTINED_FILE_IDS`. Despite the `APPWRITE_`
+prefix these are **eligibility data, not connection configuration** — they name which delivered
+artifacts are *servable*, an operator decision, not how to reach the store. They therefore belong to
+this contract, not to The Appwrite Seam Contract, whose variable map lists them only as explicit
+exclusions with a pointer back here (þing-01 verdict D3, 6/6 assent — class is *declared*, never
+inferred from a prefix).
+
+- **`APPWRITE_UNFAO_APPROVED_FILE_IDS`** — optional allowlist. When non-empty, only the listed file IDs
+  are servable; a newly delivered artifact is **not** served until approved (break-glass; faoapi C-71).
+- **`APPWRITE_UNFAO_QUARANTINED_FILE_IDS`** — blocklist. Listed IDs are never served, even if newest —
+  how an operator withdraws a bad run.
+
+**Who sets them:** the operator, by editing the deployment environment. They carry non-secret file IDs,
+so they are committable and inspectable — never secret. **Who reads them:** views-faoapi at selection
+time.
+
+## 6. Open — stated plainly, not smuggled as decided
+
+- **Where the vocabulary lives, and how a delivery file is imported.** The file uses `Delivery`,
+  `Require`, `pgm`, `cm`, `monthly`, `live`, `paused`, `months`. Those must come from somewhere.
+  views-models is **not** an installable package — `pyproject.toml` holds only pytest markers — and
+  today `reconciliation/` is imported by a `sys.path.insert(0, parents[2])` bootstrap in each
+  ensemble's `main.py`, with a comment noting that `run.sh` is immutable so `PYTHONPATH` cannot be set
+  there.
+  The readers of `deliveries/` are **tools and tests**, and both already work from the repo root:
+  `python -m tools.liveness` runs today with no install. So no new mechanism is needed for the intended
+  readers.
+  **Deferred, with a named trigger:** *make views-models an installable package when a `main.py` needs
+  to import `deliveries/`.* Today none does — only two `main.py` files import a top-level package at
+  all, both for `reconciliation/`. Doing it now would mean adding `pip install -e .` to 131 `run.sh` or
+  `requirements.txt` files to benefit two.
+- **Whether `admin1(...)` is needed**, and what reconciling three levels means. Not until an admin-1
+  source exists.
+- **Whether an edit-time consumer check is wanted**, which would bring back a registry (§3).
+- **A second `tier` value** — blocked on ADR-017 §12's shadow-destination question, not on this ADR (§3).
+
+## 7. Consequences
+
+**Positive:** "what goes where" collapses from three files in two repositories plus a live bucket query
+into one file; a delivery can be read and tested without executing it; `monthly_run.sh`'s hidden
+ordering dependency becomes derivable; a paused delivery cannot be silent.
+
+**Negative:** one more directory to know about. The vocabulary is a small language someone must learn
+before writing their first line — mitigated only by the errors ADR-020 requires. And `targets` and
+`coverage` are assertions whose checks live outside this repository, so a file that *parses* is not a
+delivery that *works* — the tooling must say which kind of check it just ran.
+
+**Not decided here:** whether a delivery *runs*. This ADR declares; execution is `monthly_run.sh`
+filtering on `frequency`, and that filter does not yet exist.
+
+## 8. Considered alternatives
+
+- **A `to = consumer("un_ocha")` key alongside the filename.** Rejected — two places to state one fact,
+  and nothing to reconcile them. ADR-017's own principle is that a thing which is never typed cannot
+  lie.
+- **`send_pgm` / `send_cm` as separate keys.** Rejected — it names keys after a closed set of levels,
+  duplicates the level already on the source, and does not extend to a third level.
+- **`reconciled` configured here rather than asserted.** Rejected — reconciliation *changes the
+  forecast*, so it belongs to the thing producing it. It is already declared on the ensemble
+  (`reconciliation` + `reconcile_with`) with more information than a boolean. A delivery that
+  transforms is `postprocessors/` rebuilt under a new name.
+- **One central routing table.** Rejected by ADR-017 §9 (alternative B) and still rejected: it
+  duplicates membership and becomes a merge bottleneck.
+
+## References
+
+- **ADR-017** — the three axes; this ADR is the file format for its delivery edge.
+- **ADR-020** — errors must descend; §4's rules are the worked example of its staircase.
+- **views-postprocessing ADR-013** — the wire; owns *how* bytes travel, where this owns *which source
+  ships to which consumer*.
+- `docs/forecast_delivery_map.md` — what the delivery path actually is today.
+- Register: **C-110** (the arming key exists only uncommitted), **C-121** (no age bound),
+  **C-122** (order as an unstated dependency), **C-123**/**C-125** (why `targets` cannot yet be an
+  edit-time check), **C-126** (live-but-never-run survives this design), **D-09** (is `REQUIRE`
+  mandatory).
+- views-models **#333** — the second consumer; should arrive as a declaration under this ADR rather
+  than as a clone of `postprocessors/un_fao/`.

--- a/docs/ADRs/019_delivery_declaration.md
+++ b/docs/ADRs/019_delivery_declaration.md
@@ -70,17 +70,29 @@ If that sentence is what you were told to do, the file is right. That is the who
 - **`REQUIRE` refuses.** Change a line and nothing different is produced — a different set of things
   is *rejected*.
 
-**The rule, and it is testable: removing a line from `REQUIRE` must never change what is produced,
-only what is allowed through.** If removing it changes the output, it was a setting and belongs above.
+**The rule, and it is testable: removing an *optional* `REQUIRE` line must never change what is
+produced, only what is allowed through.** If removing it changes the output, it was a setting and
+belongs above.
+
+**The one exception, named rather than buried: `max_age` is mandatory for a `live()` delivery (§4).**
+Removing it does not widen what is accepted — it makes the file invalid, so nothing ships. That is a
+deliberate asymmetry, not an oversight: a missing freshness bound is the failure that already happened,
+five months of it (#320). A rule stated absolutely with an exception a section later is worse than a
+rule with its exception attached, because an implementer resolving the contradiction toward "`REQUIRE`
+never blocks" would build exactly the gap that caused the incident (register C-128).
 
 This split exists for a specific reason. The file it replaces mixed a setting into a description and
 then described itself as inert. Two blocks make that mistake impossible to repeat, because the
 question *"does this change anything?"* is answered by which block a key is in.
 
-**`REQUIRE` may be omitted entirely** when there is nothing to assert. A block that is always present
-stops carrying information, and the first person to delete an empty one teaches everyone else to
-delete theirs. Specific rules are still required — see §4 — but they are required by the *shape of the
-delivery*, not by ceremony.
+**`REQUIRE` may be omitted entirely — but only for a `paused()` delivery**, which is the only kind with
+nothing mandatory to assert. Every `live()` delivery carries `max_age`, so in practice every delivery
+that ships has a `REQUIRE` block. The allowance is narrow and is stated that way rather than as a
+general permission, because a general one would read as "this block is optional" and it is not.
+
+The reasoning behind the allowance still stands where it applies: a block that is always present stops
+carrying information, and the first person to delete an empty one teaches everyone else to delete
+theirs.
 
 ## 3. The keys
 
@@ -98,7 +110,7 @@ value is a name checked against something else, so no list can be complete.
 | `reconciled` | REQUIRE | `True`, `False` | closed — 2 values | which source *combinations* are refused |
 | `targets` | REQUIRE | a tuple of target names | **open** — checked against a run's manifests | a run missing one is refused |
 | `coverage` | REQUIRE | one region name | **open** — checked against views-postprocessing | a run with the wrong cell count is refused |
-| `max_age` | REQUIRE | `months(n)` | closed *(the wrapper)*, `n` free | an older run is refused |
+| `max_age` | REQUIRE | `months(n)` | closed *(the wrapper)*, `n` free | an older run is refused — **mandatory when `live()`** |
 
 **Three of the closed sets have exactly one or two values today.** That is stated so it cannot be
 mistaken for a rich vocabulary that merely looks small in an example. Each is explained below, with
@@ -130,16 +142,10 @@ disagrees. That is why `level` does not appear in `REQUIRE`: it is asserted wher
 which is where a reader looks for it. The shape extends — `admin1(...)` will exist the day an admin-1
 source does, and not before.
 
-**Why sources are plural.** A consumer may need a grid-cell forecast **and** the country-level forecast
-it was reconciled against. Both are real products. Summing grid-cell *draws* does not reproduce a
-country-level *distribution* — sum of marginals is not the marginal of the sum unless the joint is
-preserved — and **this platform is distribution-native**. Its PredictionFrame ensembles ship
-uncollapsed pooled draws, and consumers compute distributional quantities at serve time: HDI and MAP
-in one case today, threshold-exceedance probabilities in another. A consumer computing national
-uncertainty therefore needs the country-level model's own posterior, not a reconstruction of it.
-
-That is a claim about the *kind* of product this platform ships, not about any particular ensemble or
-API — and it is why `send` takes a list rather than a single source.
+**Why `send` is a list.** Because ADR-017 §3 decided the delivery edge runs from *sources*, plural: a
+consumer may need a grid-cell forecast **and** the country-level forecast it was reconciled against,
+and summing grid-cell draws does not reproduce a country-level distribution. **The full argument lives
+in ADR-017 §3 and is not repeated here** — it justifies the axis, and this ADR only gives it a syntax.
 
 It also answers the simpler case: a country-level-only delivery names one country-level source —
 `send = [cm("<some cm ensemble>")]`. Same key, different source, no schema change.
@@ -199,12 +205,35 @@ are never confused.
 - **`paused(reason, since=...)`** — the runner skips it. The reason and the date are **required**, and
   they surface in the status report, so a pause is a visible fact with an age rather than an absence.
 
+**`intent` is the arming switch — there is not a second one.** Today the FAO delivery is armed by
+`wire_upload_enabled` inside `postprocessors/un_fao/configs/config_meta.py`: views-postprocessing
+ADR-013 §11.4 sets `UPLOAD_ENABLED = False` and makes that launcher key its only override. That key
+and `intent` are **the same fact**, so the tooling **derives** the launcher key from `intent` rather
+than asking anyone to write both. Same principle as the filename carrying the consumer: a thing that
+is never typed twice cannot disagree with itself.
+
+This matters more than a tidy-up. Without it, this ADR would move the `"ensemble"` line out of that
+file and **leave the on/off switch behind in it** — the very file whose docstring claims to be inert.
+That would fix the smell and keep the disease (register C-129).
+
 The disease being treated is two halves quietly waiting with nobody able to see it. A paused delivery
 carrying a six-month-old date says so out loud.
 
 *Why not delete the file to turn a delivery off?* Because deleting throws away the reason.
 `paused("OCHA bucket not in the registry yet — ask Simon", since="2026-08-04")` is a sentence the next
 person can act on. An absent file is not.
+
+### What is deliberately *not* a key
+
+The file this replaces declares eight things. Five map onto the keys above — `name` is the filename,
+`level` and `ensemble` are `send`, `targets` and `region` are `REQUIRE`. The other three are named here
+so their absence reads as a decision rather than an oversight:
+
+| in the old file | where it goes |
+|---|---|
+| `wire_upload_enabled: True` | **derived from `intent`** (above) — not a key |
+| `wire_contract: True` | **a constant, not a choice.** The legacy leg was retired in #149, so contract mode is unconditional; a key implying it is optional would be false |
+| `algorithm: "Postprocessor"` | **stays put** — framework plumbing that tells the pipeline what kind of thing this is. It is not a delivery decision |
 
 ## 4. Coherence rules (fail-loud)
 
@@ -282,6 +311,11 @@ ordering dependency becomes derivable; a paused delivery cannot be silent.
 before writing their first line — mitigated only by the errors ADR-020 requires. And `targets` and
 `coverage` are assertions whose checks live outside this repository, so a file that *parses* is not a
 delivery that *works* — the tooling must say which kind of check it just ran.
+
+**Transitional, and real:** until `deliveries/` exists, `intent` and `wire_upload_enabled` both exist and
+can disagree — and `wire_upload_enabled` is currently present only in an uncommitted working tree
+(C-110), so two identical checkouts already publish differently. Deriving one from the other is what
+ends that, and it does not end until Phase 1 is built.
 
 **Not decided here:** whether a delivery *runs*. This ADR declares; execution is `monthly_run.sh`
 filtering on `frequency`, and that filter does not yet exist.

--- a/docs/ADRs/020_errors_must_descend.md
+++ b/docs/ADRs/020_errors_must_descend.md
@@ -1,0 +1,161 @@
+# ADR-020: Errors must descend — and we must say where the stairs end
+
+**Status:** **Accepted** (2026-08-04)
+**Date:** 2026-08-04
+**Deciders:** Simon (maintainer)
+**Origin:** extracted from ADR-017 §13 when that document was split for containment. The scope is
+**this repository**, not delivery — which is why it is its own ADR rather than a section inside one.
+
+---
+
+> **A note on names.** Every model, ensemble, consumer, region and target named in this document is an
+> **example**. They are real names where possible, because concrete examples are easier to read than
+> placeholders — but which source feeds which consumer changes, consumers are added and retired, and
+> buckets get renamed. Nothing here is a declaration about a particular name. The rules are about the
+> **shape**; the names are illustration.
+
+---
+
+## Summary
+
+**The problem, in one breath.** A person who edits a config in this repository and gets it wrong is
+told *what* failed, and left to work out *where* to go. That works if you already know the system. It
+is the reason turning the FAO delivery on in July 2026 was hard — not because anything failed
+silently, but because *how* to do it was undiscoverable to anyone who had not built it.
+
+**The decision, in one breath.** When a config is wrong, the error sends the reader **exactly one
+level down**, naming the next file to open. Where the reader cannot go any further, the error says so
+and names a person — it never ends in a task they cannot perform.
+
+---
+
+## 1. Who this is for
+
+The person editing a config in this repository is, realistically, a research assistant with a
+social-science background who is good at Python *compared to social scientists*. They will only ever
+edit **this** repository. They cannot publish a package, edit the platform coordinate registry, or
+open a pull request against an API repo.
+
+Designing error messages for anyone else is designing for someone this project does not have.
+
+This is not a claim about any individual's ability. It is a claim about **what the work actually is**:
+the repository is 131 model directories maintained by a research group with no dedicated ops engineer,
+and the person holding the task on any given month is whoever has time.
+
+## 2. The decision
+
+**Every error a human reads from a config in this repository must name the next file to open.**
+
+Not the failing value. Not the exception type. The **file**, and where in it.
+
+Concretely — taking the delivery declaration (ADR-019) as the worked case, with example names —
+the staircase is:
+
+| what is wrong | where the error sends you |
+|---|---|
+| `pgm("skinny_love")` but it declares `cm` | `ensembles/skinny_love/configs/config_meta.py` |
+| `reconciled = True` but the partner is someone else | the same file — `reconcile_with` is on the next line |
+| `reconcile_with` names an ensemble that does not exist | `ensembles/` — and the closest name to what was typed |
+| an active ensemble contains a retired member (ADR-017 R1) | `config_modelset.py`, then `models/<member>/configs/` |
+
+Four steps, each exactly one level down, no loops, no sideways jumps.
+
+**Error messages are load-bearing architecture here, not politeness.** They are also the least-tested
+thing in most codebases, which is why the rule below exists.
+
+## 3. Error messages are tested
+
+For each failure class, a test asserts that the message **names the next file**. Without this the
+staircase rots in its second month — someone refactors a check, the message becomes
+`KeyError: 'level'`, and nothing fails.
+
+This repository already does this in three places, so the pattern is established rather than proposed:
+
+- `tests/test_reconciliation_skip_is_truthful.py` — asserts the guard ordering that makes a skip
+  truthful, with a failure message naming the fix.
+- `tests/test_run_sh_portability.py` — *"If a newly scaffolded model appears here, fix the template in
+  views-pipeline-core, not the copy."*
+- `bootstrap.sh` — *"Activate an environment with Python 3.11+ and re-run. Every run.sh builds its own;
+  `conda activate` any of them, or use the base 3.11."*
+
+## 4. Where the stairs end
+
+Some checks cannot be answered inside this repository. Pretending otherwise would be the same
+dishonesty as a config whose docstring says it does nothing while deciding what reaches the UN.
+
+Four boundaries, as of 2026-08-04. Three are locked doors; one is a hole in the floor.
+
+- **Coverage** — the cell counts defining a region live in views-postprocessing, beside the GAUL
+  asset. They belong there.
+- **Target names** — checked against the manifests of a real run in the shelf. Not a file; a network
+  resource. *(And it cannot move earlier until a source's config truthfully describes what it emits:
+  `rusty_bucket` declares `lr_*_best` and produces `lr_ged_*` — register C-123. An edit-time check
+  today would reject a **correct** file, and the first thing the repository would teach a newcomer is
+  that its errors are wrong.)*
+- **A genuinely new consumer** — needs a bucket in the platform coordinate registry (views-appwrite)
+  and a producer package (views-postprocessing).
+- **A declared-live delivery that nothing ever runs** — no error exists, because nothing failed. This
+  is the hole in the floor, and it is the failure that actually happened: 145 days of silence while a
+  complete forecast sat unshipped (#320, C-121). No message can fix it; only an assertion about
+  freshness and a report of derived status can (ADR-019).
+
+## 5. What an error must do at a locked door
+
+Name the person, supply the request, and confirm the rest of the work is fine.
+
+```
+un_ocha is not a registered consumer.
+
+  Registering one needs a bucket address from the platform coordinate registry,
+  which is in another repository you are not expected to edit.
+
+  Ask Simon, or open an issue: "Register consumer un_ocha (bucket + API)".
+  Everything else in this file is fine — this is the only thing blocking it.
+```
+
+That last line is the difference between a handoff and a dead end. A locked door that also tells you
+the rest of your work is correct is a good place to stop. One that does not is where people give up
+and ask someone else to do it for them — which is how delivery became undiscoverable in the first
+place (ADR-017 §2).
+
+## 6. Rationale (against the maintainer's principles)
+
+- **Screaming architecture** — a repository screams what it does through its failures as much as its
+  folder names. An error that names the next file *teaches the layout* at the moment someone needs it,
+  without them reading a 585-line README first.
+- **Fail loud (ADR-003)** — this ADR does not change *whether* we fail loudly; it constrains *what the
+  loud thing says*.
+- **Easier to reason about, harder to accidentally break** — the descent is a property a reviewer can
+  check by reading a message, and a test can check mechanically.
+
+## 7. Consequences
+
+**Positive:** a newcomer can repair their own mistakes without a guide; the layout teaches itself;
+"where do I go next?" stops being tribal knowledge.
+
+**Negative:** error text becomes something we maintain and test, which is real ongoing cost. Messages
+naming files couple the message to the layout — moving a file means updating messages, and the tests
+in §3 are what make that a failure rather than a slow rot.
+
+**Known limit:** §4's four boundaries are not fixed by this ADR. Three are correctly outside this
+repository; the fourth needs ADR-019's freshness rule. This ADR's contribution there is only that we
+**say so** rather than leaving a reader to discover it.
+
+## 8. Considered alternatives
+
+- **Document the layout better instead.** Rejected: prose rots silently, and the person who needs it
+  is the least equipped to notice it is stale. This repository's own README is 585 lines and entirely
+  about building a model; it says nothing about delivery.
+- **A single "troubleshooting" page.** Rejected for the same reason, plus it puts the answer somewhere
+  the reader must already know to look. The error is where they already are.
+- **Richer exception types instead of message text.** Rejected: the audience does not read exception
+  hierarchies. They read the last line of a traceback.
+
+## References
+
+- **ADR-017** — the three axes; its R1/R2 rules produce two of §2's descents.
+- **ADR-019** — the delivery declaration; the worked staircase in §2 is its file.
+- **ADR-003** — authority and fail-loud.
+- `docs/forecast_delivery_map.md` — what the boundaries in §4 actually are today.
+- Register: **C-121** (the hole in the floor), **C-123** (why the target check cannot descend yet),
+  **C-125** (the same, as a pedagogical cost).

--- a/docs/forecast_delivery_map.md
+++ b/docs/forecast_delivery_map.md
@@ -155,7 +155,9 @@ contract-reading consumers.** The ADRs are written for that **target** state. Th
 ## Where each config lives today
 
 - **A source's maturity-ish label:** `models/<m>/configs/config_deployment.py` → `deployment_status`.
-  *(Measured 2026-08-04 across all 131: **120 `shadow`, 6 `baseline`, 4 `deprecated`, 1 `deployed`**.
+  *(Measured 2026-08-04: **117 `shadow`, 6 `baseline`, 4 `deprecated`, 1 `deployed`** across 128 files —
+  132 source directories exist, so four carry no maturity at all. Both quote styles must be counted;
+  see ADR-017 §2 and register C-127.
   The single `deployed` source is `ensembles/white_mustang` — whose two members, `lavender_haze` and
   `blank_space`, are both `shadow`.)*
 - **An ensemble's members:** `ensembles/<e>/configs/config_modelset.py`.

--- a/docs/forecast_delivery_map.md
+++ b/docs/forecast_delivery_map.md
@@ -1,0 +1,188 @@
+# How a forecast actually reaches a consumer — the map
+
+> **This is not an ADR.** It is a description of how the system works *right now*, and it is expected
+> to change. When a legacy element retires, its `[LEGACY]` line here retires with it — so this page
+> is a **shrinking list, by design**.
+>
+> That is exactly why it is not an ADR: ADR-000 says decisions are *"never deleted… superseded, not
+> erased"*, and a page designed to shrink cannot live under that rule. ADR-017 and ADR-019 cite this
+> page instead of containing it.
+>
+> **The names here are not examples — they are the current state.** `rusty_bucket`, `un_fao`,
+> `pink_ponyclub` and the rest are what exists on 2026-08-04. That is the point of this page, and it
+> is also why it is not an ADR: when the source feeding a consumer changes, this page changes with it.
+> The ADRs describe the shape; this page records what currently occupies it.
+>
+> **Last re-traced against the code and the live buckets: 2026-08-04.**
+> Every claim below names the file or the bucket it came from, so it can be re-checked rather than
+> believed.
+
+---
+
+## Why this page exists
+
+Two things make today's picture harder than it should be:
+
+- there are **two stores** — two different central places a forecast can land; and
+- the shelf that matters holds **two disjoint dialects** of document.
+
+Neither is a design; both are transitional. This page makes them visible so the ADRs can stand on
+solid ground instead of describing an idealised system.
+
+---
+
+## The monthly run — this is what actually ships to the public API `[LEGACY]`
+
+`monthly_run.sh` is a hand-run list. It runs four **legacy DataFrame ensembles** —
+`pink_ponyclub`, `skinny_love`, `rude_boy`, `first_love` — each with `-m`.
+
+`-m` is `--monthly`: it bundles train + forecast + report + **prediction_store**. There is no way to
+run `monthly_run.sh` as written without publishing.
+
+Each run goes through **one** method — `_save_predictions` → `PredictionIOManager` — which writes the
+forecast three ways:
+
+```
+monthly ensemble run (-m)  ->  PredictionIOManager                    [LEGACY]
+  ├─ local disk: pandas-parquet (legacy list-in-cell)
+  ├─ legacy "views-forecasts" store  (df.forecasts.to_store)          [LEGACY]
+  │    -> external API  api.viewsforecasting.org                      [MAIN PUBLIC LINE]
+  │       (prio-data/views_api, external)
+  └─ Appwrite SHELF: production_forecasts,  type="ensemble"           [LEGACY dialect]
+```
+
+There *is* a "savers" path — the single-model PredictionFrame path with the composed
+`LocalParquetSaver` / `ViewsForecastsSaver` / `AppwriteSaver` trio (`model.py:572`). It is a
+**different, conditional** mechanism `[CURRENT]`, and it is **not** what the monthly ensembles use.
+
+## `rusty_bucket` is a different animal `[TARGET]`
+
+`rusty_bucket` is a **PredictionFrame ensemble (PFE)** — the shape everything is converging toward.
+It uses neither path above. It:
+
+- writes `save_pf` (npy/npz) to local disk; and
+- with the store on, publishes **wire shards** to the *same shelf*, tagged `type="sampled_forecast_*"`.
+
+Those shards are defined by **views-postprocessing's ADR-013**, the Sampled-Forecast Wire Contract.
+
+> *Note on numbering:* on this page **"ADR-013" always means views-postprocessing's ADR-013** — a
+> different repo's ADR. It is not this repo's `013_regression_target_name_agnosticism.md`. Written
+> **vpp ADR-013** where confusion is likely.
+
+## So the one shelf holds two disjoint dialects
+
+- legacy documents tagged `type="ensemble"`, and
+- contract shards tagged `type="sampled_forecast_*"`.
+
+They never overlap. That separation is vpp ADR-013 §11.4's transition invariant.
+
+## The FAO line — one leg, not two
+
+**Corrected 2026-08-04.** This page previously described a *live legacy leg* and a *dormant contract
+leg*. That is now inverted: the legacy leg has been **deleted**, and the contract leg is the only one.
+
+```
+production_forecasts   type="sampled_forecast_*"
+  -> vpp unfao manager: source_selection.resolve_run(...)
+       newest FULLY MANIFESTED run for the ensemble named in the launcher config
+  -> enrich (GAUL sidecar) -> validate -> unfao_bucket
+  -> views-faoapi serves unfao_bucket
+```
+
+**How to re-check each step:**
+
+| claim | where |
+|---|---|
+| the legacy pandas reader is gone | `unfao/managers/unfao.py::_read_forecast_data` — *"ADR-013 contract only… retired in #149"*. `LEGACY_FORECAST_FILTERS` no longer exists in the file. |
+| omitting the contract key is a refusal, not a fallback | `contract/launch_config.py::assert_contract_mode` raises unless `wire_contract` is truthy (register C-63) |
+| selection is by identity, not recency | `contract/wire/source_selection.py::resolve_run(port, expected_targets, expected_ensemble, …)` |
+| faoapi reads `unfao_bucket`, not the shelf | `views-faoapi/src/views_faoapi/managers/api.py:148,278`; `forecast/ingestion/wire_reader.py:3` |
+| the upload is interlocked off by default | `unfao/product.py:36` — `UPLOAD_ENABLED = False`, overridable only by the launcher key `wire_upload_enabled` (vpp ADR-013 §11.4) |
+
+*(`managers/appwrite/config.py:39` in faoapi carries `bucket_id = "production_forecasts"` as a
+dataclass default. It is overridden at `api.py:278`. It is **not** a second reader — a stale default,
+nothing more.)*
+
+## What is actually true today — and it is not what the register says
+
+**On 2026-08-04, the FAO forecast stream is 145 days stale (#320), and a complete forecast has been
+sitting on the shelf unshipped since 27 July.**
+
+- `production_forecasts` holds **461 files**, among them exactly one fully-manifested `rusty_bucket`
+  run: `rusty_bucket_forecasting_20260727_095355`, with all three `lr_ged_*` target manifests.
+- `unfao_bucket`'s newest `forecast_dataset_*` is **2026-03-10**. Its `historical_dataset_*` stream is
+  current (5 days) — so the two halves of the FAO delivery have diverged by 140 days.
+
+**Register entry C-97 is marked Resolved (2026-07-28) on the claim that *"the manifest-addressed run
+`rusty_bucket_forecasting_20260727_095355` is what faoapi serves."* That is not true.** faoapi reads
+`unfao_bucket`; the run is in `production_forecasts`; nothing carried it across. Run-0 produced the
+artifact and stopped there.
+
+**The correct statement of the crossed-wires problem is therefore:** the wire is now built on both
+sides — the producer emits contract shards, the consumer can ingest them (faoapi #204 closed,
+`wire_reader.py` on `main`) — and the step that *moves the file between them* has never run in
+anger. It is a delivery that is fully constructed and has not been performed.
+
+That is a different failure from the one this page used to describe, and a more tractable one.
+
+## Two stores, two roles
+
+- **The `views-forecasts` store** (the old one) — pandas-only front door (`df.forecasts.to_store`);
+  feeds the public API. Unstructured, matched by fragile naming — the pile nobody opens. *(It also has
+  two **non-delivery** roles no ADR governs — legacy-ensemble constituent transport, and a run-metadata
+  registry — whose retirement is sequenced by the pipeline-core roadmap.)*
+- **The Appwrite `production_forecasts` shelf** (the new one) — the two-dialect bucket above; feeds
+  the FAO postprocessor. vpp ADR-013 makes its contract dialect addressable by *declared provenance*
+  instead of filename.
+
+## Direction of travel — what is dying, and where it goes
+
+*Context only. This convergence is owned by the views-frames migration and vpp ADR-013, and sequenced
+by pipeline-core's Lean Platform End-State Roadmap (2026-07-27) — **not decided here or by any ADR in
+this repo**.*
+
+- **DataFrame ensembles** (the four monthly) → **PredictionFrame / PFE** (the `rusty_bucket` shape).
+- **the `views-forecasts` store** → **the Appwrite shelf** (→ Hetzner, eventually).
+- **shelf dialect `type="ensemble"`** → **`type="sampled_forecast_*"`** (vpp ADR-013 §11.4).
+- **the legacy FAO leg** → **the contract FAO leg.** — **DONE**, retired in #149.
+
+Everything converges on one shape: **frames-native producers → the shelf's contract dialect →
+contract-reading consumers.** The ADRs are written for that **target** state. The legacy machinery is
+*grandfathered* — described here so it is visible, not endorsed.
+
+---
+
+## Where each config lives today
+
+- **A source's maturity-ish label:** `models/<m>/configs/config_deployment.py` → `deployment_status`.
+  *(Measured 2026-08-04 across all 131: **120 `shadow`, 6 `baseline`, 4 `deprecated`, 1 `deployed`**.
+  The single `deployed` source is `ensembles/white_mustang` — whose two members, `lavender_haze` and
+  `blank_space`, are both `shadow`.)*
+- **An ensemble's members:** `ensembles/<e>/configs/config_modelset.py`.
+- **Which ensembles reconcile, and against what:** `ensembles/<e>/configs/config_meta.py` —
+  `"reconciliation"` (the method) and `"reconcile_with"` (the partner). Two ensembles declare it:
+  `skinny_love → pink_ponyclub`, `white_mustang → cruel_summer`.
+- **The FAO "which source feeds us" declaration:** `postprocessors/un_fao/configs/config_meta.py` —
+  the single line `"ensemble": "rusty_bucket"`.
+  - **The smell, exactly:** that file's own docstring says *"This config is for documentation purposes
+    only, and modifying it will not affect the model."* That is **false** — that one line decides which
+    forecast reaches the UN. ADR-019 exists to move it somewhere honest.
+- **Whether the FAO delivery actually uploads:** `wire_upload_enabled` in the same file. On
+  2026-08-04 that key is **absent from git** and present as `True` in the maintainer's uncommitted
+  working tree, so the platform's publish behaviour differs between two identical checkouts
+  (register C-110).
+- **The main public line's declaration:** *none exists.* It is emergent — `monthly_run.sh`, plus the
+  legacy store, plus the external API.
+
+---
+
+## References
+
+- **ADR-017** — sources, composition and delivery (the three axes). Cites this page for today's state.
+- **ADR-019** — the delivery declaration (the file format that replaces the buried `"ensemble"` line).
+- **ADR-020** — errors must descend.
+- **views-postprocessing ADR-013** — the wire contract; owns *how* bytes travel.
+- **pipeline-core** *Lean Platform End-State Roadmap* (2026-07-27) — owns the retirement sequencing.
+- Register: **C-97** (selection; Resolved on a claim this page contradicts), **C-110** (uncommitted
+  arming state), **C-121** (no age bound at the delivery boundary), **C-123** (`rusty_bucket`'s config
+  does not describe what it emits), **#320** (the 145-day stall).

--- a/reports/technical_risk_register.md
+++ b/reports/technical_risk_register.md
@@ -1,10 +1,10 @@
 # Technical Risk Register — views-models
 
-**Last updated:** 2026-07-31  
+**Last updated:** 2026-08-04  
 **Governing ADR:** [ADR-010](../docs/ADRs/010_technical_risk_register.md)  
-**Total entries:** 135 (126 concerns + 9 disagreements)  
-**Concerns:** Open 56 | Mitigated 20 | Resolved 41 | Accepted 3 | Partially Resolved 1 | Subsumed 1 | Merged 4  
-**Concerns by tier:** T1 5 | T2 40 | T3 53 | T4 24 (4 merge stubs carry no tier)  
+**Total entries:** 140 (131 concerns + 9 disagreements)  
+**Concerns:** Open 61 | Mitigated 20 | Resolved 41 | Accepted 3 | Partially Resolved 1 | Subsumed 1 | Merged 4  
+**Concerns by tier:** T1 5 | T2 43 | T3 54 | T4 25 (4 merge stubs carry no tier)  
 **Disagreements:** Open 7 | Resolved 1 | Subsumed 1  
 **Last curated:** 2026-07-31 (`review-rr strategic`, first full pass — tier recalibration, 4 merges, 6 causal clusters identified)
 
@@ -1571,11 +1571,11 @@
 | Field | Value |
 |---|---|
 | **Tier** | 3 |
-| **Trigger** | Enabling an edit-time `targets` check in a delivery declaration (ADR-017 §4f `REQUIRE.targets`) while any source's config still misdescribes its own output. |
+| **Trigger** | Enabling an edit-time `targets` check in a delivery declaration (ADR-019 §1 `REQUIRE.targets`) while any source's config still misdescribes its own output. |
 | **Source** | expert-code-review of the delivery declaration design (2026-08-04) |
 | **Status** | Open |
-| **Location** | `ensembles/rusty_bucket/configs/config_meta.py:4`; the proposed `deliveries/*.py` `REQUIRE.targets` |
-| **Notes** | `rusty_bucket` declares `regression_targets: ["lr_sb_best", "lr_ns_best", "lr_os_best"]` and emits `lr_ged_sb/ns/os` (**C-123**). A `targets` gate checked against the source config would therefore reject a *correct* delivery file for the repo's own FAO ensemble. **The cost is pedagogical, which is why it is worth an entry of its own:** ADR-017 §13 makes error messages load-bearing — the design's value is that a newcomer is guided down one level at a time — and the first lesson this would teach is that the repo's errors are wrong. Nothing recovers from that. **Exit:** fix C-123, then promote `targets` from a run-time assertion (checked against the run's manifests, which are truthful) to an edit-time one. Until then ADR-017 §13 records `targets` as a stair that ends outside the repo. Cross-refs: **C-123**, ADR-017 §4f/§13. |
+| **Location** | `ensembles/rusty_bucket/configs/config_meta.py:4`; the proposed `deliveries/*.py` `REQUIRE.targets` (ADR-019) |
+| **Notes** | `rusty_bucket` declares `regression_targets: ["lr_sb_best", "lr_ns_best", "lr_os_best"]` and emits `lr_ged_sb/ns/os` (**C-123**). A `targets` gate checked against the source config would therefore reject a *correct* delivery file for the repo's own FAO ensemble. **The cost is pedagogical, which is why it is worth an entry of its own:** ADR-020 makes error messages load-bearing — the design's value is that a newcomer is guided down one level at a time — and the first lesson this would teach is that the repo's errors are wrong. Nothing recovers from that. **Exit:** fix C-123, then promote `targets` from a run-time assertion (checked against the run's manifests, which are truthful) to an edit-time one. Until then ADR-020 §4 records `targets` as a stair that ends outside the repo. Cross-refs: **C-123**, ADR-019 §1, ADR-020 §4. |
 
 ---
 
@@ -1587,10 +1587,66 @@
 | **Trigger** | A delivery declared `intent = live()` that no runner picks up, or that ships a run far older than the consumer expects. |
 | **Source** | expert-code-review of the delivery declaration design (2026-08-04, Nygard) |
 | **Status** | Open |
-| **Location** | proposed `deliveries/*.py` — `DELIVERY.intent`, `REQUIRE.max_age`; ADR-017 §5 freshness rule, §13 "where the stairs end" |
-| **Notes** | The design solves the *paused* case well: `paused(reason, since=...)` cannot be set silently, so a dormant edge carries an explanation and an age. It does **not** solve the *live-but-never-run* case — a `live()` delivery that nothing executes produces no error, because nothing failed. That is precisely the 145-day FAO silence (**C-121**, **C-99**), surviving the redesign. ADR-017 §13 names it honestly as *"not a locked door — a hole in the floor"*. **Exit, two parts, both already written into the amendment:** `REQUIRE.max_age` is mandatory whenever `intent = live()` (§5 freshness rule), and `tools/liveness` reports **derived status beside declared intent** (§7), so `live()` + "never delivered" is a visible contradiction rather than an absence. Registered separately from C-121 because C-121 is the defect in today's code and this is the residual risk in tomorrow's design — closing one does not close the other. Cross-refs: **C-121**, **C-99**, **C-110**. |
+| **Location** | proposed `deliveries/*.py` — `DELIVERY.intent`, `REQUIRE.max_age`; ADR-019 §4 freshness rule, ADR-020 §4 "where the stairs end" |
+| **Notes** | The design solves the *paused* case well: `paused(reason, since=...)` cannot be set silently, so a dormant edge carries an explanation and an age. It does **not** solve the *live-but-never-run* case — a `live()` delivery that nothing executes produces no error, because nothing failed. That is precisely the 145-day FAO silence (**C-121**, **C-99**), surviving the redesign. ADR-020 §4 names it honestly as *"not a locked door — a hole in the floor"*. **Exit, two parts, both already written into the amendment:** `REQUIRE.max_age` is mandatory whenever `intent = live()` (ADR-019 §4), and `tools/liveness` reports **derived status beside declared intent** (ADR-017 §7), so `live()` + "never delivered" is a visible contradiction rather than an absence. Registered separately from C-121 because C-121 is the defect in today's code and this is the residual risk in tomorrow's design — closing one does not close the other. Cross-refs: **C-121**, **C-99**, **C-110**. |
 
 ---
+
+### C-127 — Fleet-wide config values are written in two literal styles, so a naive grep silently under-counts
+
+| Field | Value |
+|---|---|
+| **Tier** | 2 |
+| **Trigger** | Executing the `deployment_status` → `maturity` migration (ADR-017 §11), or any future statement of the form "measured across all N sources" produced by grepping the fleet. |
+| **Source** | falsify audit of the four delivery documents (2026-08-04), probe P1 |
+| **Status** | Open |
+| **Location** | 128 × `{models,ensembles}/*/configs/config_deployment.py` — 47 use `{"deployment_status": "shadow"}`, 81 use `{'deployment_status': 'shadow'}` (e.g. `models/brown_cheese/configs/config_deployment.py:19`); the false figures were at `docs/ADRs/017_source_composition_delivery.md:74` and `docs/forecast_delivery_map.md:158` |
+| **Notes** | ADR-017 §2 and the delivery map both stated *"Measured across all 131 sources: 120 `shadow`, 6 `baseline`, 4 `deprecated`, 1 `deployed`"*. The true distribution is **117 / 6 / 4 / 1 across 128 files**, and there are **132** source directories — four (`models/cool_cat`, `models/teenage_dirtbag`, `models/test_model`, `ensembles/test_ensemble`) carry no `config_deployment.py` at all. The measurement had been taken with a double-quote pattern that matched 47 of 128 files and silently reported the rest as absent. **The wrong number is now corrected in both documents; the durable risk is the heterogeneity that caused it.** ADR-017 §2's numbers are its evidence base, so this was not cosmetic — a rule whose stated justification is false is the kind a future contributor overturns. Same bug class as **C-114** (a detector blind to one spelling of the thing it was built to see), in a different subsystem: there a rejected key read as mild staleness, here 81 configs read as non-existent. **Exit:** the migration tool must parse rather than grep, and must assert it touched 128 files. Cross-refs: **C-114**, **C-124**. |
+
+### C-128 — ADR-019's "REQUIRE only refuses" rule is false for its one mandatory key, so a validator author must guess
+
+| Field | Value |
+|---|---|
+| **Tier** | 2 |
+| **Trigger** | Implementing the `REQUIRE` validator, or writing the first real delivery file under ADR-019. |
+| **Source** | falsify audit of the four delivery documents (2026-08-04), probe P3 |
+| **Status** | Open |
+| **Location** | `docs/ADRs/019_delivery_declaration.md` §2 (the testable rule, and the "may be omitted entirely" allowance) vs §4 (Freshness) |
+| **Notes** | §2 states the rule that defines the whole two-block design: *"removing a line from `REQUIRE` must never change what is produced, only what is allowed through."* §4 then requires that a `live()` delivery **must** declare `max_age`. Removing `max_age` does not widen what is accepted — it makes the file invalid, so nothing is produced. A second instance sits in the same paragraph: §2 offers *"`REQUIRE` may be omitted entirely when there is nothing to assert"*, but every `live()` delivery must carry `max_age` and every real delivery is live, so the allowance is never actually available. **Why this is Tier 2 rather than a wording nit:** an implementer who resolves the contradiction toward "`REQUIRE` is purely assertive" will not enforce freshness — and the missing freshness bound is precisely the failure that already occurred (**#320**, 145 days of silent non-delivery). The contradiction points the implementation at the bug. **Now corrected in the ADR**; the entry records the class so the next absolute-sounding rule is checked against its own exceptions. Cross-refs: **C-121**, **C-126**, **D-09**. |
+
+### C-129 — The delivery declaration has no home for the key that actually arms the delivery
+
+| Field | Value |
+|---|---|
+| **Tier** | 2 |
+| **Trigger** | Building `deliveries/un_fao.py` (ADR-017 §11 Phase 1), or adding the second consumer under **#333**. |
+| **Source** | falsify audit of the four delivery documents (2026-08-04), probe P8 (adequacy) |
+| **Status** | Open |
+| **Location** | `postprocessors/un_fao/configs/config_meta.py:26-27` (`wire_contract`, `wire_upload_enabled`); `docs/ADRs/019_delivery_declaration.md` §3 (the key set) |
+| **Notes** | The real FAO config declares **eight** keys. Five map cleanly onto ADR-019's schema; three had no home — `algorithm`, `wire_contract`, and `wire_upload_enabled`. The last is the **arming switch**: views-postprocessing ADR-013 §11.4 sets `UPLOAD_ENABLED = False` and makes that launcher key its only override. ADR-019 mentioned it **zero times** while the delivery map mentioned it twice. The consequence is exact and self-inflicted: ADR-019 exists because a delivery-deciding line sits buried in a file whose docstring calls itself inert — and the design moved the `ensemble` line out while **leaving the on/off switch behind in that same file**. Worse, `intent = live()｜paused()` and `wire_upload_enabled: True｜False` are the same fact in two places, which is the duplication ADR-019 §8 rejects by name. **Resolved in the ADR by declaring `intent` the repo-side arming switch, from which the launcher key is *derived*** — derivation, not duplication, the same principle as the filename carrying the consumer. `wire_contract` is recorded as an unconditional constant (the legacy leg retired in **#149**) and `algorithm` as framework plumbing that stays put, so all eight keys now have a stated home. **The residual risk this entry tracks:** until `deliveries/` is built, the two switches co-exist and can disagree. Cross-refs: **C-110** (the switch exists only in an uncommitted tree), **C-63**, **C-126**. |
+
+### C-130 — The maturity migration leaves ten sources with no destination value
+
+| Field | Value |
+|---|---|
+| **Tier** | 3 |
+| **Trigger** | Executing the `deployment_status` → `maturity` rename across the fleet (ADR-017 §11 Phase 2). |
+| **Source** | falsify audit of the four delivery documents (2026-08-04), probe P4 |
+| **Status** | Open |
+| **Location** | the 6 sources declaring `baseline`; `models/cool_cat`, `models/teenage_dirtbag`, `models/test_model`, `ensembles/test_ensemble` (no `config_deployment.py`) |
+| **Notes** | ADR-017 correctly holds that `baseline` is a **role**, not a maturity, and that it leaves `config_deployment.py` entirely — but every source still needs *some* maturity, and the migration table originally sent `baseline` to *(nothing)*. Six real sources carry it, and a research assistant migrating the fleet would have had no value to write. A further four source directories carry no `config_deployment.py` at all, so they have no `deployment_status` to migrate *from*. **Both now resolved in ADR-017's migration table** (`baseline` → `candidate`, role preserved where it already lives; the four unconfigured sources named explicitly). Entry retained because the migration is not yet executed and the table is the only thing that makes it mechanical. Cross-refs: **C-127**. |
+
+### C-131 — "Production-tier consumer" reads as a discriminating condition while `tier` has one value
+
+| Field | Value |
+|---|---|
+| **Tier** | 4 |
+| **Trigger** | A reader deriving `is_in_production` from ADR-017 §4e without also reading ADR-019 §3; or the addition of a second `tier` value. |
+| **Source** | falsify audit of the four delivery documents (2026-08-04), probe P2 |
+| **Status** | Open |
+| **Location** | `docs/ADRs/017_source_composition_delivery.md` §4e (the ⟺ definition) and §5 (the tier rule) vs `docs/ADRs/019_delivery_declaration.md` §3 (`tier`) |
+| **Notes** | §4e defines *in production ⟺ maturity is `graduate` **and** a delivery ships it to a **production-tier** consumer.* ADR-019 §3 fixes `tier` at exactly one value, `prod`, and says plainly that the gate is therefore *currently unconditional*. §4e did not, so the definition read as two independent conditions when one is presently always true. Not a correctness defect — the definition stays true as written, and becomes discriminating the moment a second tier value exists — but it is the kind of gap that makes a newcomer believe a check exists that does not. **Corrected by a clause in §4e pointing at ADR-019 §3.** The second tier value is itself blocked on ADR-017 §12's open shadow-destination question. Cross-refs: **C-129**. |
+
 
 ## Disagreements
 

--- a/reports/technical_risk_register.md
+++ b/reports/technical_risk_register.md
@@ -2,10 +2,10 @@
 
 **Last updated:** 2026-07-31  
 **Governing ADR:** [ADR-010](../docs/ADRs/010_technical_risk_register.md)  
-**Total entries:** 126 (120 concerns + 6 disagreements)  
-**Concerns:** Open 50 | Mitigated 20 | Resolved 41 | Accepted 3 | Partially Resolved 1 | Subsumed 1 | Merged 4  
-**Concerns by tier:** T1 5 | T2 37 | T3 50 | T4 24 (4 merge stubs carry no tier)  
-**Disagreements:** Open 4 | Resolved 1 | Subsumed 1  
+**Total entries:** 132 (124 concerns + 8 disagreements)  
+**Concerns:** Open 54 | Mitigated 20 | Resolved 41 | Accepted 3 | Partially Resolved 1 | Subsumed 1 | Merged 4  
+**Concerns by tier:** T1 5 | T2 39 | T3 52 | T4 24 (4 merge stubs carry no tier)  
+**Disagreements:** Open 6 | Resolved 1 | Subsumed 1  
 **Last curated:** 2026-07-31 (`review-rr strategic`, first full pass — tier recalibration, 4 merges, 6 causal clusters identified)
 
 ---
@@ -1249,7 +1249,7 @@
 | **Source** | maintainer ground truth (2026-07-19): "the pipeline is run once a month on a laptop; which laptop depends on who has time" — no production server exists |
 | **Status** | Open |
 | **Location** | `monthly_run.sh` (the entire production trigger: a hand-run bash list); no scheduler, no retry, no freshness check anywhere in the platform |
-| **Notes** | Production is a **rotating human ritual**: whoever has time runs `monthly_run.sh` on their own laptop, with their own env/credentials state. Consequences: run evidence is scattered across personal machines (this workstation holds Apr/May traces only); "did month X happen?" is unanswerable from any repo; a missed or failed month is invisible until a human notices downstream. The maintainer's stated goal is a **dedicated small production server modeled on the working datafactory box** (which already runs monthly by timer) — gated on this repo's cleanup. Exit criteria for closing: (a) scheduled execution on a dedicated host, (b) a dead-man's-switch freshness alarm ("month-X artifacts absent by day D ⇒ scream"), (c) the laptop ritual retired to backup after one both-run-and-compare month. The wiring-acceptance instrument for that host now exists: **`python -m tools.liveness`** (epic #238, was planned as `tools/preflight`) — its exit-code contract (0 healthy / 1 attention / 2 unreachable) is the dead-man's-switch primitive; what remains for this entry's exit is *scheduling* it (cron on the future host + an alarm on non-zero), which no code here does yet. See also C-97, C-100, C-03 (no integration in CI). |
+| **Notes** | Production is a **rotating human ritual**: whoever has time runs `monthly_run.sh` on their own laptop, with their own env/credentials state. Consequences: run evidence is scattered across personal machines (this workstation holds Apr/May traces only); "did month X happen?" is unanswerable from any repo; a missed or failed month is invisible until a human notices downstream. The maintainer's stated goal is a **dedicated small production server modeled on the working datafactory box** (which already runs monthly by timer) — gated on this repo's cleanup. Exit criteria for closing: (a) scheduled execution on a dedicated host, (b) a dead-man's-switch freshness alarm ("month-X artifacts absent by day D ⇒ scream"), (c) the laptop ritual retired to backup after one both-run-and-compare month. The wiring-acceptance instrument for that host now exists: **`python -m tools.liveness`** (epic #238, was planned as `tools/preflight`) — its exit-code contract (0 healthy / 1 attention / 2 unreachable) is the dead-man's-switch primitive; what remains for this entry's exit is *scheduling* it (cron on the future host + an alarm on non-zero), which no code here does yet. See also C-97, C-100, C-03 (no integration in CI). **Measured 2026-08-04:** the predicted silent failure has occurred and is quantified — FAO's forecast stream is **145 days stale** while a complete, deliverable run has sat on the internal shelf since 27 July. The specific mechanism at the delivery boundary is now **C-121** (no age bound on the resolved run); the missing scheduler remains this entry's. |
 
 ---
 
@@ -1392,7 +1392,7 @@
 | **Source** | run-0 delivery (2026-07-27/28); confirmed still uncommitted 2026-07-31 (`git status`) |
 | **Status** | Open |
 | **Location** | `postprocessors/un_fao/configs/config_queryset.py` (`REGION` `africa_me_legacy`→`land_gaul`; `"data_format": "feature_frame"`; datafactory pin `>=1.9.0,<2.0.0`), `postprocessors/un_fao/configs/config_meta.py` (`wire_contract`, `wire_upload_enabled`, `region: land_gaul`), `postprocessors/un_fao/README.md`, `postprocessors/un_fao/requirements.txt` — all `M` in the working tree, none on `origin/development` |
-| **Notes** | Tier 2 rationale: not silent corruption *today* (the served artifact is correct and its provenance is verifiable on the shelf), but a structurally fragile state with a realistic, one-command trigger and a wrong-output consequence — the delivered product is **not reproducible from any committed state**, and the reproduction attempt fails *quietly and plausibly* rather than loudly. The working tree is acting as the system of record for a UN-facing deliverable. Aggravating factor: the same tree also holds parallel-session-owned `violet_visitor` edits, so it cannot simply be committed wholesale — the un_fao paths must be staged by name. **Exit: commit the four un_fao paths via the merge ritual** (small, ready, blocked on nothing). Related cross-repo state, unverified from this repo and therefore not registered separately: the views-postprocessing bug-#1 name-scoping fix (`_prod_forecasts_datastore(name_scoped=False)`) was reported uncommitted in that checkout and may have the same exposure — worth a check in that repo. Cross-refs: **C-105** (the *inverse* direction of the same "working tree is the system of record" hazard — that entry is the checkout drifting *behind* the remote, this one is run-critical state living *ahead* of it and unbacked); C-53 (config value regression across merges). |
+| **Notes** | Tier 2 rationale: not silent corruption *today* (the served artifact is correct and its provenance is verifiable on the shelf), but a structurally fragile state with a realistic, one-command trigger and a wrong-output consequence — the delivered product is **not reproducible from any committed state**, and the reproduction attempt fails *quietly and plausibly* rather than loudly. The working tree is acting as the system of record for a UN-facing deliverable. Aggravating factor: the same tree also holds parallel-session-owned `violet_visitor` edits, so it cannot simply be committed wholesale — the un_fao paths must be staged by name. **Exit: commit the four un_fao paths via the merge ritual** (small, ready, blocked on nothing). Related cross-repo state, unverified from this repo and therefore not registered separately: the views-postprocessing bug-#1 name-scoping fix (`_prod_forecasts_datastore(name_scoped=False)`) was reported uncommitted in that checkout and may have the same exposure — worth a check in that repo. Cross-refs: **C-105** (the *inverse* direction of the same "working tree is the system of record" hazard — that entry is the checkout drifting *behind* the remote, this one is run-critical state living *ahead* of it and unbacked); C-53 (config value regression across merges). **Second variable found 2026-08-04, same file, same shape:** `postprocessors/un_fao/configs/config_meta.py` carries `wire_upload_enabled: True` in the working tree and **nowhere in git**. That key is the ADR-013 §11.4 upload interlock — with it absent the sink stages locally and makes ZERO store calls; with it present the run publishes to the UN FAO's bucket. So **whether this platform delivers to a partner is decided by an uncommitted edit on one laptop**, and two identical checkouts behave differently toward an external party. Registered here rather than as a new entry because it is the same defect at the same location: the configuration governing a UN-facing delivery exists only in a working tree. **Exit:** commit the key with whatever value is intended, so the deployed behaviour is derivable from a commit. Cross-ref: **C-117** (the dependency half, mitigated). |
 
 ---
 
@@ -1516,6 +1516,56 @@
 | **Location** | `tests/test_datafactory_parity.py` — `_experiment_in_progress()`, `test_both_trios_use_same_loss`, `test_constituent_posterior_samples_match`, and the guard now named `test_the_experiment_in_progress_roster_is_exactly_as_declared` |
 | **Notes** | The branch introduced a correct idea — an experiment whose values churn should not be pinned to an exact value that flickers red/green — and guarded it with `test_violet_visitor_is_experiment_in_progress`, which asserted only that **violet_visitor** carries the marker. **But `_experiment_in_progress()` applies to any model.** So the exemption was general and the alarm was specific. **Reproduced, not theorised:** adding one line to `models/pink_pirate/configs/config_hyperparameters.py` removed it from *both* parity pins and the suite reported **51 passed** with nothing to indicate a model had stopped being checked. A second probe marked all six trio models: both pins then compared `{} == {}` and passed — a test asserting nothing at all. **Fix:** pin the exemption **roster as a set** (`EXPERIMENTS_IN_PROGRESS = {"violet_visitor"}`), which fails in both directions — a model gaining the marker and a model losing it — plus an explicit non-empty assertion in each pin so neither can ever pass vacuously. Verified by re-running all three probes against the fix. **The generalisable rule:** *an escape hatch must be guarded at the same scope it operates.* A guard that names one subject cannot cover a mechanism that accepts any. Cross-refs: **C-112** (a check asked in a scope that cannot answer it), **C-113** (a gate that cannot tell "clean" from "did not run"), **C-115** (an invariant guarded by name rather than by the invariant). Member of **Cluster A** (declared-but-unenforced). **Near-miss recorded on C-71:** the same branch put prose after `Open` in a Status field, which silently dropped the entry from the header count — caught by `test_open_count_accurate`, which is what that test is for. |
 
+### C-121 — The delivery boundary accepts a forecast of unbounded age
+
+| Field | Value |
+|---|---|
+| **Tier** | 2 |
+| **Trigger** | `un_fao` running in a month where no fresh `rusty_bucket` run was produced first — which is every month, because `rusty_bucket` is not in `monthly_run.sh`. |
+| **Source** | expert-code-review of the delivery composition (2026-08-04), traced against the live store |
+| **Status** | Open |
+| **Location** | `views-postprocessing/views_postprocessing/unfao/managers/unfao.py::_read_forecast_data_contract`; `contract/wire/source_selection.py::resolve_run` |
+| **Notes** | `resolve_run` selects **the newest fully-manifested run for a named ensemble** — identity plus completeness, which is right, and is what **C-97** records as resolved. What it does not do is bound the run's **age**. So the delivery step will silently republish an arbitrarily old forecast as the current one. **Measured 2026-08-04:** FAO's forecast stream is 145 days stale (#320, newest `forecast_dataset` 2026-03-10) while `production_forecasts` holds exactly one complete run, `rusty_bucket_forecasting_20260727_095355` (all three `lr_ged_*` targets), untouched since 27 July. The forecast existed; nothing carried it across, and nothing would have objected if it had carried the March one instead. The method **already logs** `"Contract inbound resolved: run %s"` — the fact needed for the assertion is in hand and simply not asserted on. **Exit:** a declared freshness budget and a refusal, at the boundary that already knows the answer. This is the one change that addresses the failure that actually occurred. Cross-refs: **C-99** (no missed-month signal — this is its specific, now-measured instance at the delivery boundary), **C-97** (selection, resolved), **C-114** (a detector that reported its own failure as mild staleness). Member of **Cluster A** (declared-but-unenforced). |
+
+---
+
+### C-122 — The production pipeline's assembly is five ordered strings, and the order is an unstated data dependency
+
+| Field | Value |
+|---|---|
+| **Tier** | 2 |
+| **Trigger** | Adding a producer *below* its consumer in `monthly_run.sh`, or reordering the existing five lines. Concretely: adding `rusty_bucket` after the `un_fao` line rather than before it. |
+| **Source** | expert-code-review of the delivery composition (2026-08-04) |
+| **Status** | Open |
+| **Location** | `monthly_run.sh` — the five `run_folder` lines; `postprocessors/un_fao/configs/config_meta.py` (`"ensemble"`); `views-postprocessing/unfao/product.py` (`UPLOAD_ENABLED`) |
+| **Notes** | `un_fao` consumes what the ensembles produce, and that dependency is encoded **only** as line order in a shell script. Getting it wrong raises nothing: the consumer simply delivers a previous run. **Everything beneath this point injects its dependencies** — `_ContractStorePort` is an explicit DIP port, `contract/` and `delivery/` are partner-neutral and a test proves it — while the composition root hard-codes five concrete paths in a fixed sequence. The three files that must agree to deliver a forecast live in two repositories with no reference between them. Related: **13 ensembles exist and only 4 are in `monthly_run.sh`**; the one `un_fao` is configured to consume, `rusty_bucket`, is **not among them**, so "run everything monthly" produces four forecasts nobody delivers and delivers one forecast nobody just made. **Deliberately not fixed yet.** A declared composition is an abstraction over exactly one instance in this repo, and the maintainer's rule is to extract on a second incident behind a named trigger. **The named trigger: when a second partner delivery needs a production run in views-models.** The scar already exists one repo away — views-postprocessing #211, *"every partner-scoped guard was scoped to ONE partner"*, fixed there with a declared list asserted against the filesystem (`tests/conftest.py::PARTNER_PACKAGES`), not a framework. That is the shape to copy when the trigger fires. Cross-refs: **C-99**, **C-97**, **C-121**, **C-120** (same bug class: a general mechanism guarded for one subject). |
+
+---
+
+### C-123 — `rusty_bucket`'s config does not describe what it emits
+
+| Field | Value |
+|---|---|
+| **Tier** | 3 |
+| **Trigger** | Any tool or person deriving a delivery's target names from model config rather than from the manifests in the bucket. |
+| **Source** | expert-code-review (2026-08-04); confirmed against the live store |
+| **Status** | Open |
+| **Location** | `ensembles/rusty_bucket/configs/config_meta.py:4` |
+| **Notes** | Declares `regression_targets: ["lr_sb_best", "lr_ns_best", "lr_os_best"]`. The run it actually produced emitted `lr_ged_sb`, `lr_ged_ns`, `lr_ged_os` — verified by listing `production_forecasts`, where the manifests are named `rusty_bucket_forecasting_20260727_095355__lr_ged_*__manifest.json`. Delivery works **only** because `resolve_run` matches manifest filenames rather than the config. So the config is decorative at precisely the point a reader would trust it, and the only reliable source of truth for a delivery's contents is a live bucket query — which is what this review had to do. Cross-refs: views-models#151 (target-name standardisation), **C-104** (one quantity, four config keys). |
+
+---
+
+### C-124 — Coverage is validated after the expensive path, not at resolution
+
+| Field | Value |
+|---|---|
+| **Tier** | 3 |
+| **Trigger** | A run resolving successfully for a region whose cell coverage it cannot satisfy — e.g. an africa-only run against `region: land_gaul`. |
+| **Source** | expert-code-review (2026-08-04) |
+| **Status** | Open |
+| **Location** | `views-postprocessing/contract/wire/source_selection.py` — `resolve_run` (manifests) vs `TargetLease.load()` (`assert_complete_coverage`, `assert_no_excluded_cells`) |
+| **Notes** | `resolve_run` checks that every expected target has a content-verified manifest; `expected_cells` and `excluded_gids` are passed to the lease and only enforced when frames materialise. Resolution succeeding therefore does not mean delivery will succeed — the failure arrives after shard downloads, on a monthly hand-run on a laptop. The lazy design is correct for memory (it is the run-0 OOM fix); what is missing is a cheap precheck so an unsatisfiable run is rejected before the heavy fetch. Cross-refs: **C-121**. |
+
 ---
 
 ## Disagreements
@@ -1583,3 +1633,25 @@
 | **Source** | expert-code-review (2026-08-02; Hickey vs. Beck/Feathers) |
 | **Status** | Open |
 | **Notes** | **Hickey:** an allowlist of accepted exceptions is a place to hide, and its length is the metric — a test that begins by blessing the mess has inverted its own purpose. **Beck and Feathers:** the objection is about *size*, and size is a choice of ordering. Fix the one unparseable specifier (#316), then the three missing trailing newlines, then the 27 unbounded ceilings (**C-118**) — each rule is red for a real reason, gets fixed, and goes green with no baseline at all. Only the divergent-spec rule needs a recorded exception, and after that sequence it holds one entry: the r2darts split (**C-115**), with its reason. **Martin adds** the deciding criterion: an exception carrying a written reason is documentation; an exception without one is theatre. **Provisional resolution:** build in Beck's order and the disagreement does not arise; revisit if the exception list ever exceeds two entries. |
+
+---
+
+### D-07 — Is the delivery defect structural, or observational?
+
+| Field | Value |
+|---|---|
+| **Trigger** | Choosing between a declared composition (structure) and a freshness assertion (observation) as the next change |
+| **Source** | expert-code-review (2026-08-04; Nygard/Beck vs Martin/Kleppmann/Ousterhout) |
+| **Status** | Open |
+| **Notes** | **Nygard and Beck:** the incident that cost 145 days was not a wrong order — it was a delivery step that never ran, and which would have republished March data without objecting. A correctly ordered manifest would not have delivered anything either. So the assertion (**C-121**) addresses the failure that happened and the structure (**C-122**) does not. **Martin, Kleppmann and Ousterhout:** an unrepresented causal dependency in a partner-facing pipeline is a defect whether or not it has fired, and leaving it invites the next silent failure. **Provisional resolution:** both, in that order — the assertion now, the structure behind C-122's named trigger. Recorded because the ordering is the actual decision, and it is easy to reverse it in the name of tidiness. |
+
+---
+
+### D-08 — Does WET-before-DRY forbid a declared composition?
+
+| Field | Value |
+|---|---|
+| **Trigger** | Proposing a composition manifest, a dependency resolver, or moving composition into views-pipeline-core |
+| **Source** | expert-code-review (2026-08-04; Hickey vs Martin/Beck) |
+| **Status** | Open |
+| **Notes** | **Hickey:** views-models has exactly **one** composition (`monthly_run.sh`). Abstracting at n=1 is precisely the wrong-abstraction risk the rule exists to prevent, and a manifest that acquires conditionals has become a program. **Martin and Beck:** the second instance already exists one repo away — `crafd/` was cloned from `unfao/` per `docs/CLONING.md`, and views-postprocessing #211 is the recorded scar of that clone (*"every partner-scoped guard was scoped to ONE partner"*). **Provisional resolution:** the trigger has fired for views-postprocessing, **not** for views-models. Defer, behind C-122's named trigger. When it fires, copy views-postprocessing's remedy — a declared list asserted against the filesystem — not a framework. Unanimous against a dependency resolver and against moving composition into pipeline-core. |

--- a/reports/technical_risk_register.md
+++ b/reports/technical_risk_register.md
@@ -2,10 +2,10 @@
 
 **Last updated:** 2026-07-31  
 **Governing ADR:** [ADR-010](../docs/ADRs/010_technical_risk_register.md)  
-**Total entries:** 132 (124 concerns + 8 disagreements)  
-**Concerns:** Open 54 | Mitigated 20 | Resolved 41 | Accepted 3 | Partially Resolved 1 | Subsumed 1 | Merged 4  
-**Concerns by tier:** T1 5 | T2 39 | T3 52 | T4 24 (4 merge stubs carry no tier)  
-**Disagreements:** Open 6 | Resolved 1 | Subsumed 1  
+**Total entries:** 135 (126 concerns + 9 disagreements)  
+**Concerns:** Open 56 | Mitigated 20 | Resolved 41 | Accepted 3 | Partially Resolved 1 | Subsumed 1 | Merged 4  
+**Concerns by tier:** T1 5 | T2 40 | T3 53 | T4 24 (4 merge stubs carry no tier)  
+**Disagreements:** Open 7 | Resolved 1 | Subsumed 1  
 **Last curated:** 2026-07-31 (`review-rr strategic`, first full pass — tier recalibration, 4 merges, 6 causal clusters identified)
 
 ---
@@ -1566,6 +1566,30 @@
 | **Location** | `views-postprocessing/contract/wire/source_selection.py` — `resolve_run` (manifests) vs `TargetLease.load()` (`assert_complete_coverage`, `assert_no_excluded_cells`) |
 | **Notes** | `resolve_run` checks that every expected target has a content-verified manifest; `expected_cells` and `excluded_gids` are passed to the lease and only enforced when frames materialise. Resolution succeeding therefore does not mean delivery will succeed — the failure arrives after shard downloads, on a monthly hand-run on a laptop. The lazy design is correct for memory (it is the run-0 OOM fix); what is missing is a cheap precheck so an unsatisfiable run is rejected before the heavy fetch. Cross-refs: **C-121**. |
 
+### C-125 — A target-name gate would fail correct delivery files, because a source's config does not describe what it emits
+
+| Field | Value |
+|---|---|
+| **Tier** | 3 |
+| **Trigger** | Enabling an edit-time `targets` check in a delivery declaration (ADR-017 §4f `REQUIRE.targets`) while any source's config still misdescribes its own output. |
+| **Source** | expert-code-review of the delivery declaration design (2026-08-04) |
+| **Status** | Open |
+| **Location** | `ensembles/rusty_bucket/configs/config_meta.py:4`; the proposed `deliveries/*.py` `REQUIRE.targets` |
+| **Notes** | `rusty_bucket` declares `regression_targets: ["lr_sb_best", "lr_ns_best", "lr_os_best"]` and emits `lr_ged_sb/ns/os` (**C-123**). A `targets` gate checked against the source config would therefore reject a *correct* delivery file for the repo's own FAO ensemble. **The cost is pedagogical, which is why it is worth an entry of its own:** ADR-017 §13 makes error messages load-bearing — the design's value is that a newcomer is guided down one level at a time — and the first lesson this would teach is that the repo's errors are wrong. Nothing recovers from that. **Exit:** fix C-123, then promote `targets` from a run-time assertion (checked against the run's manifests, which are truthful) to an edit-time one. Until then ADR-017 §13 records `targets` as a stair that ends outside the repo. Cross-refs: **C-123**, ADR-017 §4f/§13. |
+
+---
+
+### C-126 — The delivery design makes dormancy visible but not absence of execution
+
+| Field | Value |
+|---|---|
+| **Tier** | 2 |
+| **Trigger** | A delivery declared `intent = live()` that no runner picks up, or that ships a run far older than the consumer expects. |
+| **Source** | expert-code-review of the delivery declaration design (2026-08-04, Nygard) |
+| **Status** | Open |
+| **Location** | proposed `deliveries/*.py` — `DELIVERY.intent`, `REQUIRE.max_age`; ADR-017 §5 freshness rule, §13 "where the stairs end" |
+| **Notes** | The design solves the *paused* case well: `paused(reason, since=...)` cannot be set silently, so a dormant edge carries an explanation and an age. It does **not** solve the *live-but-never-run* case — a `live()` delivery that nothing executes produces no error, because nothing failed. That is precisely the 145-day FAO silence (**C-121**, **C-99**), surviving the redesign. ADR-017 §13 names it honestly as *"not a locked door — a hole in the floor"*. **Exit, two parts, both already written into the amendment:** `REQUIRE.max_age` is mandatory whenever `intent = live()` (§5 freshness rule), and `tools/liveness` reports **derived status beside declared intent** (§7), so `live()` + "never delivered" is a visible contradiction rather than an absence. Registered separately from C-121 because C-121 is the defect in today's code and this is the residual risk in tomorrow's design — closing one does not close the other. Cross-refs: **C-121**, **C-99**, **C-110**. |
+
 ---
 
 ## Disagreements
@@ -1655,3 +1679,14 @@
 | **Source** | expert-code-review (2026-08-04; Hickey vs Martin/Beck) |
 | **Status** | Open |
 | **Notes** | **Hickey:** views-models has exactly **one** composition (`monthly_run.sh`). Abstracting at n=1 is precisely the wrong-abstraction risk the rule exists to prevent, and a manifest that acquires conditionals has become a program. **Martin and Beck:** the second instance already exists one repo away — `crafd/` was cloned from `unfao/` per `docs/CLONING.md`, and views-postprocessing #211 is the recorded scar of that clone (*"every partner-scoped guard was scoped to ONE partner"*). **Provisional resolution:** the trigger has fired for views-postprocessing, **not** for views-models. Defer, behind C-122's named trigger. When it fires, copy views-postprocessing's remedy — a declared list asserted against the filesystem — not a framework. Unanimous against a dependency resolver and against moving composition into pipeline-core. |
+
+---
+
+### D-09 — Should the `REQUIRE` block be mandatory, or is it ceremony?
+
+| Field | Value |
+|---|---|
+| **Trigger** | Writing a delivery file that has nothing to assert |
+| **Source** | expert-code-review (2026-08-04; Martin/Ousterhout vs Nygard/Kleppmann) |
+| **Status** | Open |
+| **Notes** | **Martin and Ousterhout:** make the block optional. A `REQUIRE` holding one line will read as boilerplate, and the first person who deletes an empty one teaches everyone else to delete theirs. A block that is always present stops carrying information. **Nygard and Kleppmann:** make it mandatory — `max_age` and `reconciled` are exactly the assertions whose absence caused real failures, and optional safety is not safety. **Provisional resolution (written into ADR-017 §5):** the *block* is optional; specific *rules* are conditional on the delivery's shape — `reconciled` is required with two or more sources, `max_age` is required when `intent = live()`. Requirement follows from what the delivery is, not from ceremony. Revisit if a delivery file appears with an empty `REQUIRE`. |


### PR DESCRIPTION
## What

Splits ADR-017 into three containable ADRs plus one living reference page. **Documents only — no code, nothing under `deliveries/` is built.**

| document | pages | what it decides |
|---|---|---|
| **ADR-017** *(revised)* | 9 | the three axes: maturity on the source, composition on the ensemble, delivery as a `sources → consumer` edge |
| **ADR-019** *(new)* | 6 | the delivery declaration — `deliveries/<consumer>.py`, its keys and their values |
| **ADR-020** *(new)* | 3 | errors send the reader one level down, and where the stairs end |
| **`docs/forecast_delivery_map.md`** *(new)* | 4 | today's state. **Not an ADR** |
| **ADR-000** *(amended)* | — | +15 lines: splitting for containment is not a supersession |

## Why

ADR-017 had grown to ~13 pages holding four things that change at four different rates. One of them — the map of today's system — is *"a shrinking list, by design"*, which contradicts ADR-000's *"decisions are never deleted… superseded, not erased."*

**A section designed to shrink cannot live in a document that is never meant to change.** The second reason is supersession granularity: if the delivery file format is later replaced, we retire one document whole rather than amputating a third of another.

## No decision is reversed

Every heading of the 418-line original maps to exactly one destination:

| ADR-017 § | went to |
|---|---|
| §1 the two stores / two dialects | `docs/forecast_delivery_map.md` |
| §4d serving-time curation | ADR-019 §5 |
| §4f the delivery file | ADR-019 §1–§3 |
| §5 delivery-specific rules | ADR-019 §4 *(maturity rules R1/R2 stay in 017)* |
| §13 errors must descend | ADR-020 |
| everything else | stays in ADR-017 |

## Two claims were checked and corrected, not carried over

- **ADR-017 §1 was inverted.** It said the live FAO leg reads `type="ensemble"` and so can never see `rusty_bucket`'s output. In fact the legacy leg was **retired in #149** and the contract leg is the only one. The real failure is narrower and more tractable: the wire is built on both sides and **the step that moves the artifact between buckets has never run**.
  This also means **register C-97 is marked Resolved on a claim that is not true** — it says a manifest-addressed run *"is what faoapi serves"*, but faoapi reads `unfao_bucket` and that run is in `production_forecasts`. The map records this; fixing C-97's status is out of scope here.
- **"delivering a lone model needs a fake ensemble"** — no one-member ensemble exists in the repo. Restated as a constraint that would force one, not an observation of one.

## Decisions taken here that were previously implicit

Both were found by asking "what values can this key take?" and discovering the documents did not say.

- **`tier` has exactly one value, `prod`.** With one value the maturity gate is currently unconditional — stated plainly so it cannot read as a rich vocabulary that merely looks small in an example. A second value is **blocked on ADR-017 §12's open shadow-destination question**, which is named as the trigger. *(A first draft invented `internal`; that would have silently answered §12 in a footnote. Reverted.)*
- **The `deployment_status` → `maturity` migration is now tabled**, and `deployed` maps to `graduate` **only where R2 holds, else `candidate`**. A straight rename breaks R2 on day one: exactly one source is `deployed`, and both its members are `shadow` — so the migration would violate this ADR's own rule the day it lands. Demoting it changes no behaviour, because it has no delivery edge.

Every key in both ADRs now carries its allowed values and whether the set is **closed** (listed here, anything else is an error) or **open** (a name checked against something outside this repository). The two open sets — `targets` and `coverage` — are exactly the two checks ADR-020 §4 records as leaving the repo.

## Also

Concrete names throughout the three ADRs are marked as **examples**; the map carries the opposite note, because there the names *are* the content. ADR-017 gained file examples for all three axes, matching ADR-019's.

## Verification

- `pytest -k "adr or seam or citation or doc"` → **70 passed, 3 skipped**
- No dangling `§4f` / `§13` references; no reference to `meta/consumers.py` survives
- All four render: 9 / 6 / 3 / 4 pages

**ADR-017 is 9 pages against this repo's 1–3 page norm.** Flagged rather than hidden: everything left serves one decision, so a further split would fragment rather than contain.

Closes nothing. **#282** stays open as the release tracker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
