### PR TITLE
feat(D7): a scheduled heartbeat that fails when FAO delivery goes stale

### DIFF
--- a/.github/workflows/fao_freshness.yml
+++ b/.github/workflows/fao_freshness.yml
@@ -1,0 +1,123 @@
+name: FAO Delivery Freshness
+
+# D7 of the release definition of done: a missed month must fail loudly WITHOUT a
+# human. Everything else this repo built makes the FAO delivery legible; this makes
+# its ABSENCE loud.
+#
+# The failure being guarded against actually happened: FAO received nothing for 145
+# days while a complete forecast sat on the shelf, and nobody noticed (#320). ADR-020
+# §4 calls this "the hole in the floor" — nothing raises, because nothing failed.
+#
+# The bound is NOT set here. `deliveries/un_fao.py` declares `max_age`, and
+# `tools/liveness/unfao_delivery.py` classifies against it (#360). One fact, one place.
+#
+# CADENCE vs BOUND — two different things, deliberately.
+#   * the BOUND says when a delivery is too old. Declared in deliveries/un_fao.py.
+#     Deliberately not repeated here: a number in this comment would be a third copy,
+#     and it would be wrong the moment someone edits the declaration.
+#   * the CADENCE (weekly) says how soon after that we find out.
+# Weekly costs one API call and detects within 7 days of the bound being crossed.
+# Monthly would add up to 30 days of latency on top of it — better than 145, but
+# needlessly late for something this cheap.
+
+on:
+  schedule:
+    - cron: '0 6 * * 1'      # Mondays 06:00 UTC
+  workflow_dispatch:          # so it can be proven to work on demand, not only by waiting
+
+permissions:
+  contents: read
+
+jobs:
+  fao-freshness:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      # The check uses stdlib urllib only (no Appwrite SDK, no pipeline-core), so it
+      # dodges the published-core skew that keeps other jobs fragile (C-42/C-73/C-80).
+
+      - name: Check when FAO last actually received a forecast
+        env:
+          APPWRITE_ENDPOINT: ${{ secrets.APPWRITE_ENDPOINT }}
+          APPWRITE_DATASTORE_PROJECT_ID: ${{ secrets.APPWRITE_DATASTORE_PROJECT_ID }}
+          APPWRITE_DATASTORE_API_KEY: ${{ secrets.APPWRITE_DATASTORE_API_KEY }}
+        run: |
+          set -o pipefail
+          out="$(python -m tools.liveness.unfao_delivery 2>&1)" && status=0 || status=$?
+          echo "$out"
+          verdict="$(printf '%s\n' "$out" | sed -n 's/^verdict: //p' | head -1)"
+
+          # Classify on the VERDICT, never on the exit code.
+          #
+          # SKIP_NO_CREDENTIALS maps to exit 0 (tools/liveness/report.py), because for
+          # the six-surface dashboard a truthful skip is not a failure. For THIS job it
+          # is the worst possible outcome: the heartbeat would report success having
+          # read nothing, and a dead heartbeat is indistinguishable from a healthy one.
+          #
+          # Same reasoning as monthly_run.sh's Appwrite preflight (#302) and the C-113
+          # lesson: a gate that cannot tell "passed" from "did not run" is not a gate.
+          #
+          # Every verdict this check can emit has a branch. The catch-all still fails,
+          # but nothing known should reach it: an operator who hits a real condition
+          # deserves a message naming the fix, not the word "inconclusive". The
+          # CREDENTIALS_INCOMPLETE branch exists because a first live run produced
+          # exactly that verdict — a partial credential set, not an absent one.
+          case "$verdict" in
+            DELIVERING)
+              echo ""
+              echo "OK — FAO received a forecast within the bound declared in deliveries/un_fao.py."
+              ;;
+            DELIVERY_STALLED)
+              echo "" >&2
+              echo "FAO DELIVERY IS STALE." >&2
+              echo "  The newest forecast in unfao_bucket is older than the max_age" >&2
+              echo "  declared in deliveries/un_fao.py. The facts above give the exact age." >&2
+              echo "" >&2
+              echo "  This is #320 recurring. A complete forecast may be sitting on the" >&2
+              echo "  internal shelf undelivered — check production_forecasts before" >&2
+              echo "  assuming a run is needed." >&2
+              exit 1
+              ;;
+            UNREACHABLE)
+              echo "" >&2
+              echo "APPWRITE DID NOT ANSWER." >&2
+              echo "  This says nothing about the delivery — the bucket could not be read." >&2
+              echo "  If it persists, the datastore key may have expired (both current keys" >&2
+              echo "  expire around 2026-11-30; register C-114)." >&2
+              exit 1
+              ;;
+            CREDENTIALS_INCOMPLETE)
+              echo "" >&2
+              echo "HEARTBEAT DID NOT RUN — Appwrite credentials are only partly set." >&2
+              echo "  The facts above name exactly which variables are missing." >&2
+              echo "  All three are required:" >&2
+              echo "    APPWRITE_ENDPOINT, APPWRITE_DATASTORE_PROJECT_ID, APPWRITE_DATASTORE_API_KEY" >&2
+              echo "" >&2
+              echo "  A partial set is the more likely mistake than none at all, so it gets" >&2
+              echo "  its own message rather than falling through to 'inconclusive'." >&2
+              exit 1
+              ;;
+            SKIP_NO_CREDENTIALS)
+              echo "" >&2
+              echo "HEARTBEAT DID NOT RUN — no Appwrite credentials." >&2
+              echo "  Nothing was checked, so this job proves nothing about the delivery." >&2
+              echo "  Add these to the repository's Actions secrets:" >&2
+              echo "    APPWRITE_ENDPOINT, APPWRITE_DATASTORE_PROJECT_ID, APPWRITE_DATASTORE_API_KEY" >&2
+              echo "" >&2
+              echo "  Failing rather than skipping is deliberate: a heartbeat that goes" >&2
+              echo "  green without reading anything is worse than none at all." >&2
+              exit 1
+              ;;
+            *)
+              echo "" >&2
+              echo "HEARTBEAT INCONCLUSIVE (verdict: ${verdict:-<none produced>}, exit: ${status})." >&2
+              echo "  The check did not produce a verdict this job recognises, so the" >&2
+              echo "  delivery's freshness is unknown. Unknown is not OK." >&2
+              exit 1
+              ;;
+          esac

