### PR TITLE
feat(#127): commit the un_fao global-land flip that production has been running for seven weeks

### DIFF
--- a/postprocessors/un_fao/README.md
+++ b/postprocessors/un_fao/README.md
@@ -35,10 +35,17 @@ Three UCDP fatality targets at PRIO-GRID month level:
 | `ged_os_best` | `lr_ged_os` | one-sided |
 
 Data source is the **data factory** (not viewser) — see `configs/config_queryset.py`.
-Current coverage region: **`africa_me_legacy`** (~13,110 cells). Going global to
-`land_gaul` (64,736 cells) is tracked in #127 — and it also clears the handful of
-GAUL-uncovered cells (remote islands) that fail completeness validation under
-`africa_me_legacy` (see the postmortems).
+Current coverage region: **`land_gaul`** (64,742 cells = global land ∩ FAO-GAUL
+coverage). This matches the `rusty_bucket` forecast scope cell-for-cell and excludes
+the handful of GAUL-uncovered cells (remote islands) that fail completeness validation
+under the old `africa_me_legacy` (~13,110 Africa+ME cells; see the postmortems).
+
+The historical actuals are fetched **pandas-free** as a `views_frames.FeatureFrame`
+(`data_format: feature_frame` in `config_queryset.py`), not a pandas DataFrame. At the
+global-land scale (64,742 cells × ~438 months = 28.4M rows) the pandas path OOM-kills
+(~24 GB); the frame path is the numpy-native fix. This makes the FAO delivery the
+platform's first real consumer of the pandas-free fetch path (`get_feature_frame`).
+The manager-side migration that reads this key lives in **views-postprocessing**.
 
 ## Credential topology
 
@@ -70,7 +77,7 @@ before any work. These are guarded by
 
 1. **`views-datafactory` installed** (the `datafactory_query` module):
    ```
-   pip install 'views-datafactory @ git+https://github.com/views-platform/views-datafactory.git@development'
+   pip install 'views-datafactory>=1.9.0,<2.0.0'
    ```
    If missing, `configs/config_queryset.py` fails loud at config load (not an opaque
    `ModuleNotFoundError`).

--- a/postprocessors/un_fao/configs/config_meta.py
+++ b/postprocessors/un_fao/configs/config_meta.py
@@ -161,5 +161,10 @@ def get_meta_config():
         # run-0 contract-leg delivery — views-postprocessing instruction 2026-07-27:
         # read/deliver the ADR-013 wire dialect and un-freeze the upload interlock,
         # with the declared land_gaul region curation applied at the delivery boundary.
+        # NOT COMMITTED (register C-110): wire_contract and region are still
+        # working-tree only. wire_upload_enabled is no longer here — it is derived
+        # from DELIVERY.intent above (#348).
+        "wire_contract": True,
+        "region": "land_gaul",
     }
     return meta_config

--- a/postprocessors/un_fao/configs/config_queryset.py
+++ b/postprocessors/un_fao/configs/config_queryset.py
@@ -17,8 +17,7 @@ except ImportError as e:  # fail loud with the fix, not a bare ModuleNotFoundErr
         "The un_fao postprocessor requires views-datafactory (provides the "
         "`datafactory_query` module), which is not installed in this environment.\n"
         "Install it:\n"
-        "    pip install 'views-datafactory @ "
-        "git+https://github.com/views-platform/views-datafactory.git@development'\n"
+        "    pip install 'views-datafactory>=1.9.0,<2.0.0'\n"
         "and add a ~/.netrc entry for host 204.168.219.108 (the Zarr store; see "
         "the bright_starship model README)."
     ) from e
@@ -29,7 +28,12 @@ model_name = ModelPathManager.get_model_name_from_path(__file__)
 
 ZARR_URL = DEFAULT_REMOTE.zarr_url
 
-REGION = "africa_me_legacy"
+# Global-land: the historical actuals must cover the SAME cells the forecast does.
+# rusty_bucket forecasts global land, curated at the delivery boundary to `land_gaul`
+# (64,742 = land ∩ FAO-GAUL coverage). Fetching actuals at this exact region makes the
+# historical frame match the forecast cell-for-cell and satisfy the delivery coverage
+# gate (was `africa_me_legacy`, ~13,110 Africa+ME cells — the legacy scope).
+REGION = "land_gaul"
 
 FACTORY_FEATURES = ["ged_sb_best", "ged_ns_best", "ged_os_best"]
 
@@ -49,4 +53,11 @@ def generate():
         "region": REGION,
         "loa": "priogrid_month",
         "features": FEATURE_RENAME,
