### PR TITLE
test(ADR-012): assert the lr_/by_ target prefixes — the guard the ADR asked for and never got

### DIFF
--- a/docs/ADRs/009_boundary_contracts.md
+++ b/docs/ADRs/009_boundary_contracts.md
@@ -39,6 +39,7 @@ Every config file boundary must enforce:
 | Model naming | `^[a-z]+_[a-z]+$` | `tests/test_model_structure.py` |
 | Required files | `main.py`, `run.sh`, `configs/` with 6 config files | `tests/test_model_structure.py` |
 | CLI pattern | Import from `views_pipeline_core.cli`, no `wandb.login()` | `tests/test_cli_pattern.py` |
+| Targets ↔ metrics | Declaring `classification_targets` obliges a classification metric key (`classification_point_metrics` or `classification_sample_metrics`); likewise for regression. The rule is **owned upstream** by views-pipeline-core's `CoreConfigSniffer` and is not restated here, so the two cannot drift. | `tests/test_core_config_sniffer_contract.py`, which loads every config through the installed sniffer |
 
 ### Ensemble Boundaries
 

--- a/docs/ADRs/012_target_scale_and_prefix_convention.md
+++ b/docs/ADRs/012_target_scale_and_prefix_convention.md
@@ -115,7 +115,7 @@ Placing the full lifecycle in the modeling library keeps the contract simple: da
 ## Validation & Monitoring
 
 - `tools/audit/queryset_transforms.py` — programmatically verifies no queryset-level log transforms are applied to target columns. Run periodically or before release.
-- Existing tests (`test_config_completeness.py`) can be extended to assert that all `regression_targets` use the `lr_` prefix and all `classification_targets` use the `by_` prefix.
+- `tests/test_target_prefix_convention.py` asserts that all `regression_targets` use the `lr_` prefix and all `classification_targets` use the `by_` prefix. **Implemented 2026-08-11**, ~3 months after this ADR proposed it; until then nothing checked either prefix. Fixture entities are excluded via `meta/fixtures.json` (nine declare a deliberate `synth_target`), and that exclusion is itself pinned, so a *real* model adopting `synth_` still fails. It lives in its own file rather than inside `test_config_completeness.py`: that file asks whether required keys are present, this one asks whether the values are well-formed.
 - Any model producing predictions on a non-measurement scale is a bug in the modeling library, not in this repo. Such bugs would manifest as anomalous evaluation metrics (e.g., CRPS or MSE orders of magnitude off expected ranges).
 
 ---