--- a/tests/test_fao_freshness_workflow.py
+++ b/tests/test_fao_freshness_workflow.py
@@ -1,0 +1,159 @@
+"""The FAO freshness heartbeat must be able to fail (D7, #320).
+
+A workflow nobody tests is how `update_catalogs` accumulated **eight consecutive
+failures without anyone noticing** (#336). This one guards a delivery that already
+went dark for 145 days, so the ways it could quietly stop working are worth pinning.
+
+Three properties, and the second is the one that matters:
+
+1. It is **scheduled** — a heartbeat that only runs when someone pushes is not a
+   heartbeat, and the thing being detected is precisely that nobody looked.
+2. It classifies on the **verdict**, never on the exit code. `SKIP_NO_CREDENTIALS`
+   maps to exit 0 in `tools/liveness/report.py`, so a job keyed on the exit code
+   would report success having read nothing — a dead heartbeat indistinguishable
+   from a healthy one. Same defect class as C-113 and C-114.
+3. It **fails** on a missing-credentials skip rather than passing.
+
+These are static checks on the workflow file. They cannot prove GitHub runs it, but
+they can prove it was not quietly rewritten into something that always passes.
+"""
+
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.beige
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+WORKFLOW = REPO_ROOT / ".github" / "workflows" / "fao_freshness.yml"
+
+
+@pytest.fixture(scope="module")
+def workflow() -> dict:
+    yaml = pytest.importorskip(
+        "yaml", reason="PyYAML not installed — cannot parse the workflow (truthful skip)"
+    )
+    assert WORKFLOW.exists(), (
+        f"{WORKFLOW.relative_to(REPO_ROOT)} is missing.\n"
+        f"  D7 of the release requires a scheduled check that fails when the FAO "
+        f"delivery goes stale."
+    )
+    return yaml.safe_load(WORKFLOW.read_text(encoding="utf-8"))
+
+
+@pytest.fixture(scope="module")
+def body() -> str:
+    return WORKFLOW.read_text(encoding="utf-8")
+
+
+class TestItRuns:
+    def test_it_is_scheduled(self, workflow):
+        # PyYAML parses a bare `on:` key as the boolean True.
+        triggers = workflow.get("on", workflow.get(True, {}))
+        assert "schedule" in triggers, (
+            "the heartbeat has no schedule. A check that only runs on push cannot "
+            "detect that nobody has run anything — which is the failure it exists for."
+        )
+
+    def test_it_can_be_triggered_by_hand(self, workflow):
+        """So it can be *proven* to fire, rather than believed to."""
+        triggers = workflow.get("on", workflow.get(True, {}))
+        assert "workflow_dispatch" in triggers
+
+    def test_it_reads_the_check_this_repo_already_has(self, body):
+        assert "tools.liveness.unfao_delivery" in body
+
+
+class TestItCanActuallyFail:
+    """The properties that stop it becoming a green light nobody questions."""
+
+    def test_it_classifies_on_the_verdict_not_the_exit_code(self, body):
+        assert "verdict" in body, "the job must read the check's verdict"
+        assert "DELIVERING)" in body, (
+            "the job must name the passing verdict explicitly — an allow-list, so an "
+            "unrecognised verdict fails rather than slipping through"
+        )
+
+    def test_a_missing_credential_skip_fails_rather_than_passes(self, body):
+        """`SKIP_NO_CREDENTIALS` is exit 0. For this job it must be a failure."""
+        assert "SKIP_NO_CREDENTIALS)" in body, (
+            "the job does not handle SKIP_NO_CREDENTIALS. It maps to exit 0, so "
+            "without an explicit branch the heartbeat passes having read nothing."
+        )
+        skip_branch = body.split("SKIP_NO_CREDENTIALS)")[1].split(";;")[0]
+        assert "exit 1" in skip_branch, (
+            "SKIP_NO_CREDENTIALS does not fail the job. A heartbeat that goes green "
+            "without reading anything is worse than no heartbeat."
+        )
+
+    def test_an_unrecognised_verdict_fails(self, body):
+        catchall = body.split("*)")[-1]
+        assert "exit 1" in catchall, (
+            "an unknown verdict does not fail the job. A gate that cannot tell "
+            "'passed' from 'did not run' is not a gate (C-113)."
+        )
+
+    def test_the_stale_branch_fails(self, body):
+        stale_branch = body.split("DELIVERY_STALLED)")[1].split(";;")[0]
+        assert "exit 1" in stale_branch
+
+
+class TestItDoesNotSetItsOwnBound:
+    def test_the_threshold_is_not_written_in_the_workflow(self, body):
+        """#360 collapsed two thresholds into one. A number here would make three."""
+        import re
+
+        for match in re.finditer(r"\b(\d+)\s*(?:days?|DAYS?)\b", body):
+            assert match.group(1) not in ("45", "60"), (
+                f"the workflow names a freshness bound ({match.group(0)!r}). The bound "
+                f"is declared in deliveries/un_fao.py and read by the check — a copy "
+                f"here re-creates the defect #360 removed."
+            )
+
+    def test_it_says_where_the_bound_lives(self, body):
+        assert "deliveries/un_fao.py" in body, (
+            "an operator reading a failure must be told which file declares the bound"
+        )
+
+
+class TestSecrets:
+    def test_it_requests_exactly_the_three_appwrite_secrets(self, body):
+        for name in (
+            "APPWRITE_ENDPOINT",
+            "APPWRITE_DATASTORE_PROJECT_ID",
+            "APPWRITE_DATASTORE_API_KEY",
+        ):
+            assert f"secrets.{name}" in body, f"{name} is not passed to the check"
+
+    def test_no_secret_value_is_echoed(self, body):
+        """The check redacts its own credentials; the workflow must not undo that."""
+        assert "echo \"$APPWRITE" not in body
+        assert "${{ secrets." in body  # referenced only through the env block
+
+
+class TestEveryVerdictHasABranch:
+    """The catch-all must be unreachable in practice.
+
+    It still fails, so safety does not depend on this — but an operator who hits a
+    real condition deserves a message naming the fix rather than the word
+    "inconclusive". A first live run produced CREDENTIALS_INCOMPLETE, which had no
+    branch and fell through; this test exists so the next new verdict does not.
+    """
+
+    def test_all_verdicts_this_check_can_emit_are_handled(self, body):
+        from tools.liveness import unfao_delivery  # noqa: F401
+        import inspect
+        import re
+
+        source = inspect.getsource(unfao_delivery)
+        emitted = set(re.findall(r'verdict\s*=\s*"([A-Z_]+)"', source))
+        emitted |= set(re.findall(r'verdict="([A-Z_]+)"', source))
+        # Verdicts the shared credential helper can return on this surface.
+        emitted |= {"SKIP_NO_CREDENTIALS", "CREDENTIALS_INCOMPLETE"}
+
+        unhandled = sorted(v for v in emitted if f"{v})" not in body)
+        assert not unhandled, (
+            f"these verdicts have no branch in the workflow: {unhandled}\n"
+            f"  They would fall to the catch-all and be reported as 'inconclusive', "
+            f"when the check already knows exactly what is wrong."
+        )


