### PR TITLE
S2 — migrate pink_pirate/blue_stranger/purple_alien viewser→datafactory (Epic #242, #245)

### DIFF
--- a/models/blue_stranger/configs/config_queryset.py
+++ b/models/blue_stranger/configs/config_queryset.py
@@ -1,29 +1,46 @@
-from viewser import Queryset, Column
+"""Data specification for blue_stranger (datafactory consumer).
+
+This replaces the viewser Queryset pattern used in other models.
+Instead of connecting to PRIO's PostgreSQL via viewser, blue_stranger
+fetches from the VIEWS data factory via load_dataset().
+
+Prerequisites:
+    pip install views-datafactory
+    ~/.netrc entry for 204.168.219.108 (see README.md for setup)
+"""
+
+from __future__ import annotations
+
+from datafactory_query.defaults import DEFAULT_REMOTE
 from views_pipeline_core.managers.model import ModelPathManager
 
 model_name = ModelPathManager.get_model_name_from_path(__file__)
 
+# Data source URL — load_dataset() detects zarr vs npy from the path.
+# Zarr over HTTP requires ~/.netrc credentials (see README.md).
+ZARR_URL = DEFAULT_REMOTE.zarr_url
+
+# 13,110 PRIO-GRID cells matching VIEWSER's Africa + Middle East coverage
+REGION = "africa_me_legacy"
+
+# UCDP field names as stored in the zarr store
+FACTORY_FEATURES = ["ged_sb_best", "ged_ns_best", "ged_os_best", "gaul0_code"]
+
+# Factory name → VIEWSER name (so downstream model code doesn't change)
+FEATURE_RENAME = {
+    "ged_sb_best": "lr_sb_best",   # state-based fatalities (best estimate)
+    "ged_ns_best": "lr_ns_best",   # non-state fatalities
+    "ged_os_best": "lr_os_best",   # one-sided violence fatalities
+    "gaul0_code": "c_id",          # FAO GAUL country code → identity column
+}
+
 def generate():
-    """
-    Contains the configuration for the input data in the form of a viewser queryset. That is the data from viewser that is used to train the model.
-    This configuration is "behavioral" so modifying it will affect the model's runtime behavior and integration into the deployment system.
-    There is no guarantee that the model will work if the input data configuration is changed here without changing the model settings and algorithm accordingly.
-
-    Returns:
-    - queryset_base (Queryset): A queryset containing the base data for the model training.
-    """
-    
-    # VIEWSER 6
-
-    queryset_base = (Queryset(f"{model_name}", "priogrid_month")
-        .with_column(Column("lr_sb_best", from_loa = "priogrid_month", from_column = "ged_sb_best_sum_nokgi").transform.missing.replace_na())
-        .with_column(Column("lr_ns_best", from_loa = "priogrid_month", from_column = "ged_ns_best_sum_nokgi").transform.missing.replace_na())
-        .with_column(Column("lr_os_best", from_loa = "priogrid_month", from_column = "ged_os_best_sum_nokgi").transform.missing.replace_na())
-#        .with_column(Column("month", from_loa = "month", from_column = "month"))
-#        .with_column(Column("year_id", from_loa = "country_year", from_column = "year_id"))
-        .with_column(Column("c_id", from_loa = "country_year", from_column = "country_id"))
-        .with_column(Column("col", from_loa = "priogrid", from_column = "col"))
-        .with_column(Column("row", from_loa = "priogrid", from_column = "row")))
-
-
-    return queryset_base
+    """Data source descriptor (satisfies ModelPathManager.get_queryset() interface)."""
+    return {
+        "name": model_name,
+        "source": "views-datafactory",  # "views-datafactory" or "viewser"
+        "zarr_url": ZARR_URL,
+        "region": REGION,               # any datafactory_query region name
+        "loa": "priogrid_month",        # "priogrid_month" or "country_month"
+        "features": FEATURE_RENAME,
+    }

--- a/models/blue_stranger/requirements.txt
+++ b/models/blue_stranger/requirements.txt
@@ -1,1 +1,2 @@
 views-hydranet>=0.1.0,<1.0.0
+views-datafactory>=1.9.0,<2.0.0

--- a/models/pink_pirate/configs/config_queryset.py
+++ b/models/pink_pirate/configs/config_queryset.py
@@ -1,29 +1,46 @@
-from viewser import Queryset, Column
+"""Data specification for pink_pirate (datafactory consumer).
+
+This replaces the viewser Queryset pattern used in other models.
+Instead of connecting to PRIO's PostgreSQL via viewser, pink_pirate
+fetches from the VIEWS data factory via load_dataset().
+
+Prerequisites:
+    pip install views-datafactory
+    ~/.netrc entry for 204.168.219.108 (see README.md for setup)
+"""
+
+from __future__ import annotations
+
+from datafactory_query.defaults import DEFAULT_REMOTE
 from views_pipeline_core.managers.model import ModelPathManager
 
 model_name = ModelPathManager.get_model_name_from_path(__file__)
 
+# Data source URL — load_dataset() detects zarr vs npy from the path.
+# Zarr over HTTP requires ~/.netrc credentials (see README.md).
+ZARR_URL = DEFAULT_REMOTE.zarr_url
+
+# 13,110 PRIO-GRID cells matching VIEWSER's Africa + Middle East coverage
+REGION = "africa_me_legacy"
+
+# UCDP field names as stored in the zarr store
+FACTORY_FEATURES = ["ged_sb_best", "ged_ns_best", "ged_os_best", "gaul0_code"]
+
+# Factory name → VIEWSER name (so downstream model code doesn't change)
+FEATURE_RENAME = {
+    "ged_sb_best": "lr_sb_best",   # state-based fatalities (best estimate)
+    "ged_ns_best": "lr_ns_best",   # non-state fatalities
+    "ged_os_best": "lr_os_best",   # one-sided violence fatalities
+    "gaul0_code": "c_id",          # FAO GAUL country code → identity column
+}
+
 def generate():
-    """
-    Contains the configuration for the input data in the form of a viewser queryset. That is the data from viewser that is used to train the model.
-    This configuration is "behavioral" so modifying it will affect the model's runtime behavior and integration into the deployment system.
-    There is no guarantee that the model will work if the input data configuration is changed here without changing the model settings and algorithm accordingly.
-
-    Returns:
-    - queryset_base (Queryset): A queryset containing the base data for the model training.
-    """
-    
-    # VIEWSER 6
-
-    queryset_base = (Queryset(f"{model_name}", "priogrid_month")
-        .with_column(Column("lr_sb_best", from_loa = "priogrid_month", from_column = "ged_sb_best_sum_nokgi").transform.missing.replace_na())
-        .with_column(Column("lr_ns_best", from_loa = "priogrid_month", from_column = "ged_ns_best_sum_nokgi").transform.missing.replace_na())
-        .with_column(Column("lr_os_best", from_loa = "priogrid_month", from_column = "ged_os_best_sum_nokgi").transform.missing.replace_na())
-#        .with_column(Column("month", from_loa = "month", from_column = "month"))
-#        .with_column(Column("year_id", from_loa = "country_year", from_column = "year_id"))
-        .with_column(Column("c_id", from_loa = "country_year", from_column = "country_id"))
-        .with_column(Column("col", from_loa = "priogrid", from_column = "col"))
-        .with_column(Column("row", from_loa = "priogrid", from_column = "row")))
-
-
-    return queryset_base
+    """Data source descriptor (satisfies ModelPathManager.get_queryset() interface)."""
+    return {
+        "name": model_name,
+        "source": "views-datafactory",  # "views-datafactory" or "viewser"
+        "zarr_url": ZARR_URL,
+        "region": REGION,               # any datafactory_query region name
+        "loa": "priogrid_month",        # "priogrid_month" or "country_month"
+        "features": FEATURE_RENAME,
+    }

--- a/models/pink_pirate/requirements.txt
+++ b/models/pink_pirate/requirements.txt
@@ -1,1 +1,2 @@
 views-hydranet>=0.1.0,<1.0.0
+views-datafactory>=1.9.0,<2.0.0

--- a/models/purple_alien/configs/config_queryset.py
+++ b/models/purple_alien/configs/config_queryset.py
@@ -1,29 +1,46 @@
-from viewser import Queryset, Column
+"""Data specification for purple_alien (datafactory consumer).
+
+This replaces the viewser Queryset pattern used in other models.
+Instead of connecting to PRIO's PostgreSQL via viewser, purple_alien
+fetches from the VIEWS data factory via load_dataset().
+
+Prerequisites:
+    pip install views-datafactory
+    ~/.netrc entry for 204.168.219.108 (see README.md for setup)
+"""
+
+from __future__ import annotations
+
+from datafactory_query.defaults import DEFAULT_REMOTE
 from views_pipeline_core.managers.model import ModelPathManager
 
 model_name = ModelPathManager.get_model_name_from_path(__file__)
 
+# Data source URL — load_dataset() detects zarr vs npy from the path.
+# Zarr over HTTP requires ~/.netrc credentials (see README.md).
+ZARR_URL = DEFAULT_REMOTE.zarr_url
+
+# 13,110 PRIO-GRID cells matching VIEWSER's Africa + Middle East coverage
+REGION = "africa_me_legacy"
+
+# UCDP field names as stored in the zarr store
+FACTORY_FEATURES = ["ged_sb_best", "ged_ns_best", "ged_os_best", "gaul0_code"]
+
+# Factory name → VIEWSER name (so downstream model code doesn't change)
+FEATURE_RENAME = {
+    "ged_sb_best": "lr_sb_best",   # state-based fatalities (best estimate)
+    "ged_ns_best": "lr_ns_best",   # non-state fatalities
+    "ged_os_best": "lr_os_best",   # one-sided violence fatalities
+    "gaul0_code": "c_id",          # FAO GAUL country code → identity column
+}
+
 def generate():
-    """
-    Contains the configuration for the input data in the form of a viewser queryset. That is the data from viewser that is used to train the model.
-    This configuration is "behavioral" so modifying it will affect the model's runtime behavior and integration into the deployment system.
-    There is no guarantee that the model will work if the input data configuration is changed here without changing the model settings and algorithm accordingly.
-
-    Returns:
-    - queryset_base (Queryset): A queryset containing the base data for the model training.
-    """
-    
-    # VIEWSER 6
-
-    queryset_base = (Queryset(f"{model_name}", "priogrid_month")
-        .with_column(Column("lr_sb_best", from_loa = "priogrid_month", from_column = "ged_sb_best_sum_nokgi").transform.missing.replace_na())
-        .with_column(Column("lr_ns_best", from_loa = "priogrid_month", from_column = "ged_ns_best_sum_nokgi").transform.missing.replace_na())
-        .with_column(Column("lr_os_best", from_loa = "priogrid_month", from_column = "ged_os_best_sum_nokgi").transform.missing.replace_na())
-#        .with_column(Column("month", from_loa = "month", from_column = "month"))
-#        .with_column(Column("year_id", from_loa = "country_year", from_column = "year_id"))
-        .with_column(Column("c_id", from_loa = "country_year", from_column = "country_id"))
-        .with_column(Column("col", from_loa = "priogrid", from_column = "col"))
-        .with_column(Column("row", from_loa = "priogrid", from_column = "row")))
-
-
-    return queryset_base
+    """Data source descriptor (satisfies ModelPathManager.get_queryset() interface)."""
+    return {
+        "name": model_name,
+        "source": "views-datafactory",  # "views-datafactory" or "viewser"
+        "zarr_url": ZARR_URL,
+        "region": REGION,               # any datafactory_query region name
+        "loa": "priogrid_month",        # "priogrid_month" or "country_month"
+        "features": FEATURE_RENAME,
+    }

--- a/models/purple_alien/requirements.txt
+++ b/models/purple_alien/requirements.txt
@@ -1,1 +1,2 @@
 views-hydranet>=0.1.0,<1.0.0
+views-datafactory>=1.9.0,<2.0.0


### PR DESCRIPTION
## What
Migrate the 3 remaining viewser HydraNet models to the `africa_me_legacy` **views-datafactory** descriptor (Epic #242 S2 / #245):
- `pink_pirate`, `blue_stranger`, `purple_alien` `config_queryset.py` → the datafactory form (bright_starship template, model-name-agnostic; per-model docstring fixed)
- `+ views-datafactory>=1.9.0,<2.0.0` in each `requirements.txt`

Fleet is now **0 viewser** HydraNets on development (was 4: these 3 + violet — see note).

## Validation
- **Tier-A PASS** (fresh-pull + transitivity, views-hydranet dossier `2026-08-08_hydranet_ensemble_dossier` EXP-01): a FRESH datafactory pull (`africa_me_legacy` 121–504, `last_valid=559`) is **byte-identical** to the frozen v2 truth — 100.000% exact-match on lr_sb/ns/os_best, 0% drift, maxima identical, F-A1..F-A4 all quiet. The 3 querysets are byte-identical to the already-Tier-A-PASSed africa datafactory form, so the migration preserves the viewser conflict truth.
- **Full suite green: 7456 passed**, 229 skipped; ruff clean. Source-detection + datafactory parity + reconciliation + config-completeness + ensemble-config tests all pass with the 3 on datafactory.
- 2-lesson smoke deemed redundant: the 2026-08-04 plumbing smoke already trained 4 africa datafactory HydraNets end-to-end, and Tier-A confirms these 3 pull the identical data.

## ⚠️ Note for S3
`development`'s **violet_visitor is still viewser** — its datafactory migration is uncommitted scratch that was never merged (so development has 4 datafactory HydraNets, not the 5 the epic assumed). violet is a gated_NB ensemble member that also needs datafactory before S3/S5. Out of scope for this PR (#245 = the viewser trio); flagged for Epic #242 S3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)