--- a/tests/test_target_prefix_convention.py
+++ b/tests/test_target_prefix_convention.py
@@ -1,0 +1,163 @@
+"""Target names carry the prefix their kind requires (ADR-012).
+
+ADR-012 fixes two prefixes: ``lr_`` marks a **regression** target on its original
+measurement scale, ``by_`` marks a **classification** target derived from counts. All
+other prefixes (``ln_``, ``lx_``, …) are deprecated and must not appear as targets in
+new configs.
+
+The ADR proposed this guard itself — *"Existing tests (`test_config_completeness.py`)
+can be extended to assert that all `regression_targets` use the `lr_` prefix and all
+`classification_targets` use the `by_` prefix"* — and it was never written. It lives in
+its own file rather than inside `test_config_completeness.py` because it is a different
+question: that file asks whether required keys are *present*, this one asks whether the
+values are *well-formed*.
+
+**Why now.** views-models#367 declared `classification_targets` without the metric key
+that obliges, and nothing caught it. That is the same family: a targets declaration that
+no test inspected. #374 closed the metric half by loading every config through
+pipeline-core's `CoreConfigSniffer`; this closes the prefix half, which the sniffer does
+not check — it validates the targets↔metrics *pairing*, never the target *names*.
+
+**What this does not do.** It asserts the prefix and nothing about the suffix, the scale,
+or whether the target exists in the data. ADR-012 is explicit that the prefix is an
+identity convention: `lr_` does not mean a transform was applied or needs undoing.
+Queryset-level transforms are `tools/audit/queryset_transforms.py`'s job.
+"""
+
+import json
+from pathlib import Path
+
+import pytest
+
+from tests.conftest import ALL_ENSEMBLE_DIRS, ALL_MODEL_DIRS, load_config_module
+
+pytestmark = [pytest.mark.beige]
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+#: The canonical registry of not-real entities. Loaded, never hardcoded — the same rule
+#: `tools/partitions/fileops.py` and `tools/catalogs/create_catalogs.py` follow, pinned
+#: by `test_bump_partitions.py::TestFixtureSetConsistency` (C-61, #99).
+FIXTURES_PATH = REPO_ROOT / "meta" / "fixtures.json"
+
+REGRESSION_PREFIX = "lr_"
+CLASSIFICATION_PREFIX = "by_"
+
+#: Both config files that may declare targets. Models put them in hyperparameters,
+#: ensembles in meta; several declare in both, so each is read wherever it appears.
+TARGET_SOURCES = (
+    ("config_hyperparameters.py", "get_hp_config"),
+    ("config_meta.py", "get_meta_config"),
+)
+
+
+def _fixture_names():
+    return set(json.loads(FIXTURES_PATH.read_text()))
+
+
+def _declared_targets(directory):
+    """{"regression_targets": [...], "classification_targets": [...]} across both files."""
+    found = {"regression_targets": [], "classification_targets": []}
+    for filename, getter in TARGET_SOURCES:
+        path = directory / "configs" / filename
+        if not path.exists():
+            continue
+        fn = getattr(load_config_module(path), getter, None)
+        if fn is None:
+            continue
+        config = fn() or {}
+        for key in found:
+            found[key].extend(config.get(key) or [])
+    return found
+
+
+def _real_sources():
+    """Every non-fixture model and ensemble directory.
+
+    Fixtures are excluded because their targets are deliberately synthetic
+    (`synth_target`) — nine of them declare it, and every one is registered in
+    `meta/fixtures.json`. Excluding by that registry rather than by prefix keeps the
+    exclusion a declared fact rather than a circular one: a real model that started
+    using `synth_` would still fail.
+    """
+    fixtures = _fixture_names()
+    for directory in list(ALL_MODEL_DIRS) + list(ALL_ENSEMBLE_DIRS):
+        if directory.name in fixtures:
+            continue
+        yield directory
+
+
+def _offenders(key, prefix):
+    bad = {}
+    for directory in _real_sources():
+        wrong = sorted(
+            {t for t in _declared_targets(directory)[key] if not t.startswith(prefix)}
+        )
+        if wrong:
+            bad[directory.name] = wrong
+    return bad
+
+
+def test_regression_targets_use_the_lr_prefix():
+    """ADR-012: `lr_` marks a target on its original measurement scale."""
+    offenders = _offenders("regression_targets", REGRESSION_PREFIX)
+    assert not offenders, (
+        f"regression_targets must use the '{REGRESSION_PREFIX}' prefix (ADR-012):\n"
+        + "\n".join(f"  {name}: {targets}" for name, targets in sorted(offenders.items()))
+    )
+
+
+def test_classification_targets_use_the_by_prefix():
+    """ADR-012: `by_` marks a classification target derived from counts."""
+    offenders = _offenders("classification_targets", CLASSIFICATION_PREFIX)
+    assert not offenders, (
+        f"classification_targets must use the '{CLASSIFICATION_PREFIX}' prefix (ADR-012):\n"
+        + "\n".join(f"  {name}: {targets}" for name, targets in sorted(offenders.items()))
+    )
+
+
+def test_the_prefix_checks_are_not_vacuous():
+    """Both assertions must be inspecting real targets, not an empty set.
+
+    If discovery or config loading broke, the two tests above would pass while reading
+    nothing. Floors are set well under today's counts (190 regression, 24 classification
+    across non-fixture sources) so ordinary churn does not trip them.
+    """
+    counts = {"regression_targets": 0, "classification_targets": 0}
+    for directory in _real_sources():
+        declared = _declared_targets(directory)
+        for key in counts:
+            counts[key] += len(declared[key])
+
+    assert counts["regression_targets"] > 100, (
+        f"only {counts['regression_targets']} regression targets seen — the prefix "
+        f"assertion is passing over almost nothing"
+    )
+    assert counts["classification_targets"] > 10, (
+        f"only {counts['classification_targets']} classification targets seen — the "
+        f"prefix assertion is passing over almost nothing"
+    )
+
+
+def test_fixtures_are_excluded_by_the_registry_not_by_the_prefix():
+    """The exclusion is a declared fact, and it is load-bearing.
+
+    Nine fixture entities declare `synth_target` as a regression target. If they were
+    not registered in `meta/fixtures.json`, the regression assertion would fail — so
+    this pins that the registry is what excludes them, and that it still contains them.
+    """
+    fixtures = _fixture_names()
+    synthetic = {
+        directory.name
+        for directory in list(ALL_MODEL_DIRS) + list(ALL_ENSEMBLE_DIRS)
+        if any(
+            not t.startswith(REGRESSION_PREFIX)
+            for t in _declared_targets(directory)["regression_targets"]
+        )
+    }
+    assert synthetic, "no synthetic-target entity found — this test has lost its subject"
+    assert synthetic <= fixtures, (
+        f"these declare non-{REGRESSION_PREFIX} regression targets but are NOT in "
+        f"meta/fixtures.json: {sorted(synthetic - fixtures)}. Either register them as "
+        f"fixtures or give them ADR-012 target names."
+    )


