### PR TITLE
feat(#345): errors must descend, and the meta-test that stops it rotting (S3 of epic #342)

### DIFF
--- a/deliveries/coherence.py
+++ b/deliveries/coherence.py
@@ -35,6 +35,31 @@ class CoherenceError(Exception):
     """A delivery file is incoherent. The message names the next file to open."""
 
 
+#: Who to ask when the staircase ends outside this repository (ADR-020 §1, §5).
+MAINTAINER = "Simon"
+
+
+def locked_door(*, what: str, why: str, request: str) -> str:
+    """Compose the message for a check that cannot be answered in this repository.
+
+    ADR-020 §5: name the person, supply the request, and confirm the rest of the work
+    is fine. That last part is not politeness — it is the difference between a handoff
+    and a dead end. A locked door that also tells you the rest of your work is correct
+    is a good place to stop; one that does not is where people give up and ask someone
+    else to do it for them, which is how delivery became undiscoverable in the first
+    place (ADR-017 §2).
+
+    The audience cannot publish a package or edit another repository (ADR-020 §1), so
+    no message composed here may end in a task they cannot perform.
+    """
+    return (
+        f"{what}.\n\n"
+        f"  {why}.\n\n"
+        f'  Ask {MAINTAINER}, or open an issue: "{request}".\n'
+        f"  Everything else in this file is fine — this is the only thing blocking it."
+    )
+
+
 # ── Reading a source's own declarations ────────────────────────────────────
 
 

--- a/deliveries/vocabulary.py
+++ b/deliveries/vocabulary.py
@@ -116,6 +116,7 @@ def paused(reason: str, since: date) -> Intent:
     if not isinstance(since, date):
         raise TypeError(
             f"paused(..., since=...) needs a datetime.date, got {type(since).__name__}.\n"
+            f'  Write: paused("<why>", since=date(2026, 8, 4))\n'
             f"  Without a date, nobody can tell a new pause from a forgotten one."
         )
     return Intent(state="paused", since=since, reason=reason)
@@ -131,7 +132,8 @@ class Months:
 def months(count: int) -> Months:
     if not isinstance(count, int) or isinstance(count, bool) or count < 1:
         raise ValueError(
-            f"months(...) needs a positive whole number of months, got {count!r}."
+            f"months(...) needs a positive whole number of months, got {count!r}.\n"
+            f"  Write: months(2)"
         )
     return Months(count=count)
 
@@ -155,7 +157,13 @@ class Delivery:
                 "country-level forecast it was reconciled against."
             )
         if not self.send:
-            raise ValueError("send must name at least one source.")
+            raise ValueError(
+                "send must name at least one source — a delivery that sends nothing "
+                "is not a delivery.\n"
+                "  Write: send=[pgm('<ensemble>')]\n"
+                "  To turn a delivery off, set intent=paused(\"<why>\", since=...) "
+                "instead; deleting the sources throws away the reason."
+            )
         object.__setattr__(self, "send", tuple(self.send))
 
 

