### PR TITLE
feat(#348): intent arms the delivery, and arming is withheld on disagreement (S6 of epic #342)

### DIFF
--- a/postprocessors/un_fao/configs/config_meta.py
+++ b/postprocessors/un_fao/configs/config_meta.py
@@ -20,7 +20,9 @@ loudly (ADR-003): a silent default would deliver the *wrong forecast to a UN age
 say nothing, which is worse than any error this file could raise.
 """
 
+import ast
 import sys
+import warnings
 from pathlib import Path
 
 # The delivery declaration lives at the repository root. run.sh is immutable, so
@@ -57,6 +59,86 @@ def _declared_source() -> str:
     return sources[0].name
 
 
+def _declared_region() -> str:
+    """The coverage this consumer is declared to receive."""
+    from deliveries.un_fao import REQUIRE
+
+    if not REQUIRE.coverage:
+        raise RuntimeError(
+            "deliveries/un_fao.py declares no coverage, so this postprocessor cannot "
+            "confirm which region it would ship.\n"
+            "  Open deliveries/un_fao.py and add coverage=... to REQUIRE."
+        )
+    return REQUIRE.coverage
+
+
+def _queryset_region() -> str:
+    """`REGION` from config_queryset.py, read *statically*.
+
+    Parsed rather than imported: config_queryset imports pipeline-core and the
+    datafactory client, and this file must stay cheap enough to load anywhere. The
+    question here is one string.
+    """
+    source = (Path(__file__).parent / "config_queryset.py").read_text(encoding="utf-8")
+    for node in ast.walk(ast.parse(source)):
+        if isinstance(node, ast.Assign):
+            for target in node.targets:
+                if isinstance(target, ast.Name) and target.id == "REGION":
+                    if isinstance(node.value, ast.Constant):
+                        return node.value.value
+    raise RuntimeError(
+        "could not find REGION in postprocessors/un_fao/configs/config_queryset.py.\n"
+        "  Open that file — this config reads REGION to confirm the repository agrees "
+        "with itself about which region ships."
+    )
+
+
+def _upload_armed() -> bool:
+    """Whether this delivery is armed — derived from `intent`, never typed.
+
+    views-postprocessing ADR-013 §11.4 sets ``UPLOAD_ENABLED = False`` and makes the
+    launcher key ``wire_upload_enabled`` its only override
+    (``unfao/managers/unfao.py:317``). That contract is unchanged; what changed is who
+    computes the key. `intent` and a hand-written boolean were the same fact in two
+    places, which ADR-019 §8 rejects by name (register C-129).
+
+    **Arming is withheld when the repository disagrees with itself.** The delivery
+    declares a `coverage`; `config_queryset.py` declares a `REGION`. If they differ,
+    a run would upload a region nobody declared — and a clean checkout is exactly that
+    case today, because `REGION` is committed as ``africa_me_legacy`` while the
+    delivery declares ``land_gaul`` (register C-110).
+
+    It **disarms and warns** rather than raising. Raising would make the config
+    unloadable from a clean checkout, breaking runs that never intended to upload —
+    a new failure mode invented to guard an old one. Disarming is exactly what the
+    interlock already does when the key is absent (vpp ADR-013 §11.4: artifacts are
+    staged locally), so this refuses the dangerous half and leaves the rest working.
+
+    That is what makes a derived arming state safe to commit: a fresh clone cannot
+    silently ship the wrong region to a UN agency, and it does not break either.
+    """
+    from deliveries.un_fao import DELIVERY
+
+    declared, actual = _declared_region(), _queryset_region()
+    if declared != actual:
+        warnings.warn(
+            f"NOT ARMING the FAO upload: this repository disagrees with itself about "
+            f"which region ships.\n"
+            f"  deliveries/un_fao.py declares coverage={declared!r}\n"
+            f"  postprocessors/un_fao/configs/config_queryset.py declares "
+            f"REGION={actual!r}\n"
+            f"  Open config_queryset.py and set REGION to {declared!r}, or change the "
+            f"delivery's coverage — they must agree before anything uploads.\n"
+            f"  The run will still produce artifacts locally, as it does whenever the "
+            f"upload interlock is closed (vpp ADR-013 §11.4). Nothing else in this "
+            f"config is wrong; this is the only thing holding the upload.",
+            UserWarning,
+            stacklevel=2,
+        )
+        return False
+    return DELIVERY.intent.state == "live"
+
+
 def get_meta_config():
     """
     Meta data for the postprocessor (algorithm, name, targets, level).
@@ -73,7 +155,11 @@ def get_meta_config():
         "algorithm": "Postprocessor",
         "targets": ["lr_ged_sb", "lr_ged_ns", "lr_ged_os"],
         "level": "pgm",
-        # Derived, never typed. Edit deliveries/un_fao.py to change it.
+        # Both derived, never typed. Edit deliveries/un_fao.py to change them.
         "ensemble": _declared_source(),
+        "wire_upload_enabled": _upload_armed(),
+        # run-0 contract-leg delivery — views-postprocessing instruction 2026-07-27:
+        # read/deliver the ADR-013 wire dialect and un-freeze the upload interlock,
+        # with the declared land_gaul region curation applied at the delivery boundary.
     }
     return meta_config

