### PR TITLE
feat(#347): the FAO config derives its source from the delivery declaration (S5 of epic #342)

### DIFF
--- a/postprocessors/un_fao/configs/config_meta.py
+++ b/postprocessors/un_fao/configs/config_meta.py
@@ -1,25 +1,79 @@
+"""Meta configuration for the UN FAO postprocessor.
+
+**What this file decides, and what it no longer decides.**
+
+It used to carry a line of the form `"ensemble": "<a source name>"` — one hand-typed string choosing
+which forecast reaches the UN — under a docstring claiming that modifying this file
+"will not affect the model". That was false, and it is the specific defect ADR-019 was
+written to remove.
+
+The source is now **declared once**, in `deliveries/un_fao.py`, and *derived* here. The
+key survives because `views_postprocessing` reads `self.configs["ensemble"]`
+(`unfao/managers/unfao.py:140` and `:195`) one repository away; removing it would raise
+`KeyError` there. So the decision moved and the interface did not — ADR-017's principle
+applied literally: a thing that is never typed cannot lie.
+
+**To change which forecast goes to the UN, edit `deliveries/un_fao.py`. Not this file.**
+
+There is deliberately no fallback. If the declaration is missing or malformed this fails
+loudly (ADR-003): a silent default would deliver the *wrong forecast to a UN agency* and
+say nothing, which is worse than any error this file could raise.
+"""
+
+import sys
+from pathlib import Path
+
+# The delivery declaration lives at the repository root. run.sh is immutable, so
+# PYTHONPATH cannot be set there — the same bootstrap the reconciliation layer uses in
+# each ensemble's main.py (see ensembles/skinny_love/main.py:9).
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+
+def _declared_source() -> str:
+    """The single source this consumer is declared to receive.
+
+    Raises rather than guessing. Every failure names the file to open (ADR-020).
+    """
+    try:
+        from deliveries.un_fao import DELIVERY
+    except Exception as exc:
+        raise RuntimeError(
+            f"cannot read the FAO delivery declaration: {exc}.\n"
+            f"  Open deliveries/un_fao.py — it declares which forecast goes to the UN.\n"
+            f"  This config derives its source from that file and will not guess one."
+        ) from exc
+
+    sources = list(DELIVERY.send)
+    if len(sources) != 1:
+        raise RuntimeError(
+            f"deliveries/un_fao.py declares {len(sources)} sources, and this "
+            f"postprocessor can carry exactly one.\n"
+            f"  Open deliveries/un_fao.py and check `send`.\n"
+            f"  Delivering several sources to one consumer needs the reconciliation "
+            f"rules in ADR-019 §4, which the postprocessor does not yet implement."
+        )
+    return sources[0].name
+
+
 def get_meta_config():
     """
-    Contains the meta data for the model (model algorithm, name, target variable, and level of analysis).
-    This config is for documentation purposes only, and modifying it will not affect the model, the training, or the evaluation.
+    Meta data for the postprocessor (algorithm, name, targets, level).
+
+    `ensemble` is **derived** from deliveries/un_fao.py, not declared here — see the
+    module docstring.
 
     Returns:
-    - meta_config (dict): A dictionary containing model meta configuration.
+    - meta_config (dict): the postprocessor meta configuration.
     """
-    
+
     meta_config = {
-        "name": "un_fao", 
+        "name": "un_fao",
         "algorithm": "Postprocessor",
-        # Uncomment and modify the following lines as needed for additional metadata:
         "targets": ["lr_ged_sb", "lr_ged_ns", "lr_ged_os"],
-        # "queryset": "escwa001_cflong",
         "level": "pgm",
-        # The forecast ensemble whose .env credentials / upload metadata this
-        # postprocessor uses (it does NOT pool the ensemble by target name — it
-        # renames its own datafactory actuals via config_queryset.FEATURE_RENAME).
-        # rusty_bucket is the FAO global-land forecast ensemble (#77, #143);
-        # replaces the ghost orange_ensemble.
-        "ensemble": "rusty_bucket"
-        # "creator": "Your name here",
+        # Derived, never typed. Edit deliveries/un_fao.py to change it.
+        "ensemble": _declared_source(),
     }
     return meta_config

--- a/tests/test_deliveries_characterisation.py
+++ b/tests/test_deliveries_characterisation.py
@@ -95,74 +95,47 @@ class TestDeclarationShape:
 
 
 class TestParityWithCommittedConfig:
-    """The declaration must describe reality before anything is allowed to depend on it."""
+    """**Superseded by #347, deliberately not deleted.**
 
-    def test_ensemble_matches(self):
-        mod = _load_delivery("un_fao")
-        committed = _committed_fao_meta()
-        declared = {s.name for s in mod.DELIVERY.send}
-        assert declared == {committed["ensemble"]}, (
-            f"deliveries/un_fao.py sends {sorted(declared)} but "
-            f"postprocessors/un_fao/configs/config_meta.py declares "
-            f"'{committed['ensemble']}'.\n"
-            f"  These must agree until #347 makes the launcher read the declaration."
-        )
+    This class used to assert that `deliveries/un_fao.py` and the FAO config named the
+    same source. That was the invariant that made #347 safe to attempt: the declaration
+    had to be proven to describe reality before anything depended on it.
 
-    def test_level_matches(self):
-        mod = _load_delivery("un_fao")
-        committed = _committed_fao_meta()
-        for source in mod.DELIVERY.send:
-            assert source.level == committed["level"], (
-                f"deliveries/un_fao.py claims {source.level}('{source.name}') but "
-                f"postprocessors/un_fao/configs/config_meta.py declares "
-                f"level '{committed['level']}'."
-            )
+    Since #347 the config *derives* its source from the declaration, so comparing the
+    two would compare the declaration to itself — a test that always passes and proves
+    nothing. Re-adding it would be worse than having no test, because a green
+    tautology reads like coverage.
 
-    def test_targets_match(self):
-        mod = _load_delivery("un_fao")
-        committed = _committed_fao_meta()
-        assert list(mod.REQUIRE.targets) == list(committed["targets"]), (
-            f"deliveries/un_fao.py requires {list(mod.REQUIRE.targets)} but "
-            f"postprocessors/un_fao/configs/config_meta.py declares "
-            f"{committed['targets']}."
-        )
+    The invariant that survives is in `tests/test_fao_launcher_reads_declaration.py`:
+    changing the declaration must change what the config yields. That is a claim about
+    *direction*, which a tautology cannot express.
+
+    What still bites is below: a new key appearing in the committed config.
+    """
 
     def test_parity_scope_is_still_accurate(self):
-        """If the FAO config gains or loses a committed key, this test must be revisited.
+        """If the FAO config gains or loses a committed key, this must be revisited.
 
-        Guards the assumption in the module docstring: a new committed key might belong
-        in the declaration, and silently ignoring it is how the two drift apart.
+        A new committed key might belong in the delivery declaration, and silently
+        ignoring it is how the two drift apart again.
         """
         committed = set(_committed_fao_meta())
         assert committed == COMMITTED_META_KEYS, (
-            f"the committed keys of postprocessors/un_fao/configs/config_meta.py "
-            f"changed: {sorted(committed ^ COMMITTED_META_KEYS)}.\n"
+            f"the committed keys of {FAO_META} changed: "
+            f"{sorted(committed ^ COMMITTED_META_KEYS)}.\n"
             f"  Decide whether the new/removed key belongs in deliveries/un_fao.py, "
             f"then update COMMITTED_META_KEYS in this file."
         )
 
 
-# ── Nothing depends on the declaration yet ─────────────────────────────────
-
-
-class TestNoBehaviourChange:
-    def test_nothing_reads_deliveries_yet(self):
-        """#343 is additive. The launcher starts reading the declaration in #347."""
-        proc = subprocess.run(
-            ["git", "grep", "-l", "-E", r"deliveries[./]", "--",
-             "postprocessors/", "models/", "ensembles/", "monthly_run.sh"],
-            cwd=REPO_ROOT, capture_output=True, text=True,
-        )
-        # git grep: 0 = matches found, 1 = none, anything else = it did not run.
-        # Reading empty stdout as "no matches" would make this guard pass on error —
-        # the defect recorded as C-113, in the one test that proves this story is
-        # additive. Silence must not be mistaken for a clean result.
-        assert proc.returncode in (0, 1), (
-            f"git grep could not run (rc={proc.returncode}), so this guard proved "
-            f"nothing.\n  git said: {proc.stderr.strip() or '(nothing)'}"
-        )
-        hits = proc.stdout.split()
-        assert not hits, (
-            f"{hits} reference deliveries/ — but #343 must change no behaviour.\n"
-            f"  Making the launcher read the declaration is #347."
-        )
+# ── The additive guard has been retired ───────────────────────────────────
+#
+# #343 asserted that nothing under postprocessors/, models/, ensembles/ or
+# monthly_run.sh referenced deliveries/, because that story was additive. #347 is the
+# story that changed it, and the guard fired there exactly as intended.
+#
+# It was not deleted, it was **inverted**: the same fact is still checked, with the
+# opposite expected value, in
+# tests/test_fao_launcher_reads_declaration.py::TestTheAdditiveGuardIsCorrectlyRetired.
+# A guard that is removed when it becomes inconvenient teaches the next person that
+# guards are negotiable.

--- a/tests/test_deliveries_characterisation.py
+++ b/tests/test_deliveries_characterisation.py
@@ -13,6 +13,7 @@ fail on another. The declaration still records `coverage`, because that is what 
 the *test* only pins what the repository can prove.
 """
 
+import ast
 import subprocess
 from pathlib import Path
 
@@ -33,8 +34,15 @@ COMMITTED_META_KEYS = {"name", "algorithm", "targets", "level", "ensemble"}
 FAO_META = "postprocessors/un_fao/configs/config_meta.py"
 
 
-def _committed_fao_meta() -> dict:
-    """The FAO meta config as committed, not as it sits in someone's working tree."""
+def _committed_meta_keys() -> set[str]:
+    """The FAO meta config's key names, as committed — read *statically*.
+
+    This used to `exec` the file. Since #347 the config imports the delivery
+    declaration and manipulates `sys.path`, so executing a detached git blob needs a
+    `__file__` that does not exist, and every future import the config gains would
+    break this test again. Parsing is enough: the question here is only which keys the
+    committed file declares, and `ast` answers that without running anything.
+    """
     proc = subprocess.run(
         ["git", "show", f"HEAD:{FAO_META}"],
         cwd=REPO_ROOT, capture_output=True, text=True,
@@ -43,18 +51,23 @@ def _committed_fao_meta() -> dict:
         raise AssertionError(
             f"could not read {FAO_META} from git HEAD.\n"
             f"  git said: {proc.stderr.strip() or '(nothing)'}\n"
-            f"  This test compares the delivery declaration against the *committed*\n"
-            f"  config, because working-tree-only keys differ between checkouts (C-110)."
+            f"  This test inspects the *committed* config, because working-tree-only "
+            f"keys differ between checkouts (C-110)."
         )
-    namespace: dict = {}
     try:
-        exec(compile(proc.stdout, f"<HEAD:{FAO_META}>", "exec"), namespace)  # noqa: S102
+        tree = ast.parse(proc.stdout, filename=f"HEAD:{FAO_META}")
     except SyntaxError as exc:
         raise AssertionError(
             f"{FAO_META} does not parse as committed: {exc}.\n"
             f"  Open that file — the committed version is broken, not your working copy."
         ) from exc
-    return namespace["get_meta_config"]()
+    keys: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Dict):
+            for key in node.keys:
+                if isinstance(key, ast.Constant) and isinstance(key.value, str):
+                    keys.add(key.value)
+    return keys
 
 
 def _load_delivery(consumer: str):
@@ -119,7 +132,7 @@ class TestParityWithCommittedConfig:
         A new committed key might belong in the delivery declaration, and silently
         ignoring it is how the two drift apart again.
         """
-        committed = set(_committed_fao_meta())
+        committed = _committed_meta_keys()
         assert committed == COMMITTED_META_KEYS, (
             f"the committed keys of {FAO_META} changed: "
             f"{sorted(committed ^ COMMITTED_META_KEYS)}.\n"

--- a/tests/test_fao_launcher_reads_declaration.py
+++ b/tests/test_fao_launcher_reads_declaration.py
@@ -1,0 +1,180 @@
+"""The FAO config derives its source from the delivery declaration (#347, ADR-019).
+
+Before this, `postprocessors/un_fao/configs/config_meta.py` carried the line
+`"ensemble": "rusty_bucket"` — one hand-typed string deciding which forecast reaches
+the UN, inside a file whose own docstring said modifying it *"will not affect the
+model"*. That sentence was false for the life of the file.
+
+**The key still exists; it is no longer typed.** `views_postprocessing`'s FAO manager
+reads `self.configs["ensemble"]` at `unfao/managers/unfao.py:140` and `:195`, one
+repository away. Deleting the key would raise `KeyError` there. So the config now
+*derives* the value from `deliveries/un_fao.py` instead of declaring it — the decision
+moves, the interface does not. ADR-017's principle applied literally: a thing that is
+never typed cannot lie.
+
+The tests that matter here are the failure paths. A config that silently fell back to a
+default source would deliver the *wrong forecast to the UN* and say nothing, which is
+worse than any error.
+"""
+
+import ast
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from tests.conftest import load_config_module
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+FAO_CONFIG = REPO_ROOT / "postprocessors" / "un_fao" / "configs" / "config_meta.py"
+
+
+def _meta() -> dict:
+    module = load_config_module(FAO_CONFIG, module_name="fao_meta_under_test")
+    return module.get_meta_config()
+
+
+def _string_literals_excluding_docs(path: Path) -> set[str]:
+    """Every string constant in the file that is not a docstring or a comment.
+
+    Inspecting raw text would flag the module docstring, which *describes* the old
+    hand-typed line in order to explain why it is gone. Prose about a name is not a
+    declaration of one, and a test that cannot tell the difference teaches people to
+    stop explaining themselves.
+    """
+    tree = ast.parse(path.read_text(encoding="utf-8"))
+    docstrings = set()
+    for node in ast.walk(tree):
+        if isinstance(node, (ast.Module, ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
+            doc = ast.get_docstring(node, clean=False)
+            if doc is not None:
+                docstrings.add(doc)
+    return {
+        node.value for node in ast.walk(tree)
+        if isinstance(node, ast.Constant)
+        and isinstance(node.value, str)
+        and node.value not in docstrings
+    }
+
+
+# ── The derivation ─────────────────────────────────────────────────────────
+
+
+@pytest.mark.beige
+class TestConfigDerivesFromTheDeclaration:
+    def test_the_key_still_exists_for_views_postprocessing(self):
+        """`unfao/managers/unfao.py:195` does `self.configs["ensemble"]`. If this key
+        disappears, the FAO delivery raises KeyError in a repo this epic does not
+        touch."""
+        assert "ensemble" in _meta(), (
+            "views_postprocessing reads configs['ensemble']; removing it breaks the "
+            "delivery one repo away (unfao/managers/unfao.py:195)."
+        )
+
+    def test_it_matches_what_the_delivery_declares(self):
+        from deliveries.un_fao import DELIVERY
+
+        declared = [source.name for source in DELIVERY.send]
+        assert _meta()["ensemble"] in declared
+
+    def test_the_name_is_not_hand_written_in_the_config(self):
+        """The point of the story: the decision lives in deliveries/un_fao.py now.
+
+        A literal source name in this file would mean two places state one fact, with
+        nothing reconciling them — ADR-019 §8's rejected alternative.
+        """
+        from deliveries.un_fao import DELIVERY
+
+        literals = _string_literals_excluding_docs(FAO_CONFIG)
+        for source in DELIVERY.send:
+            assert source.name not in literals, (
+                f"'{source.name}' is still hand-written in "
+                f"postprocessors/un_fao/configs/config_meta.py.\n"
+                f"  It must be derived from deliveries/un_fao.py, not typed twice."
+            )
+
+    def test_changing_the_declaration_changes_the_config(self):
+        """The invariant that replaces #343's parity test: the config is downstream
+        of the declaration, not merely equal to it today."""
+        import deliveries.un_fao as declaration
+        from deliveries.vocabulary import Delivery, monthly, pgm, prod
+
+        original = declaration.DELIVERY
+        try:
+            declaration.DELIVERY = Delivery(
+                send=[pgm("skinny_love")],
+                frequency=monthly,
+                tier=prod,
+                intent=original.intent,
+            )
+            assert _meta()["ensemble"] == "skinny_love"
+        finally:
+            declaration.DELIVERY = original
+        assert _meta()["ensemble"] != "skinny_love"
+
+
+# ── The failure paths, which are the ones that matter ──────────────────────
+
+
+@pytest.mark.red
+class TestItFailsLoudlyRatherThanFallingBack:
+    def test_no_default_source_appears_anywhere_in_the_config(self):
+        """ADR-003. A fallback here would deliver the wrong forecast to the UN and
+        say nothing — worse than any error this file could raise."""
+        text = FAO_CONFIG.read_text(encoding="utf-8")
+        code = "\n".join(
+            line for line in text.splitlines()
+            if not line.strip().startswith("#")
+        )
+        for pattern in ('get("ensemble",', "get('ensemble',", "or \"rusty", "or 'rusty"):
+            assert pattern not in code, (
+                f"{pattern!r} looks like a fallback source in {FAO_CONFIG.name}.\n"
+                f"  A silent default delivers the wrong forecast; fail loud instead."
+            )
+
+    def test_a_missing_declaration_names_the_file(self):
+        """Run in a subprocess so the real import machinery is exercised, not a mock."""
+        script = (
+            "import sys; sys.path.insert(0, %r)\n"
+            "import importlib.util, pathlib\n"
+            "sys.modules['deliveries.un_fao'] = None\n"
+            "spec = importlib.util.spec_from_file_location('m', %r)\n"
+            "m = importlib.util.module_from_spec(spec)\n"
+            "spec.loader.exec_module(m)\n"
+            "m.get_meta_config()\n"
+        ) % (str(REPO_ROOT), str(FAO_CONFIG))
+        proc = subprocess.run(
+            [sys.executable, "-c", script],
+            capture_output=True, text=True, cwd=REPO_ROOT,
+        )
+        assert proc.returncode != 0, (
+            "a broken delivery declaration must fail, not fall back to a default"
+        )
+        assert "un_fao" in proc.stderr or "deliveries" in proc.stderr, (
+            f"the failure names no file, so a reader cannot act on it (ADR-020).\n"
+            f"  stderr: {proc.stderr[-400:]}"
+        )
+
+
+# ── The guard from #343 has done its job and must now be retired ───────────
+
+
+@pytest.mark.beige
+class TestTheAdditiveGuardIsCorrectlyRetired:
+    def test_the_postprocessor_now_reads_deliveries(self):
+        """#343 asserted that nothing under postprocessors/ referenced deliveries/,
+        because that story was additive. This story is the one that changes it, so
+        the guard is inverted here rather than deleted — the fact stays checked, its
+        expected value flips."""
+        hits = subprocess.run(
+            ["git", "grep", "-l", "deliveries", "--", "postprocessors/"],
+            cwd=REPO_ROOT, capture_output=True, text=True,
+        )
+        assert hits.returncode in (0, 1), (
+            f"git grep could not run (rc={hits.returncode}); this guard proved nothing."
+        )
+        assert "postprocessors/un_fao/configs/config_meta.py" in hits.stdout, (
+            "the FAO config does not reference deliveries/ — the derivation is not "
+            "wired up."
+        )


### PR DESCRIPTION
Implements #347. **First story in this epic that changes production behaviour.**

## The issue as written would have broken the delivery

#347 said *"remove the `\"ensemble\"` key from `config_meta.py`"*. Tracing first showed the key is read **one repository away**:

| file | line |
|---|---|
| `views_postprocessing/unfao/managers/unfao.py` | 140 — `self.configs.get("ensemble", None)` |
| `views_postprocessing/unfao/managers/unfao.py` | 195 — `expected_ensemble=self.configs["ensemble"]` |

`postprocessors/un_fao/main.py` never reads it. Deleting the key raises `KeyError` inside a repo this epic is not touching.

**So the key survives as an interface and dies as a decision.** The config now *derives* it from `deliveries/un_fao.py`. ADR-017's principle applied literally — a thing that is never typed cannot lie — and no cross-repo change.

## No fallback, deliberately

A silent default here would deliver the **wrong forecast to a UN agency** and say nothing, which is worse than any error this file could raise. A missing or malformed declaration fails loudly naming `deliveries/un_fao.py` (ADR-003, ADR-020), verified **in a subprocess** so the real import machinery runs rather than a mock.

## Staged narrowly, on purpose — please read this bit

The working tree carries three keys that are **not in git**: `wire_contract`, `wire_upload_enabled`, `region` (**C-110**).

Committing the file wholesale would have put `region: land_gaul` into git while `config_queryset.py` still says `REGION = "africa_me_legacy"` there — leaving **two committed files disagreeing about which region ships**. That is worse than today.

So only the derivation is committed. The three keys remain uncommitted exactly as before; `config_meta.py` still shows as modified after this commit. **#348 handles the arming key**, and resolving C-110 properly is a separate decision.

Verified: the *indexed* version resolves `rusty_bucket` correctly from a clean checkout.

## Two guards behaved as designed, and were retired honestly

- **#343's "nothing reads `deliveries/` yet" fired here** — this is the story that changes it. **Inverted, not deleted**: same fact, opposite expected value. A guard removed when it becomes inconvenient teaches the next person that guards are negotiable.
- **#343's parity test would have become a tautology**, because the config now derives from the declaration it was compared against. A green tautology reads like coverage. Replaced by a claim about **direction** — changing the declaration must change what the config yields — with the reason recorded in place so nobody re-adds the comparison.

## One test was wrong

It flagged the source name in the module **docstring**, which describes the old line in order to explain why it is gone. Prose about a name is not a declaration of one. It now inspects string constants excluding docstrings, via `ast`.

## Verification

- **Full suite: 7612 passed, 0 failed** · `ruff check .` clean
- **No delivery performed.** Performing one is G4, blocked on the C-90 decision.

Refs #342, #350.

🤖 Generated with [Claude Code](https://claude.com/claude-code)