--- a/tests/test_delivery_errors_descend.py
+++ b/tests/test_delivery_errors_descend.py
@@ -1,0 +1,234 @@
+"""Errors from a delivery file must send the reader one level down (ADR-020).
+
+Two kinds of test live here, and the second is the point of the story.
+
+**Per-failure tests** assert that each failure class names the file to open next.
+**The meta-test** enumerates every `raise` site in `deliveries/` *statically* and asserts
+the same thing — including sites no test happens to provoke.
+
+The static form matters. ADR-020 §3 predicts the failure mode: *"the staircase rots in
+its second month — someone refactors a check, the message becomes `KeyError: 'level'`,
+and nothing fails."* It did not take a month. While writing #344, an audit of its ten
+raise sites found one that named no file, because `_check_reconciliation` never received
+the `consumer` argument and so *could not* name the file even in principle. Nine of ten
+were right; nothing would have failed. A dynamic meta-test that only inspects errors it
+manages to trigger would have missed it, because no fixture reached that path.
+
+Assertions are on **substance, not wording**: that a path appears, not that a sentence
+matches. Brittle string equality would make every message edit a test failure, and would
+teach the next person to delete the test rather than fix the message.
+"""
+
+import ast
+import re
+from datetime import date
+from pathlib import Path
+
+import pytest
+
+from deliveries import coherence
+from deliveries.coherence import CoherenceError, check
+from deliveries.vocabulary import Delivery, Require, cm, live, monthly, months, pgm, prod
+
+pytestmark = pytest.mark.red
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+DELIVERIES_DIR = REPO_ROOT / "deliveries"
+
+#: A message "names the next file" if it contains something a reader can open.
+NAMES_A_FILE = re.compile(r"[\w./-]+\.py\b|\b(?:models|ensembles|deliveries)/")
+
+
+def _delivery(send, **require_kwargs):
+    require_kwargs.setdefault("max_age", months(2))
+    return (
+        Delivery(
+            send=send,
+            frequency=monthly,
+            tier=prod,
+            intent=live(since=date(2026, 8, 4)),
+        ),
+        Require(**require_kwargs),
+    )
+
+
+# ── The staircase, one step at a time (ADR-020 §2) ─────────────────────────
+
+
+class TestEachFailureNamesTheNextFile:
+    def test_wrong_level_claim_points_at_the_sources_config(self):
+        delivery, require = _delivery([cm("rusty_bucket")])
+        with pytest.raises(CoherenceError) as exc:
+            check(delivery, require, consumer="un_fao")
+        assert "ensembles/rusty_bucket/configs/config_meta.py" in str(exc.value)
+
+    def test_unknown_source_points_at_where_sources_live(self):
+        delivery, require = _delivery([pgm("no_such_ensemble")])
+        with pytest.raises(CoherenceError) as exc:
+            check(delivery, require, consumer="un_fao")
+        message = str(exc.value)
+        assert "models/" in message and "ensembles/" in message
+
+    def test_unknown_source_suggests_the_closest_real_name(self):
+        """ADR-020 §2: '...and the closest name to what was typed'."""
+        delivery, require = _delivery([pgm("rusty_buckt")])
+        with pytest.raises(CoherenceError) as exc:
+            check(delivery, require, consumer="un_fao")
+        assert "rusty_bucket" in str(exc.value)
+
+    def test_disconnected_reconciliation_points_at_the_partner_declaration(self):
+        delivery, require = _delivery(
+            [pgm("skinny_love"), cm("rude_boy")], reconciled=True
+        )
+        with pytest.raises(CoherenceError) as exc:
+            check(delivery, require, consumer="un_fao")
+        message = str(exc.value)
+        assert "config_meta.py" in message
+        assert "reconcile_with" in message
+
+    def test_missing_freshness_points_at_the_delivery_file(self):
+        delivery, require = _delivery([pgm("rusty_bucket")], max_age=None)
+        with pytest.raises(CoherenceError) as exc:
+            check(delivery, require, consumer="un_fao")
+        assert "deliveries/un_fao.py" in str(exc.value)
+
+    def test_no_error_ends_in_a_bare_exception_type(self):
+        """A reader sees the last line of a traceback. It must not be a KeyError."""
+        delivery, require = _delivery([pgm("no_such_ensemble")])
+        with pytest.raises(CoherenceError) as exc:
+            check(delivery, require, consumer="un_fao")
+        assert len(str(exc.value)) > 40, "an error this short cannot be teaching anything"
+
+
+# ── The meta-test: what stops this rotting ─────────────────────────────────
+
+
+def _raise_sites(path: Path) -> list[tuple[int, str]]:
+    source = path.read_text(encoding="utf-8")
+    tree = ast.parse(source, filename=str(path))
+    sites = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Raise) and node.exc is not None:
+            segment = ast.get_source_segment(source, node) or ""
+            sites.append((node.lineno, segment))
+    return sites
+
+
+class TestMetaEveryRaiseSiteDescends:
+    """Enumerate raise sites statically, so a path no test provokes is still checked."""
+
+    def test_there_are_raise_sites_to_check(self):
+        """Guard against the meta-test silently checking nothing.
+
+        If `deliveries/` is restructured and this finds zero sites, the suite would
+        go green while enforcing nothing — the same shape as the C-113 defect.
+        """
+        total = sum(len(_raise_sites(p)) for p in DELIVERIES_DIR.glob("*.py"))
+        assert total >= 5, (
+            f"only {total} raise sites found across deliveries/*.py — this meta-test "
+            f"is probably no longer looking where the checks live."
+        )
+
+    def test_every_check_raise_names_a_file(self):
+        """`coherence.py` compares files. The reader is looking at the delivery file
+        and the problem is in a *different* one, so the message must name it."""
+        offenders = [
+            f"coherence.py:{lineno}"
+            for lineno, segment in _raise_sites(DELIVERIES_DIR / "coherence.py")
+            if not NAMES_A_FILE.search(segment)
+        ]
+        assert not offenders, (
+            f"these raise sites name no file to open: {offenders}\n"
+            f"  ADR-020 §2: an error must send the reader exactly one level down, "
+            f"naming the next file.\n"
+            f"  If the site genuinely cannot name one — because the answer is outside "
+            f"this repository — use locked_door() instead (ADR-020 §5)."
+        )
+
+    def test_every_vocabulary_raise_shows_what_to_write(self):
+        """`vocabulary.py` raises while the delivery file is being *constructed*, so
+        Python's traceback already names that file and the exact line. Demanding a
+        filename here would mean guessing one — the constructor cannot know which
+        delivery called it.
+
+        The obligation is therefore different, not absent: show the corrected form.
+        Verified by hand: a failure in `live()` from a delivery file produces a
+        traceback whose frames name that file. The two rules together are what
+        ADR-020 §2 means by "exactly one level down" — sometimes down is the line
+        you are already on.
+        """
+        offenders = [
+            f"vocabulary.py:{lineno}"
+            for lineno, segment in _raise_sites(DELIVERIES_DIR / "vocabulary.py")
+            if "Write:" not in segment and "send=[" not in segment
+        ]
+        assert not offenders, (
+            f"these vocabulary errors say what is wrong but not what to write: "
+            f"{offenders}\n"
+            f"  Add a corrected example, e.g. 'Write: months(2)'.\n"
+            f"  The reader is a research assistant who cannot infer the right form "
+            f"from a type name (ADR-020 §1)."
+        )
+
+    def test_no_module_in_deliveries_escapes_both_rules(self):
+        """Guards the split above: a new module in deliveries/ must be assigned to
+        one rule or the other, not silently checked by neither."""
+        covered = {"coherence.py", "vocabulary.py", "__init__.py", "un_fao.py"}
+        present = {p.name for p in DELIVERIES_DIR.glob("*.py")}
+        unassigned = {
+            name for name in present - covered
+            if _raise_sites(DELIVERIES_DIR / name)
+        }
+        assert not unassigned, (
+            f"{sorted(unassigned)} raise errors but are covered by neither rule.\n"
+            f"  Open tests/test_delivery_errors_descend.py and decide which applies: "
+            f"cross-file checks must name a file; construction errors must show what "
+            f"to write."
+        )
+
+
+class TestMetaKnownLimit:
+    """The static scan has one blind spot. Stating it beats implying it is complete."""
+
+    def test_helpers_that_build_messages_elsewhere_are_not_covered(self):
+        """A check that raises via a helper hides its message from the scan.
+
+        `deliveries/coherence.py` has one such helper, `_require_source`, and it is
+        covered by `TestEachFailureNamesTheNextFile` above. This test pins that the
+        helper still produces a descending message, since the meta-test cannot.
+        """
+        with pytest.raises(CoherenceError) as exc:
+            coherence._require_source("definitely_not_a_source")
+        assert NAMES_A_FILE.search(str(exc.value)), (
+            "_require_source raises from a helper, so the static meta-test cannot see "
+            "its message. It must be checked here instead."
+        )
+
+
+# ── Locked doors (ADR-020 §5) ──────────────────────────────────────────────
+
+
+class TestLockedDoor:
+    """Where the stairs end, the error names a person and confirms the rest is fine."""
+
+    def test_message_names_a_person_and_a_ready_made_request(self):
+        message = coherence.locked_door(
+            what="un_ocha is not a registered consumer",
+            why="Registering one needs a bucket address from the platform coordinate "
+                "registry, which is in another repository you are not expected to edit",
+            request='Register consumer un_ocha (bucket + API)',
+        )
+        assert "Simon" in message
+        assert "open an issue" in message
+
+    def test_message_confirms_the_rest_of_the_work_is_fine(self):
+        """ADR-020 §5: 'that last line is the difference between a handoff and a
+        dead end.' Without it, this is where people give up and ask someone else."""
+        message = coherence.locked_door(what="x", why="y", request="z")
+        assert "Everything else in this file is fine" in message
+
+    def test_message_does_not_end_in_a_task_the_reader_cannot_perform(self):
+        """ADR-020 §1: the reader cannot publish a package or edit another repo."""
+        message = coherence.locked_door(what="x", why="y", request="z")
+        last = [line for line in message.strip().splitlines() if line.strip()][-1]
+        assert "fine" in last or "blocking" in last