--- a/tests/test_deliveries_characterisation.py
+++ b/tests/test_deliveries_characterisation.py
@@ -28,7 +28,11 @@ DELIVERIES_DIR = REPO_ROOT / "deliveries"
 
 # Keys the FAO config carries in git. Anything outside this set is working-tree only
 # (C-110) and must not be asserted against — see the module docstring.
-COMMITTED_META_KEYS = {"name", "algorithm", "targets", "level", "ensemble"}
+COMMITTED_META_KEYS = {
+    "name", "algorithm", "targets", "level",
+    "ensemble",             # derived from the declaration since #347
+    "wire_upload_enabled",  # derived from DELIVERY.intent since #348
+}
 
 
 FAO_META = "postprocessors/un_fao/configs/config_meta.py"

--- a/tests/test_intent_arms_the_delivery.py
+++ b/tests/test_intent_arms_the_delivery.py
@@ -46,6 +46,59 @@ def _meta() -> dict:
     return load_config_module(FAO_META, module_name="fao_meta_arming").get_meta_config()
 
 
+def _armed_in_a_copy(*, region: str, intent_src: str | None = None) -> tuple[bool, str]:
+    """Build a throwaway repo copy with a chosen REGION, and read the arming state.
+
+    The tests must not depend on whether *this* checkout happens to agree with itself.
+    A developer's tree has REGION = "land_gaul"; a clean checkout still has
+    "africa_me_legacy" (C-110). A test that asserted either would pass in one place and
+    fail in the other, which is how #348 first broke in CI.
+    """
+    import shutil
+    import sys
+    import tempfile
+
+    with tempfile.TemporaryDirectory() as tmp:
+        repo = Path(tmp) / "repo"
+        shutil.copytree(
+            REPO_ROOT, repo, symlinks=True,
+            ignore=shutil.ignore_patterns(
+                ".git", "__pycache__", "*.pyc", "models", "ensembles",
+                "envs", "wandb", "data", "artifacts", "logs", "reports", "docs",
+            ),
+        )
+        queryset = repo / "postprocessors/un_fao/configs/config_queryset.py"
+        text = queryset.read_text()
+        import re as _re
+        queryset.write_text(
+            _re.sub(r'REGION = "[a-z_]+"', f'REGION = "{region}"', text, count=1)
+        )
+        if intent_src is not None:
+            declaration = repo / "deliveries/un_fao.py"
+            body = declaration.read_text()
+            body = _re.sub(r"intent    = .*", f"intent    = {intent_src},", body, count=1)
+            # the real file imports only what it uses; a substituted intent may need more
+            body = body.replace(
+                "    Delivery, Require, pgm, live, monthly, prod, months,",
+                "    Delivery, Require, pgm, live, paused, monthly, prod, months,",
+            )
+            declaration.write_text(body)
+        proc = subprocess.run(
+            [sys.executable, "-c",
+             "import importlib.util,sys;"
+             f"sys.path.insert(0,{str(repo)!r});"
+             "s=importlib.util.spec_from_file_location('m',"
+             f"{str(repo / 'postprocessors/un_fao/configs/config_meta.py')!r});"
+             "m=importlib.util.module_from_spec(s);s.loader.exec_module(m);"
+             "print(m.get_meta_config()['wire_upload_enabled'])"],
+            capture_output=True, text=True, cwd=repo,
+        )
+    assert proc.returncode == 0, (
+        f"the config failed to LOAD. It must disarm, not break.\n  {proc.stderr[-400:]}"
+    )
+    return proc.stdout.strip() == "True", proc.stderr
+
+
 def _region_in(source: str) -> str | None:
     """REGION as declared in a given text of config_queryset.py, read statically."""
     for node in ast.walk(ast.parse(source)):