### PR DESCRIPTION
ADR-012 proposed this guard itself — *"Existing tests (`test_config_completeness.py`) can be extended to assert that all `regression_targets` use the `lr_` prefix and all `classification_targets` use the `by_` prefix"* — and it was never written. Nothing checked either prefix, for about three months.

Same family as #367: a targets declaration that no test inspected. **#374** closed the metric half by loading every config through pipeline-core's `CoreConfigSniffer`. The sniffer validates the targets↔metrics **pairing** and never the target **names**, so this closes the other half.

## What the tree already looks like

Measured across every non-fixture source:

| | count | prefixes |
|---|---|---|
| `regression_targets` | 190 | all `lr_` |
| `classification_targets` | 24 | all `by_` |

The convention already holds everywhere. This **pins** it; it does not repair anything.

## Fixtures

Nine fixture entities declare a deliberate `synth_target`. They are excluded via `meta/fixtures.json`, **loaded rather than hardcoded** — the rule `tools/partitions/fileops.py` and `tools/catalogs/create_catalogs.py` follow, pinned by `TestFixtureSetConsistency` (C-61, #99).

That exclusion is itself pinned by a test, so it stays a *declared* fact rather than a circular one: a **real** model adopting `synth_` still fails.

## Placement

Own file, not an addition to `test_config_completeness.py`. That file asks whether required keys are *present*; this asks whether the values are *well-formed*. Different question, different file.

## Both ADRs updated to say the guards exist

- **ADR-012** — implementation note, with the three-month gap stated rather than glossed.
- **ADR-009** — the conventions table gains a targets↔metrics row. Worth noting the gap was wider than the one missing key: that table previously mentioned **no** targets or metrics keys at all. The row **attributes** the rule to pipeline-core's sniffer rather than restating it, so the two cannot drift.

## Verified it bites

Injecting `'ln_sb_best'` into `bright_starship` turns it red, naming the model and the offending target; removing it turns it green.

My first attempt at that check used `"by_sb_best"` while the file uses `'by_sb_best'`, so the injection silently changed nothing and the "test" passed. The guard was fine — the verification was the vacuous thing. Worth recording, because a check that cannot fail looks exactly like a check that passed.

## Verification

- `ruff check .` clean
- Full suite: **7753 passed, 219 skipped, 6 xfailed, 1 xpassed, 0 failed**