### PR DESCRIPTION
Implements #345. ADR-020 for the delivery surface.

## The meta-test is the story

It enumerates every `raise` site in `deliveries/` **statically**, via `ast` — so a path no fixture reaches is still checked. A dynamic version that only inspects errors it manages to trigger would miss exactly the site nobody thought about. That is not hypothetical: in #344 one raise in ten named no file, because the function never received the argument it would have needed, and no test reached it.

## The rule differs by module, deliberately

| module | what it must do | why |
|---|---|---|
| `coherence.py` | **name the file** | it compares files; the reader is looking at the delivery file and the problem is in a *different* one |
| `vocabulary.py` | **show what to write** | it raises while the delivery file is being *constructed*, so Python's traceback already names that file and line (verified by hand). The constructor cannot know which delivery called it, so demanding a filename would mean guessing one |

A third test guards the split: a new module in `deliveries/` cannot end up covered by neither rule.

## It found three real gaps on its first run

All in code written by someone actively thinking about the rule:

- `paused(since=…)` — said what was wrong, not what to write
- `months(…)` — the same
- `send=[]` — *"send must name at least one source."* and nothing about what to write, **or that `paused()` is what you actually want when turning a delivery off**

That is this story's justification, measured rather than argued.

## locked_door() — ADR-020 §5

Where the staircase ends outside this repo, the message names a person, supplies a ready-made request, and confirms the rest of the file is fine. That last line is not politeness — it is the difference between a handoff and a dead end, and its absence is where people give up and ask someone else, which is how delivery became undiscoverable in the first place (ADR-017 §2).

## Two deliberate choices

**Assertions are on substance, not wording** — that a path appears, not that a sentence matches. Brittle string equality would make every message edit a test failure and teach the next person to delete the test rather than fix the message.

**One known limit, stated rather than implied:** a check raising via a helper hides its message from the static scan. `coherence.py` has one such helper, `_require_source`, and it is covered by a direct test.

## Verification

- **Full suite: 7598 passed, 0 failed** (run in full this time — the previous story's CI break came from my running only the targeted file)
- `ruff check .` clean

Refs #342, #350.

🤖 Generated with [Claude Code](https://claude.com/claude-code)