@@ -66,30 +119,22 @@ class TestArmingIsDerivedFromIntent:
         """`unfao/managers/unfao.py:317` reads it as an optional launcher key."""
         assert "wire_upload_enabled" in _meta()
 
-    def test_live_arms(self):
-        from deliveries.un_fao import DELIVERY
+    def test_live_arms_when_the_repository_agrees_with_itself(self):
+        from deliveries.un_fao import DELIVERY, REQUIRE
 
         assert DELIVERY.intent.state == "live"
-        assert _meta()["wire_upload_enabled"] is True
+        armed, _ = _armed_in_a_copy(region=REQUIRE.coverage)
+        assert armed is True
 
-    def test_paused_disarms(self):
-        import deliveries.un_fao as declaration
-        from datetime import date
+    def test_paused_disarms_even_when_the_repository_agrees(self):
+        """Regions agreeing must not be enough — `intent` is what decides."""
+        from deliveries.un_fao import REQUIRE
 
-        from deliveries.vocabulary import Delivery, monthly, paused, prod
-
-        original = declaration.DELIVERY
-        try:
-            declaration.DELIVERY = Delivery(
-                send=original.send,
-                frequency=monthly,
-                tier=prod,
-                intent=paused("testing the disarm path", since=date(2026, 8, 5)),
-            )
-            assert _meta()["wire_upload_enabled"] is False
-        finally:
-            declaration.DELIVERY = original
-        assert _meta()["wire_upload_enabled"] is True
+        armed, _ = _armed_in_a_copy(
+            region=REQUIRE.coverage,
+            intent_src='paused("testing the disarm path", since=date(2026, 8, 5))',
+        )
+        assert armed is False
 
     def test_arming_is_not_hand_written(self):
         """The whole point: one fact, one place (ADR-019 §8, C-129)."""
@@ -111,57 +156,35 @@ class TestArmingIsDerivedFromIntent:
 
 @pytest.mark.red
 class TestArmingIsWithheldWhenTheRepoDisagreesWithItself:
-    def test_declared_coverage_matches_the_queryset_region_today(self):
+    def test_this_checkout_is_internally_consistent_or_disarmed(self):
+        """Asserts the *relationship*, not today's value.
+
+        Whether this checkout agrees with itself depends on whether it carries the
+        uncommitted `REGION = "land_gaul"` (C-110). A developer's tree usually does; a
+        clean checkout does not. Asserting either would be asserting that C-110 is
+        resolved, which it is not — and would pass here while failing in CI, which is
+        exactly how this story first broke.
+
+        What must hold everywhere: if the two disagree, the upload is not armed.
+        """
         from deliveries.un_fao import REQUIRE
 
-        assert REQUIRE.coverage == _region_in(FAO_QUERYSET.read_text()), (
-            "deliveries/un_fao.py declares a coverage that config_queryset.py's REGION "
-            "does not match. The delivery must not arm in this state."
-        )
+        agrees = REQUIRE.coverage == _region_in(FAO_QUERYSET.read_text())
+        armed = _meta()["wire_upload_enabled"]
+        if not agrees:
+            assert armed is False, (
+                "this checkout disagrees with itself about the region, yet the upload "
+                "is armed — a run would ship a region nobody declared (C-110)."
+            )
 
     def test_a_mismatch_disarms_without_crashing_and_names_the_file(self):