### PR DESCRIPTION
Closes **D7** of the release definition of done. Everything epic #342 built makes the FAO delivery *legible*; this makes its **absence loud** — the half that was missing, and the actual mechanism of #320.

## It classifies on the verdict, never the exit code

`SKIP_NO_CREDENTIALS` maps to **exit 0** in `tools/liveness/report.py` — correct for the six-surface dashboard, catastrophic here. A job keyed on the exit code would report success **having read nothing**, and a dead heartbeat is indistinguishable from a healthy one.

Same shape as `monthly_run.sh`'s Appwrite preflight (#302) and the C-113 lesson: *a gate that cannot tell "passed" from "did not run" is not a gate.*

So: an allow-list. `DELIVERING` passes; **everything else fails** — stale, unreachable, no credentials, partial credentials, unrecognised verdict, empty verdict. Verified by running the case statement against each.

## Running it for real found a verdict I had missed

The first end-to-end run emitted **`CREDENTIALS_INCOMPLETE`**, not `SKIP_NO_CREDENTIALS` — a *partial* credential set, which is the likelier mistake than none at all.

The catch-all failed it correctly, so safety never depended on this. But the operator would have read *"inconclusive"* when the check already knew exactly which variables were missing. `CREDENTIALS_INCOMPLETE` and `UNREACHABLE` now have their own messages, and **a test enumerates the verdicts the check can emit and fails if any lacks a branch.**