+        # Fetch the historical actuals as a pandas-free views_frames.FeatureFrame instead
+        # of a pandas DataFrame. The migrated un_fao manager reads this via
+        # pipeline-core's declared_data_format() and calls get_feature_frame() rather than
+        # get_data(). This is the root fix for the global-land (land_gaul, 64,742-cell,
+        # 28.4M-row) actuals OOM. NOTE: no-op until the views-postprocessing manager
+        # migration lands (it must — see the un_fao frame-native issue); land together.
+        "data_format": "feature_frame",
     }

--- a/postprocessors/un_fao/requirements.txt
+++ b/postprocessors/un_fao/requirements.txt
@@ -1,1 +1,1 @@
-views-datafactory @ git+https://github.com/views-platform/views-datafactory.git@development
+views-datafactory>=1.9.0,<2.0.0

--- a/tests/test_deliveries_characterisation.py
+++ b/tests/test_deliveries_characterisation.py
@@ -26,12 +26,23 @@ pytestmark = pytest.mark.beige
 REPO_ROOT = Path(__file__).resolve().parents[1]
 DELIVERIES_DIR = REPO_ROOT / "deliveries"
 
-# Keys the FAO config carries in git. Anything outside this set is working-tree only
-# (C-110) and must not be asserted against — see the module docstring.
+# Keys the FAO config carries in git.
+#
+# C-110 is CLOSED as of #127: the config's working-tree-only state was committed, so
+# "committed" and "working tree" are now the same set. The comment that used to say
+# anything outside this set is working-tree only no longer applies.
 COMMITTED_META_KEYS = {
     "name", "algorithm", "targets", "level",
     "ensemble",             # derived from the declaration since #347
     "wire_upload_enabled",  # derived from DELIVERY.intent since #348
+    "wire_contract",        # committed by #127
+    # Committed by #127, and this guard's own question — "might this key belong in the
+    # delivery declaration?" — answers YES for this one. `region` duplicates
+    # REQUIRE.coverage in deliveries/un_fao.py and REGION in config_queryset.py, and it
+    # is the only one of the three the un_fao manager actually reads
+    # (unfao/managers/unfao.py:236,312,419 -> delivery/provenance.py:47). Scheduled to
+    # become derived by ADR-021; until then it is a typed literal that nothing checks.
+    "region",
 }
 
 


### PR DESCRIPTION
Closes #127. Resolves **C-110**. Unblocks #373 and, through it, #333.

## What this is

Four changes that have existed **only in the maintainer's working tree since 2026-06-24** — seven weeks — while being what the FAO delivery actually runs. A clean clone of this repo has been getting Africa-only behaviour the entire time.

| file | change |
|---|---|
| `config_queryset.py` | `REGION` `africa_me_legacy` → `land_gaul`; `data_format: feature_frame`; datafactory install pinned instead of a git URL |
| `config_meta.py` | `wire_contract: True`; `region: land_gaul` |
| `requirements.txt` | `views-datafactory` git URL → `>=1.9.0,<2.0.0` |
| `README.md` | coverage restated as `land_gaul`, 64,742 cells |

## What it changes operationally — the point, not a side effect

**Before:** a fresh checkout **disarmed** the FAO upload. `_upload_armed()` saw `REGION=africa_me_legacy` against a delivery declaring `land_gaul`, refused, staged artifacts locally and warned.

**After:** a fresh checkout **arms** — the two agree.

The maintainer's laptop already behaved this way. Every other machine — a server, a colleague's clone, CI — did not. This is deliberate and approved.

## The numbers

**64,742 is correct**, confirmed by two independent sources: `views-datafactory/src/datafactory_query/land_gaul_pgids.json` has 64,742 entries, and `views_postprocessing/delivery/coverage.py:56` pins `64_742`. #127's body still says **64,736 / 82 excluded**; both are stale — the 82 became **76** when datafactory#163 supplemented 6 Azorean cells. The README committed here already carries the right figures.

**The producer's manifest says `expected_cell_count: 64818`, and that is not a discrepancy.** 64,818 is `land`, the pre-curation forecast extent; the 76 excluded sub-Antarctic cells are removed at the delivery boundary. Do not "correct" it to 64,742 — that would be the actual regression.

## A guard fired, and it was right

`test_parity_scope_is_still_accurate` pins the set of keys the FAO config carries in git, asking *"might this new committed key belong in the delivery declaration?"*

For `wire_contract`, no. **For `region`, yes** — it duplicates `REQUIRE.coverage` and `config_queryset.REGION`, and it is the only one of the three the manager actually reads (`unfao/managers/unfao.py:236,312,419` → `delivery/provenance.py:47`). Recorded in the pin rather than waved through, and scheduled to become derived by **ADR-021**.

The stale comment claiming *"anything outside this set is working-tree only (C-110)"* is corrected — that is exactly what this PR closes.

## Not touched

`models/violet_visitor/configs/config_queryset.py` remains fenced and uncommitted.

## Verification

- `ruff check .` clean
- Full suite: **7753 passed, 219 skipped, 6 xfailed, 1 xpassed, 0 failed**