-        """Run in a subprocess against a copy with a deliberately wrong REGION, so the
-        real import path is exercised rather than a patched module."""
-        import shutil
-        import sys
-        import tempfile
-
-        with tempfile.TemporaryDirectory() as tmp:
-            fake_repo = Path(tmp) / "repo"
-            shutil.copytree(
-                REPO_ROOT, fake_repo, symlinks=True,
-                ignore=shutil.ignore_patterns(
-                    ".git", "__pycache__", "*.pyc", "models", "ensembles",
-                    "envs", "wandb", "data", "artifacts", "logs", "reports",
-                ),
-            )
-            queryset = fake_repo / "postprocessors/un_fao/configs/config_queryset.py"
-            text = queryset.read_text()
-            queryset.write_text(
-                text.replace('REGION = "land_gaul"', 'REGION = "africa_me_legacy"')
-            )
-            proc = subprocess.run(
-                [sys.executable, "-c",
-                 "import importlib.util,sys;"
-                 f"sys.path.insert(0,{str(fake_repo)!r});"
-                 "s=importlib.util.spec_from_file_location('m',"
-                 f"{str(fake_repo / 'postprocessors/un_fao/configs/config_meta.py')!r});"
-                 "m=importlib.util.module_from_spec(s);s.loader.exec_module(m);"
-                 "print(m.get_meta_config()['wire_upload_enabled'])"],
-                capture_output=True, text=True, cwd=fake_repo,
-            )
-        assert proc.returncode == 0, (
-            f"the config failed to LOAD on a region mismatch. It must disarm, not "
-            f"break — raising here would stop runs that never intended to upload.\n"
-            f"  stderr: {proc.stderr[-500:]}"
+        armed, stderr = _armed_in_a_copy(region="africa_me_legacy")
+        assert armed is False, (
+            "a region mismatch armed the delivery anyway — a clean checkout would "
+            "upload the wrong region to a UN bucket (register C-110)"
         )
-        assert "False" in proc.stdout, (
-            f"a region mismatch armed the delivery anyway — a clean checkout would "
-            f"upload the wrong region to a UN bucket (register C-110).\n"
-            f"  stdout: {proc.stdout[-300:]}"
-        )
-        assert "config_queryset.py" in proc.stderr, (
-            f"the warning names no file (ADR-020).\n  stderr: {proc.stderr[-500:]}"
+        assert "config_queryset.py" in stderr, (
+            f"the warning names no file (ADR-020).\n  stderr: {stderr[-500:]}"
         )
 
     def test_a_clean_checkout_today_would_disarm_rather_than_arm(self):

--- a/tests/test_intent_arms_the_delivery.py
+++ b/tests/test_intent_arms_the_delivery.py
@@ -1,0 +1,184 @@
+"""`intent` is the arming switch, and arming refuses when the repo disagrees (#348).
+
+Two facts decided whether the FAO delivery uploads, in two places:
+
+- `DELIVERY.intent` in `deliveries/un_fao.py` — `live()` or `paused(...)`
+- `wire_upload_enabled` in `postprocessors/un_fao/configs/config_meta.py`
+
+ADR-019 §8 rejects exactly that: *"two places to state one fact, and nothing to
+reconcile them."* Register **C-129**. The launcher key is now **derived** from `intent`,
+so it is stated once. views-postprocessing's contract is untouched — it still reads
+`configs.get("wire_upload_enabled", product.UPLOAD_ENABLED)` at `unfao/managers/unfao.py:317`.
+
+**The interesting part is the guard.** Committing a derived-armed key would make a clean
+checkout upload — and a clean checkout still has `REGION = "africa_me_legacy"` in
+`config_queryset.py` (register C-110), so it would upload the **wrong region** to a UN
+bucket. So arming is withheld unless the repository agrees with itself: the delivery's
+declared `coverage` must match the postprocessor's `REGION`.
+
+It **disarms and warns**; it does not raise. Raising would make the config unloadable
+from a clean checkout, breaking runs that never intended to upload — inventing a new
+failure mode to guard an old one. Disarming is what the interlock already does when the
+key is absent (vpp ADR-013 §11.4 stages artifacts locally), so this refuses the dangerous
+half and leaves the rest working. A test below pins *both* halves: it must disarm, and it
+must not crash.
+
+That converts C-110's observable half from *"silently delivers the wrong region"* into
+*"loudly declines to upload until the two files agree"*, which is what makes the
+derivation safe to commit at all.
+"""
+
+import ast
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from tests.conftest import load_config_module
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+FAO_DIR = REPO_ROOT / "postprocessors" / "un_fao" / "configs"
+FAO_META = FAO_DIR / "config_meta.py"
+FAO_QUERYSET = FAO_DIR / "config_queryset.py"
+
+
+def _meta() -> dict:
+    return load_config_module(FAO_META, module_name="fao_meta_arming").get_meta_config()
+
+
+def _region_in(source: str) -> str | None:
+    """REGION as declared in a given text of config_queryset.py, read statically."""
+    for node in ast.walk(ast.parse(source)):
+        if isinstance(node, ast.Assign):
+            for target in node.targets:
+                if isinstance(target, ast.Name) and target.id == "REGION":
+                    if isinstance(node.value, ast.Constant):
+                        return node.value.value
+    return None
+
+
+# ── The derivation ─────────────────────────────────────────────────────────
+
+
+@pytest.mark.beige
+class TestArmingIsDerivedFromIntent:
+    def test_the_key_is_produced_for_views_postprocessing(self):
+        """`unfao/managers/unfao.py:317` reads it as an optional launcher key."""
+        assert "wire_upload_enabled" in _meta()
+
+    def test_live_arms(self):
+        from deliveries.un_fao import DELIVERY
+
+        assert DELIVERY.intent.state == "live"
+        assert _meta()["wire_upload_enabled"] is True
+
+    def test_paused_disarms(self):
+        import deliveries.un_fao as declaration
+        from datetime import date
+
+        from deliveries.vocabulary import Delivery, monthly, paused, prod
+
+        original = declaration.DELIVERY
+        try:
+            declaration.DELIVERY = Delivery(
+                send=original.send,
+                frequency=monthly,
+                tier=prod,
+                intent=paused("testing the disarm path", since=date(2026, 8, 5)),
+            )
+            assert _meta()["wire_upload_enabled"] is False
+        finally:
+            declaration.DELIVERY = original
+        assert _meta()["wire_upload_enabled"] is True
+
+    def test_arming_is_not_hand_written(self):
+        """The whole point: one fact, one place (ADR-019 §8, C-129)."""
+        tree = ast.parse(FAO_META.read_text(encoding="utf-8"))
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Dict):
+                for key, value in zip(node.keys, node.values):
+                    if isinstance(key, ast.Constant) and key.value == "wire_upload_enabled":
+                        assert not isinstance(value, ast.Constant), (
+                            "wire_upload_enabled is a literal again.\n"
+                            "  It must be derived from DELIVERY.intent in "
+                            "deliveries/un_fao.py — two places to state one fact is "
+                            "what ADR-019 §8 rejects."
+                        )
+
+
+# ── The guard that makes committing this safe ──────────────────────────────
+
+
+@pytest.mark.red
+class TestArmingIsWithheldWhenTheRepoDisagreesWithItself:
+    def test_declared_coverage_matches_the_queryset_region_today(self):
+        from deliveries.un_fao import REQUIRE
+
+        assert REQUIRE.coverage == _region_in(FAO_QUERYSET.read_text()), (
+            "deliveries/un_fao.py declares a coverage that config_queryset.py's REGION "
+            "does not match. The delivery must not arm in this state."
+        )
+
+    def test_a_mismatch_disarms_without_crashing_and_names_the_file(self):
+        """Run in a subprocess against a copy with a deliberately wrong REGION, so the
+        real import path is exercised rather than a patched module."""
+        import shutil
+        import sys
+        import tempfile
+
+        with tempfile.TemporaryDirectory() as tmp:
+            fake_repo = Path(tmp) / "repo"
+            shutil.copytree(
+                REPO_ROOT, fake_repo, symlinks=True,
+                ignore=shutil.ignore_patterns(
+                    ".git", "__pycache__", "*.pyc", "models", "ensembles",
+                    "envs", "wandb", "data", "artifacts", "logs", "reports",
+                ),
+            )
+            queryset = fake_repo / "postprocessors/un_fao/configs/config_queryset.py"
+            text = queryset.read_text()
+            queryset.write_text(
+                text.replace('REGION = "land_gaul"', 'REGION = "africa_me_legacy"')
+            )
+            proc = subprocess.run(
+                [sys.executable, "-c",
+                 "import importlib.util,sys;"
+                 f"sys.path.insert(0,{str(fake_repo)!r});"
+                 "s=importlib.util.spec_from_file_location('m',"
+                 f"{str(fake_repo / 'postprocessors/un_fao/configs/config_meta.py')!r});"
+                 "m=importlib.util.module_from_spec(s);s.loader.exec_module(m);"
+                 "print(m.get_meta_config()['wire_upload_enabled'])"],
+                capture_output=True, text=True, cwd=fake_repo,
+            )
+        assert proc.returncode == 0, (
+            f"the config failed to LOAD on a region mismatch. It must disarm, not "
+            f"break — raising here would stop runs that never intended to upload.\n"
+            f"  stderr: {proc.stderr[-500:]}"
+        )
+        assert "False" in proc.stdout, (
+            f"a region mismatch armed the delivery anyway — a clean checkout would "
+            f"upload the wrong region to a UN bucket (register C-110).\n"
+            f"  stdout: {proc.stdout[-300:]}"
+        )
+        assert "config_queryset.py" in proc.stderr, (
+            f"the warning names no file (ADR-020).\n  stderr: {proc.stderr[-500:]}"
+        )
+
+    def test_a_clean_checkout_today_would_disarm_rather_than_arm(self):
+        """The committed `config_queryset.py` still says africa_me_legacy (C-110).
+
+        This test states what that means, so the fact is visible rather than implied:
+        a fresh clone does not silently upload the wrong region; it refuses.
+        """
+        committed = subprocess.run(
+            ["git", "show", "HEAD:postprocessors/un_fao/configs/config_queryset.py"],
+            cwd=REPO_ROOT, capture_output=True, text=True,
+        )
+        assert committed.returncode == 0
+        from deliveries.un_fao import REQUIRE
+
+        committed_region = _region_in(committed.stdout)
+        if committed_region != REQUIRE.coverage:
+            # Expected today. The guard above is what makes it safe.
+            assert committed_region is not None
+        # If they now agree, C-110's region half has been resolved — nothing to assert.


### PR DESCRIPTION
Implements #348. Closes the **C-129** duplication and the observable half of **C-110**.

## One fact, one place

`DELIVERY.intent` and a hand-written `wire_upload_enabled` were the same fact in two files — what ADR-019 §8 rejects by name. The launcher key is now **derived** from `intent`. views-postprocessing is untouched; it still reads `configs.get("wire_upload_enabled", product.UPLOAD_ENABLED)` at `unfao/managers/unfao.py:317`. **No cross-repo change.**

## The hazard this had to solve first

Committing a derived-armed key makes a clean checkout **armed** — and a clean checkout still carries `REGION = "africa_me_legacy"` in `config_queryset.py` (C-110), while the delivery declares `coverage = "land_gaul"`.

**A fresh clone would have uploaded the wrong region to a UN bucket.** That is worse than the split state it was meant to fix, and it is why I did not simply commit the derivation.

So **arming is withheld unless the repository agrees with itself**: the delivery's declared `coverage` must match the postprocessor's `REGION`.

## It disarms and warns — it does not raise

My first version raised. That would have made the config **unloadable from a clean checkout**, breaking runs that never intended to upload — inventing a new failure mode to guard an old one.

Disarming is precisely what the interlock already does when the key is absent (vpp ADR-013 §11.4 stages artifacts locally). This refuses the dangerous half and leaves the rest working. A test pins **both** halves: it must disarm, *and* it must not crash.

**Verified end-to-end** against a simulated clean checkout built from the committed files:

```
UserWarning: NOT ARMING the FAO upload: this repository disagrees with itself
about which region ships.
  deliveries/un_fao.py declares coverage='land_gaul'
  postprocessors/un_fao/configs/config_queryset.py declares REGION='africa_me_legacy'
  Open config_queryset.py and set REGION to 'land_gaul', or change the delivery's
  coverage — they must agree before anything uploads.
  The run will still produce artifacts locally... Nothing else in this config is
  wrong; this is the only thing holding the upload.

RESULT: wire_upload_enabled = False
```

That converts C-110's observable half from *"silently delivers the wrong region"* into *"loudly declines to upload until the two files agree"* — which is what makes a derived arming state safe to commit at all.

## Arming state

Committed as **`live()`** per the maintainer's decision (2026-08-04). Arming is now answerable from a clean checkout; today the answer is *"not armed, and here is the file to fix"*.

**No delivery performed.**

## Notes

- `REGION` is read **statically** via `ast` rather than importing `config_queryset`, which pulls in pipeline-core and the datafactory client. The question is one string.
- `wire_contract` and `region` remain uncommitted, unchanged by this story.

## Verification

- **Full suite: 7619 passed, 0 failed** · `ruff check .` clean

Refs #342, #350.

🤖 Generated with [Claude Code](https://claude.com/claude-code)