### PR TITLE
feat(#346): derive is_in_production, and report what is declared (S4 of epic #342)

### DIFF
--- a/deliveries/coherence.py
+++ b/deliveries/coherence.py
@@ -86,7 +86,7 @@ def _source_dir(name: str) -> Path | None:
     return None
 
 
-def _config(source: str, which: str) -> dict:
+def source_config(source: str, which: str) -> dict:
     """Load one of a source's config dicts, or {} if that config does not exist."""
     directory = _source_dir(source)
     if directory is None:
@@ -99,7 +99,7 @@ def _config(source: str, which: str) -> dict:
     return getter() if getter else {}
 
 
-def _require_source(name: str) -> Path:
+def require_source(name: str) -> Path:
     directory = _source_dir(name)
     if directory is None:
         raise CoherenceError(
@@ -133,8 +133,8 @@ def maturity_of(source: str, _seen: frozenset[str] = frozenset()) -> str:
             f"  Open ensembles/{source}/configs/config_modelset.py and break the cycle.\n"
             f"  An ensemble cannot contain itself; its maturity would have no answer."
         )
-    _require_source(source)
-    status = _config(source, "deployment").get("deployment_status")
+    require_source(source)
+    status = source_config(source, "deployment").get("deployment_status")
     if status is None:
         # Four source directories carry no config_deployment.py at all (ADR-017 §3).
         return "candidate"
@@ -144,7 +144,7 @@ def maturity_of(source: str, _seen: frozenset[str] = frozenset()) -> str:
         # ADR-017 §3: `graduate` only where R2 already holds, else `candidate`. A
         # straight rename would make the repo's one `deployed` ensemble a graduate
         # with candidate members — a violation of ADR-017's own rule on day one.
-        members = _config(source, "modelset").get("models", [])
+        members = source_config(source, "modelset").get("models", [])
         deeper = _seen | {source}
         if members and all(maturity_of(m, deeper) == "graduate" for m in members):
             return "graduate"
@@ -161,8 +161,8 @@ def maturity_of(source: str, _seen: frozenset[str] = frozenset()) -> str:
 
 def _check_resolution_and_level(delivery) -> None:
     for source in delivery.send:
-        directory = _require_source(source.name)
-        declared = _config(source.name, "meta").get("level")
+        directory = require_source(source.name)
+        declared = source_config(source.name, "meta").get("level")
         if declared is None:
             raise CoherenceError(
                 f"{source.level}('{source.name}') cannot be checked: that source "
@@ -198,7 +198,7 @@ def _check_reconciliation(delivery, require, consumer: str) -> None:
     # One connected group covering every source listed (ADR-019 §4).
     edges: set[frozenset[str]] = set()
     for name in names:
-        meta = _config(name, "meta")
+        meta = source_config(name, "meta")
         partner = meta.get("reconcile_with")
         if meta.get("reconciliation") and partner:
             edges.add(frozenset((name, partner)))
@@ -254,7 +254,7 @@ def _check_tier(delivery, consumer: str) -> None:
 def _check_maturity_rules(delivery) -> None:
     """R1 and R2 (ADR-017 §5), for the ensembles a delivery actually names."""
     for source in delivery.send:
-        members = _config(source.name, "modelset").get("models", [])
+        members = source_config(source.name, "modelset").get("models", [])
         if not members:
             continue
         own = maturity_of(source.name)

--- a/deliveries/status.py
+++ b/deliveries/status.py
@@ -1,0 +1,177 @@
+"""Derived delivery status — "in production" is worked out, never typed (ADR-017 §4e).
+
+    A source is *in production* ⟺ its maturity is `graduate` **and** a delivery ships
+    it (directly, or via a composite that contains it) to a **production-tier** consumer.
+
+Nobody writes "deployed" anywhere. The answer is computed from the source's own maturity
+and the delivery edges in `deliveries/`, so there is no field that can lie.
+
+**What this module does not do.** It reads declarations. It observes nothing: no bucket,
+no run, no artifact. A delivery declared `live()` that no runner ever executes is
+invisible here, because nothing failed — ADR-020 §4's "hole in the floor", register
+C-126, and the failure that actually happened (#320). The observation side is
+`python -m tools.liveness`, and `report()` says so in its own output rather than leaving
+a reader to assume it checked.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+from deliveries.coherence import CoherenceError, maturity_of, require_source, source_config
+
+DELIVERIES_DIR = Path(__file__).resolve().parent
+REPO_ROOT = DELIVERIES_DIR.parent
+
+#: Modules in deliveries/ that are machinery, not declarations.
+_NOT_A_DELIVERY = {"__init__", "vocabulary", "coherence", "status"}
+
+
+def delivery_files() -> list[Path]:
+    """Every `deliveries/<consumer>.py`. The filename is the consumer (ADR-019 §1)."""
+    return sorted(
+        path for path in DELIVERIES_DIR.glob("*.py")
+        if path.stem not in _NOT_A_DELIVERY
+    )
+
+
+def load_delivery(path: Path):
+    spec = importlib.util.spec_from_file_location(f"_delivery_{path.stem}", path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _members_of(source: str) -> list[str]:
+    return source_config(source, "modelset").get("models", [])
+
+
+def delivered_sources() -> dict[str, list[str]]:
+    """Every source reachable from a delivery, mapped to the consumers reached.
+
+    Walks composites: ADR-017 §4a says a model inside a delivered ensemble is in
+    production *transitively*, so naming the ensemble is not enough — the members
+    have to be followed.
+    """
+    reached: dict[str, list[str]] = {}
+
+    def visit(name: str, consumer: str, seen: frozenset[str]) -> None:
+        if name in seen:
+            raise CoherenceError(
+                f"'{name}' is a member of itself, directly or through "
+                f"{' -> '.join(sorted(seen))}.\n"
+                f"  Open ensembles/{name}/configs/config_modelset.py and break the cycle."
+            )
+        reached.setdefault(name, [])
+        if consumer not in reached[name]:
+            reached[name].append(consumer)
+        for member in _members_of(name):
+            visit(member, consumer, seen | {name})
+
+    for path in delivery_files():
+        module = load_delivery(path)
+        for source in module.DELIVERY.send:
+            visit(source.name, path.stem, frozenset())
+    return reached
+
+
+def consumers_for(source: str) -> list[str]:
+    """Which consumers this source reaches, directly or as a member."""
+    return delivered_sources().get(source, [])
+
+
+def in_production(source: str) -> bool:
+    """ADR-017 §4e's conjunction. Computed on demand; never stored.
+
+    The second conjunct is written for the general case. `tier` has exactly one value
+    today (ADR-019 §3), so "to a production-tier consumer" is currently equivalent to
+    "at all" — do not read it as a check that is discriminating yet (register C-131).
+    """
+    require_source(source)
+    if maturity_of(source) != "graduate":
+        return False
+    # Must be reached by a delivery that is ITSELF production-tier. Checking "some
+    # prod delivery exists" and "this source is delivered somewhere" separately
+    # would conflate two different deliveries — currently indistinguishable, because
+    # `tier` has one value, and wrong the moment it has two (register C-131).
+    return any(
+        consumer in _prod_tier_consumers()
+        for consumer in consumers_for(source)
+    )
+
+
+def _prod_tier_consumers() -> set[str]:
+    return {
+        path.stem for path in delivery_files()
+        if load_delivery(path).DELIVERY.tier.name == "prod"
+    }
+
+
+def report() -> str:
+    """A read-only summary of what the repository *declares* about its deliveries."""
+    lines = [
+        "Declared delivery state",
+        "=" * 60,
+        "",
+        "Everything below is DECLARED, not observed. No bucket was read and no run",
+        "was checked. A delivery declared live that no runner executes looks",
+        "exactly like one that shipped this morning (ADR-020 §4, register C-126).",
+        "For what actually happened, run:  python -m tools.liveness",
+        "",
+    ]
+
+    paths = delivery_files()
+    if not paths:
+        lines.append("No delivery files. Expected deliveries/<consumer>.py (ADR-019 §1).")
+        return "\n".join(lines)
+
+    for path in paths:
+        module = load_delivery(path)
+        delivery, require = module.DELIVERY, module.REQUIRE
+        intent = delivery.intent
+        state = intent.state
+        if intent.reason:
+            state += f" — {intent.reason}"
+
+        lines += [
+            f"{path.stem}",
+            f"  declared in   deliveries/{path.name}",
+            f"  frequency     {delivery.frequency.name}",
+            f"  tier          {delivery.tier.name}",
+            f"  intent        {state}  (since {intent.since})",
+            "  sends",
+        ]
+        for source in delivery.send:
+            maturity = maturity_of(source.name)
+            produced = "in production" if in_production(source.name) else "not in production"
+            lines.append(
+                f"    {source.level}({source.name})  maturity={maturity}  → {produced}"
+            )
+            members = _members_of(source.name)
+            if members:
+                lines.append(f"      via {len(members)} members, transitively")
+
+        if require.max_age:
+            lines.append(f"  max_age       {require.max_age.count} months")
+        else:
+            lines.append("  max_age       none declared")
+        if require.targets:
+            lines.append(f"  targets       {', '.join(require.targets)}  (not checked here)")
+        if require.coverage:
+            lines.append(f"  coverage      {require.coverage}  (not checked here)")
+        lines.append("")
+
+    lines += [
+        "-" * 60,
+        "'in production' is derived from maturity + a delivery edge (ADR-017 §4e).",
+        "It is not stored anywhere, so there is no field that can be wrong.",
+        "",
+        "targets and coverage are declared but not verified here — both are answered",
+        "outside this repository (ADR-020 §4).",
+    ]
+    return "\n".join(lines)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    print(report())

--- a/tests/test_delivery_coherence.py
+++ b/tests/test_delivery_coherence.py
@@ -214,9 +214,9 @@ class TestCycleGuard:
         cannot act on."""
         import deliveries.coherence as coh
 
-        monkeypatch.setattr(coh, "_require_source", lambda name: tmp_path / name)
+        monkeypatch.setattr(coh, "require_source", lambda name: tmp_path / name)
         monkeypatch.setattr(
-            coh, "_config",
+            coh, "source_config",
             lambda src, which: {"deployment_status": "deployed"} if which == "deployment"
             else {"models": ["loopy"]} if which == "modelset" else {},
         )

--- a/tests/test_delivery_errors_descend.py
+++ b/tests/test_delivery_errors_descend.py
@@ -129,12 +129,17 @@ class TestMetaEveryRaiseSiteDescends:
             f"is probably no longer looking where the checks live."
         )
 
+    #: Modules whose errors are about *other* files, so must name one.
+    NAMES_FILES = ("coherence.py", "status.py")
+
     def test_every_check_raise_names_a_file(self):
-        """`coherence.py` compares files. The reader is looking at the delivery file
-        and the problem is in a *different* one, so the message must name it."""
+        """`coherence.py` and `status.py` reason across files. The reader is looking
+        at the delivery file and the problem is in a *different* one, so the message
+        must name it."""
         offenders = [
-            f"coherence.py:{lineno}"
-            for lineno, segment in _raise_sites(DELIVERIES_DIR / "coherence.py")
+            f"{name}:{lineno}"
+            for name in self.NAMES_FILES
+            for lineno, segment in _raise_sites(DELIVERIES_DIR / name)
             if not NAMES_A_FILE.search(segment)
         ]
         assert not offenders, (
@@ -173,7 +178,7 @@ class TestMetaEveryRaiseSiteDescends:
     def test_no_module_in_deliveries_escapes_both_rules(self):
         """Guards the split above: a new module in deliveries/ must be assigned to
         one rule or the other, not silently checked by neither."""
-        covered = {"coherence.py", "vocabulary.py", "__init__.py", "un_fao.py"}
+        covered = set(self.NAMES_FILES) | {"vocabulary.py", "__init__.py", "un_fao.py"}
         present = {p.name for p in DELIVERIES_DIR.glob("*.py")}
         unassigned = {
             name for name in present - covered
@@ -193,14 +198,14 @@ class TestMetaKnownLimit:
     def test_helpers_that_build_messages_elsewhere_are_not_covered(self):
         """A check that raises via a helper hides its message from the scan.
 
-        `deliveries/coherence.py` has one such helper, `_require_source`, and it is
+        `deliveries/coherence.py` has one such helper, `require_source`, and it is
         covered by `TestEachFailureNamesTheNextFile` above. This test pins that the
         helper still produces a descending message, since the meta-test cannot.
         """
         with pytest.raises(CoherenceError) as exc:
-            coherence._require_source("definitely_not_a_source")
+            coherence.require_source("definitely_not_a_source")
         assert NAMES_A_FILE.search(str(exc.value)), (
-            "_require_source raises from a helper, so the static meta-test cannot see "
+            "require_source raises from a helper, so the static meta-test cannot see "
             "its message. It must be checked here instead."
         )
 

--- a/tests/test_derived_production_status.py
+++ b/tests/test_derived_production_status.py
@@ -1,0 +1,131 @@
+""""In production" is derived, never declared (ADR-017 §4e).
+
+    A source is *in production* ⟺ its maturity is `graduate` **and** a delivery ships
+    it (directly, or via a composite that contains it) to a **production-tier** consumer.
+
+Two things this file is careful about.
+
+**Transitivity.** ADR-017 §4a: a model inside a delivered ensemble is in production
+*transitively*. The derivation has to walk `config_modelset.py`, not just look at what
+`send` names.
+
+**Not over-claiming.** The report says what is *declared*. It observes nothing. A
+declared-live delivery that nothing ever runs is invisible to it — that is ADR-020 §4's
+"hole in the floor" (register C-126), and it is the failure that actually happened
+(#320). Wording that implied otherwise would be the truthfulness bug ADR-005 and C-75
+exist to prevent, so a test pins that the report says so out loud.
+"""
+
+from pathlib import Path
+
+import pytest
+
+from deliveries.status import (
+    delivered_sources,
+    in_production,
+    report,
+)
+
+pytestmark = pytest.mark.beige
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+# ── The derivation ─────────────────────────────────────────────────────────
+
+
+class TestDerivation:
+    def test_candidate_source_is_not_in_production(self):
+        """`rusty_bucket` is delivered to FAO but is `candidate` (was `shadow`),
+        so the first conjunct fails. It is delivered, not in production."""
+        assert in_production("rusty_bucket") is False
+
+    def test_undelivered_source_is_not_in_production(self):
+        """`pink_ponyclub` runs monthly and ships to the public API, but no
+        `deliveries/*.py` names it, so the second conjunct fails."""
+        assert in_production("pink_ponyclub") is False
+
+    def test_both_conjuncts_are_required(self):
+        """Neither maturity nor a delivery edge alone is enough."""
+        for source in ("rusty_bucket", "pink_ponyclub", "white_mustang"):
+            assert in_production(source) is False
+
+    def test_transitive_membership_is_followed(self):
+        """ADR-017 §4a: a model inside a delivered ensemble is in production
+        *transitively*. Today no ensemble qualifies, so no member does either —
+        but the walk must actually happen, not be skipped."""
+        members = delivered_sources()
+        assert "rusty_bucket" in members, (
+            "rusty_bucket is named by deliveries/un_fao.py and must appear"
+        )
+        assert len(members) > 1, (
+            "delivered_sources() returned only the directly-named source — the walk "
+            "into config_modelset.py did not happen"
+        )
+
+    def test_unknown_source_fails_loudly(self):
+        from deliveries.coherence import CoherenceError
+
+        with pytest.raises(CoherenceError):
+            in_production("no_such_source_anywhere")
+
+
+# ── The value is computed, not stored ──────────────────────────────────────
+
+
+class TestNothingStoresTheAnswer:
+    def test_no_config_declares_is_in_production(self):
+        """ADR-017 §4e: "it can't lie, because there's no field to lie in."
+
+        If someone adds the field to a config, the derivation stops being the only
+        answer and the label can drift from reality — which is the entire defect
+        this ADR was written to remove.
+        """
+        offenders = []
+        for base in ("models", "ensembles", "postprocessors", "deliveries"):
+            for path in (REPO_ROOT / base).rglob("*.py"):
+                if "__pycache__" in path.parts:
+                    continue
+                text = path.read_text(encoding="utf-8", errors="ignore")
+                for i, line in enumerate(text.splitlines(), 1):
+                    if "is_in_production" in line and "def " not in line and "import" not in line:
+                        offenders.append(f"{path.relative_to(REPO_ROOT)}:{i}")
+        assert not offenders, (
+            f"'is_in_production' appears as data, not a derivation: {offenders}\n"
+            f"  ADR-017 §4e: the value is worked out on demand and never stored."
+        )
+
+
+# ── The report ─────────────────────────────────────────────────────────────
+
+
+class TestReport:
+    def test_names_every_declared_field(self):
+        text = report()
+        for field in ("frequency", "tier", "intent", "un_fao", "rusty_bucket"):
+            assert field in text, f"the report does not mention {field!r}"
+
+    def test_frequency_has_a_consumer(self):
+        """ADR-019 §3 makes `frequency` required. A required key nothing reads is
+        decoration. `monthly_run.sh` is deliberately not changed by this epic, so
+        the report is what gives the key a reader."""
+        assert "monthly" in report()
+
+    def test_says_plainly_that_it_observed_nothing(self):
+        """C-126 / ADR-020 §4: a declared-live delivery that nothing runs produces
+        no error, because nothing failed. The report must not imply it checked."""
+        text = report().lower()
+        assert "declared" in text
+        assert any(
+            phrase in text
+            for phrase in ("not observed", "does not observe", "no observation")
+        ), "the report must say it reports declarations, not observations"
+
+    def test_points_at_the_instrument_that_does_observe(self):
+        """ADR-017 §7: the declaration side is here, the verification side is
+        `tools/liveness`. A reader asking "did it actually ship?" needs the pointer."""
+        assert "tools.liveness" in report() or "tools/liveness" in report()
+
+    def test_runs_offline(self):
+        """No network, no Appwrite. This reads files only."""
+        report()


### PR DESCRIPTION
Implements #346. ADR-017 §4e: *in production ⟺ maturity is `graduate` **and** a delivery ships it (directly, or via a composite that contains it) to a production-tier consumer.* Computed on demand, stored nowhere.

A test pins that `is_in_production` never appears **as data** anywhere in `models/`, `ensembles/`, `postprocessors/` or `deliveries/`. The moment it does, the derivation stops being the only answer and the label can drift — the defect ADR-017 exists to remove.

## Transitivity is real, not decorative

ADR-017 §4a: a model inside a delivered ensemble is in production *transitively*. `delivered_sources()` walks `config_modelset.py`, turning one named source into nine reachable ones today. A test fails if the walk stops at the named source.

## The report says what it did not do

```
Everything below is DECLARED, not observed. No bucket was read and no run
was checked. A delivery declared live that no runner executes looks
exactly like one that shipped this morning (ADR-020 §4, register C-126).
For what actually happened, run:  python -m tools.liveness

un_fao
  frequency     monthly
  tier          prod
  intent        live  (since 2026-08-04)
  sends
    pgm(rusty_bucket)  maturity=candidate  → not in production
      via 8 members, transitively
```

A test asserts it says so. Wording that implied verification would be the truthfulness bug ADR-005 and **C-75** exist to prevent.

This also gives `frequency` a consumer — ADR-019 §3 made it required, and a required key nothing reads is decoration. `monthly_run.sh` is deliberately untouched (out of scope); the report says what *should* run, which is what **C-99** and **C-126** need, without changing the production ritual.

## Two defects found reviewing my own work

1. **A logic bug in `in_production()`.** It checked *"some prod delivery exists"* and *"this source is delivered somewhere"* as separate conditions — so a source delivered only by a non-prod delivery would count as long as any prod delivery existed. Indistinguishable today because `tier` has one value; **wrong the moment it has two** (C-131). Now checks the delivery reaching the source is itself prod-tier.
2. **`status.py` imported another module's privates** (`_config`, `_require_source`). Promoted to `source_config()` / `require_source()`. Duplicating the loader would risk two readers drifting on how configs are read — this is under-naming, not the WET case.

## #345's meta-test earned itself again

It caught `status.py` as a new module in `deliveries/` that raises errors but was covered by neither descent rule. That guard was written yesterday for exactly this.

## Verification

- **Full suite: 7609 passed, 0 failed**
- `ruff check .` clean

Refs #342, #350.

🤖 Generated with [Claude Code](https://claude.com/claude-code)