## The bound is not set here

`deliveries/un_fao.py` declares `max_age`; #360 made the check read it. A test fails if a number appears in this workflow — and **it caught my own comment**, which had written *"the BOUND (60 days)"* in prose. That would have been wrong the moment someone edited the declaration.

Cadence and bound are now explicitly separated: the bound says *when* a delivery is too old, the weekly cadence says *how soon after that we find out*. Weekly gives detection within 7 days for one API call; monthly would add up to 30 days of latency on top of the bound.

## Deliberately landing before the delivery

The stream is stale **right now**. So the first scheduled run should go **red** — proving the detector fires against a known-bad state we did not have to manufacture. G4 then turns it green with no code change.

Scheduled afterwards it would be green from birth, having never demonstrated it can fail.

## Blocked on

Three Actions secrets: `APPWRITE_ENDPOINT`, `APPWRITE_DATASTORE_PROJECT_ID`, `APPWRITE_DATASTORE_API_KEY`.

Until they exist the job fails with a message naming them — which is the **correct** state: it has verified nothing and does not claim to.

## Verification

Tested, because a workflow nobody tests is how `update_catalogs` reached eight consecutive failures unnoticed (#336) — the same invisibility that let #320 run five months.

Full suite in both states: **7650 passed, 0 failed.** `ruff` clean.

Refs #282, #320.

🤖 Generated with [Claude Code](https://claude.com/claude-code)