### PR TITLE
feat(ADR-021): coverage is declared once — and the copy nothing checked was the one the UN sees

### DIFF
--- a/deliveries/status.py
+++ b/deliveries/status.py
@@ -109,6 +109,43 @@ def declared_max_age_days(consumer: str = "un_fao") -> int:
     return require.max_age.count * 30
 
 
+
+def declared_coverage(consumer: str = "un_fao") -> str:
+    """The coverage region this consumer's delivery declares.
+
+    The *only* declaration of which cells a consumer receives. Everything that needs
+    the region derives it from here: the postprocessor's actuals fetch region
+    (`config_queryset.REGION`) and the region it reports to the manager
+    (`config_meta["region"]`). Three typed copies of one string is what ADR-019 §8
+    rejects, and it is what this repository did until ADR-021 — with the copy the
+    manager actually reads being the one nothing checked (register C-110, C-133).
+
+    **This is the delivered coverage, not the producer's extent.** `rusty_bucket`
+    forecasts `land` (64,818 cells); the delivery boundary curates that to `land_gaul`
+    (64,742) by removing 76 sub-Antarctic cells outside FAO GAUL 2024. That reduction
+    is owned by `views_postprocessing/delivery/coverage.py`, not by this function.
+
+    Raises rather than defaulting, for the same reason as `declared_max_age_days`:
+    a fallback region would re-create the defect with one of the copies invisible.
+    """
+    path = DELIVERIES_DIR / f"{consumer}.py"
+    if not path.exists():
+        raise FileNotFoundError(
+            f"no delivery declaration for '{consumer}'.\n"
+            f"  Expected: deliveries/{consumer}.py\n"
+            f"  The coverage region is declared there; this will not invent one."
+        )
+    require = load_delivery(path).REQUIRE
+    if not require.coverage:
+        raise ValueError(
+            f"deliveries/{consumer}.py declares no coverage, so there is no region to "
+            f"fetch or deliver.\n"
+            f"  Add coverage=\"<region>\" to REQUIRE.\n"
+            f"  Every consumer must declare one (ADR-019 §3, ADR-021)."
+        )
+    return require.coverage
+
+
 def consumers_for(source: str) -> list[str]:
     """Which consumers this source reaches, directly or as a member."""
     return delivered_sources().get(source, [])

--- a/docs/ADRs/021_coverage_is_declared_once.md
+++ b/docs/ADRs/021_coverage_is_declared_once.md
@@ -1,0 +1,146 @@
+# ADR-021: Coverage is declared once, in the delivery
+
+**Status:** Accepted
+**Date:** 2026-08-11
+**Deciders:** Simon, VIEWS platform team
+**Related ADRs:** [ADR-017](017_source_composition_delivery.md) (the three axes), [ADR-019](019_delivery_declaration.md) (the delivery file format; §3 the vocabulary, §8 "two places to state one fact"), [ADR-020](020_errors_must_descend.md) (errors name the next file down)
+
+---
+
+## Context
+
+`land_gaul` — the set of cells the UN FAO receives — was a typed literal in **three**
+places:
+
+| # | location | guarded by |
+|---|---|---|
+| 1 | `deliveries/un_fao.py` — `coverage = "land_gaul"` | `_upload_armed()` |
+| 2 | `postprocessors/un_fao/configs/config_queryset.py` — `REGION = "land_gaul"` | `_upload_armed()` |
+| 3 | `postprocessors/un_fao/configs/config_meta.py` — `"region": "land_gaul"` | **nothing** |
+
+`config_meta.py::_upload_armed()` compared (1) against (2) and disarmed the upload when
+they differed. It never looked at (3) — and (3) is the only one that leaves this
+repository. views-postprocessing's `unfao/managers/unfao.py` reads `configs.get("region")`
+at lines 236, 312 and 419, and `delivery/provenance.py:47` writes it into the provenance
+record delivered to the partner.
+
+So the interlock guarded the two copies the manager never reads, and not the one it does.
+Setting (1) and (2) both to `"land"` **armed** the upload while (3) still said
+`"land_gaul"`: the run would curate to `land_gaul` and ship a provenance record claiming
+`land_gaul` against a declaration saying `land`. No warning, output that looks correct,
+external partner. Registered as **C-133**.
+
+Two further facts made this the moment to fix it rather than note it:
+
+- **`_queryset_region()` was a partial Python interpreter.** It could not import
+  `config_queryset.py` — that file pulls in pipeline-core — so it walked the file's AST
+  for `REGION = <constant>`. It matched only a bare literal; a derived or conditional
+  assignment raised `RuntimeError` from a config read. It was knowledge of another file's
+  *syntax*, not its interface. Same family as **C-57**.
+- **`un_crafd` is the second consumer** (#333, blocked by #373). One postprocessor held
+  three copies; two would hold six. This repository's own rule is to extract when a second
+  incident shows the shape.
+
+ADR-019 §8 had already rejected the pattern by name — *"two places to state one fact, and
+nothing to reconcile them"* — and stated the principle: *"a thing which is never typed
+cannot lie."* Coverage was the clause's most literal violation, and the only one that had
+been given a *reconciliation* rather than a *derivation*. #348 derived
+`wire_upload_enabled` from `DELIVERY.intent`; #360 derived the freshness bound via
+`declared_max_age_days()`. Coverage did not get the same treatment.
+
+---
+
+## Decision
+
+### 1. Coverage is declared once, in the delivery.
+
+`deliveries/<consumer>.py`'s `REQUIRE.coverage` is the sole declaration of which cells a
+consumer receives. **No `config_*.py` under `postprocessors/` may contain a coverage
+literal.**
+
+### 2. Everything else derives it.
+
+`config_queryset.REGION` and `config_meta["region"]` are obtained from
+`deliveries.status.declared_coverage(<consumer>)`, which sits beside
+`declared_max_age_days()` — the same shape, the same module, the same refusal to default.
+
+The actuals fetch region and the delivered coverage are **one fact**. This is not an
+assumption: `config_queryset.py` set `REGION` to the delivery's region precisely because
+*"the historical actuals must cover the SAME cells the forecast does"*. Typing it in both
+places gave the repository two copies to disagree about, and it did — `africa_me_legacy`
+in git against `land_gaul` in a working tree, for seven weeks (**C-110**, closed by #127).
+
+### 3. The producer's extent is a different fact and is not governed here.
+
+`rusty_bucket` forecasts **`land`, 64,818 cells**; the delivery boundary curates that to
+**`land_gaul`, 64,742**, by removing 76 sub-Antarctic cells outside FAO GAUL 2024. The
+run-0 manifest correctly declares `expected_cell_count: 64818`. That reduction is owned by
+`views_postprocessing/delivery/coverage.py`.
+
+**Do not "correct" the 76-cell gap.** Three scopes exist — producer extent, delivered
+coverage, actuals fetch — and only the last two are the same fact.
+
+### 4. The cross-check is deleted. One assertion remains.
+
+`_upload_armed()`'s region comparison and `_queryset_region()`'s AST parse are **removed**.
+Derived values cannot disagree, so a check for disagreement is dead weight that implies the
+state is reachable. Extending it to the third copy would have hardened the duplication
+instead of removing it.
+
+A single assertion in `get_meta_config()` — the emitted `region` equals the declaration —
+is **kept**, and is deliberately belt-and-braces rather than a reconciliation. It can only
+fire if someone reintroduces a literal. It costs one line, and what it guards is delivered
+to a UN agency.
+
+---
+
+## Consequences
+
+### Positive
+
+- The failure mode is removed rather than detected. The previous design's best case was a
+  correct refusal; this one has no case to refuse.
+- A parser of another file's source text is gone, and with it the class of defect where a
+  config becomes unreadable because a sibling's assignment stopped being a bare literal.
+- `un_crafd` is born derived and types coverage nowhere — #373's decision (b) becomes free
+  rather than adding copies four and five.
+- Changing coverage is now a one-line edit to the declaration.
+
+### Negative
+
+- **The delivery declaration is now a hard dependency of data fetching.** Before, a
+  malformed `deliveries/<consumer>.py` disarmed the upload and the run still produced local
+  artifacts; now `config_queryset.generate()` cannot resolve a region and fetching fails.
+  This is accepted: a run that cannot say which cells it is fetching should not fetch. Per
+  ADR-020, the error names `deliveries/<consumer>.py`.
+- `config_queryset.py` gains a `sys.path` bootstrap and an import of `deliveries/`, which
+  `config_meta.py` already carried. Both configs now depend on two subsystems.
+
+### Known inconsistency, deliberately not fixed here
+
+The same fact is called **`coverage`** in the declaration and **`region`** in both derived
+places, because views-postprocessing reads `configs.get("region")` in six places across
+`unfao/managers/unfao.py` and `crafd/managers/crafd.py`. Three names for one fact is part
+of how the duplication stayed invisible. Renaming the wire key is a cross-repo change and
+is not attempted here; this ADR records the debt rather than hiding it.
+
+### The rule this ADR exists to stop being rediscovered
+
+**A reconciliation is not a derivation.** Cross-checking two copies of a fact leaves the
+duplication in place and quietly implies that all copies are covered. Here the check
+covered the two that did not matter. If you find yourself adding a comparison between two
+places that state the same thing, the fix is to delete one of them.
+
+---
+
+## References
+
+- `deliveries/status.py` — `declared_coverage()`, beside `declared_max_age_days()`
+- `postprocessors/un_fao/configs/config_queryset.py`, `config_meta.py` — the derived readers
+- `tests/test_intent_arms_the_delivery.py` — the inverted guard: a mismatch must be
+  unrepresentable
+- Register: **C-133** (the unguarded consumed copy), **C-110** (region uncommitted for
+  seven weeks, closed by #127), **C-129** (same fact in two places), **C-57** (a parser
+  cannot distinguish code from the text describing it)
+- Issues: #127, #333, #373; `views_postprocessing/delivery/coverage.py` for the
+  `land` → `land_gaul` curation

--- a/postprocessors/un_fao/configs/config_meta.py
+++ b/postprocessors/un_fao/configs/config_meta.py
@@ -20,9 +20,7 @@ loudly (ADR-003): a silent default would deliver the *wrong forecast to a UN age
 say nothing, which is worse than any error this file could raise.
 """
 
-import ast
 import sys
-import warnings
 from pathlib import Path
 
 # The delivery declaration lives at the repository root. run.sh is immutable, so
@@ -72,27 +70,6 @@ def _declared_region() -> str:
     return REQUIRE.coverage
 
 
-def _queryset_region() -> str:
-    """`REGION` from config_queryset.py, read *statically*.
-
-    Parsed rather than imported: config_queryset imports pipeline-core and the
-    datafactory client, and this file must stay cheap enough to load anywhere. The
-    question here is one string.
-    """
-    source = (Path(__file__).parent / "config_queryset.py").read_text(encoding="utf-8")
-    for node in ast.walk(ast.parse(source)):
-        if isinstance(node, ast.Assign):
-            for target in node.targets:
-                if isinstance(target, ast.Name) and target.id == "REGION":
-                    if isinstance(node.value, ast.Constant):
-                        return node.value.value
-    raise RuntimeError(
-        "could not find REGION in postprocessors/un_fao/configs/config_queryset.py.\n"
-        "  Open that file — this config reads REGION to confirm the repository agrees "
-        "with itself about which region ships."
-    )
-
-
 def _upload_armed() -> bool:
     """Whether this delivery is armed — derived from `intent`, never typed.
 
@@ -102,40 +79,23 @@ def _upload_armed() -> bool:
     computes the key. `intent` and a hand-written boolean were the same fact in two
     places, which ADR-019 §8 rejects by name (register C-129).
 
-    **Arming is withheld when the repository disagrees with itself.** The delivery
-    declares a `coverage`; `config_queryset.py` declares a `REGION`. If they differ,
-    a run would upload a region nobody declared — and a clean checkout is exactly that
-    case today, because `REGION` is committed as ``africa_me_legacy`` while the
-    delivery declares ``land_gaul`` (register C-110).
+    **There is no longer a region cross-check here, and that is the point.** Until
+    ADR-021 this function compared the delivery's `coverage` against a `REGION` literal
+    in `config_queryset.py` — parsed out of that file's source with `ast`, because
+    importing it pulls in pipeline-core — and disarmed when they disagreed. Both are
+    now derived from `deliveries.status.declared_coverage()`, so they cannot disagree:
+    the check was deleted rather than extended to the third copy, because reconciling
+    a duplication keeps the duplication.
 
-    It **disarms and warns** rather than raising. Raising would make the config
-    unloadable from a clean checkout, breaking runs that never intended to upload —
-    a new failure mode invented to guard an old one. Disarming is exactly what the
-    interlock already does when the key is absent (vpp ADR-013 §11.4: artifacts are
-    staged locally), so this refuses the dangerous half and leaves the rest working.
+    The residual assertion in `get_meta_config()` is deliberate belt-and-braces, not a
+    reconciliation. It costs one line, and the value it guards is written into the
+    provenance record delivered to a UN agency.
 
     That is what makes a derived arming state safe to commit: a fresh clone cannot
     silently ship the wrong region to a UN agency, and it does not break either.
     """
     from deliveries.un_fao import DELIVERY
 
-    declared, actual = _declared_region(), _queryset_region()
-    if declared != actual:
-        warnings.warn(
-            f"NOT ARMING the FAO upload: this repository disagrees with itself about "
-            f"which region ships.\n"
-            f"  deliveries/un_fao.py declares coverage={declared!r}\n"
-            f"  postprocessors/un_fao/configs/config_queryset.py declares "
-            f"REGION={actual!r}\n"
-            f"  Open config_queryset.py and set REGION to {declared!r}, or change the "
-            f"delivery's coverage — they must agree before anything uploads.\n"
-            f"  The run will still produce artifacts locally, as it does whenever the "
-            f"upload interlock is closed (vpp ADR-013 §11.4). Nothing else in this "
-            f"config is wrong; this is the only thing holding the upload.",
-            UserWarning,
-            stacklevel=2,
-        )
-        return False
     return DELIVERY.intent.state == "live"
 
 
@@ -172,4 +132,13 @@ def get_meta_config():
         # this string that nothing checked (register C-133).
         "region": _declared_region(),
     }
+    # Belt-and-braces, not a reconciliation (ADR-021). Derived values cannot disagree,
+    # so this can only fire if someone reintroduces a literal. One line, and what it
+    # guards is the region written into the provenance record shipped to the UN FAO.
+    assert meta_config["region"] == _declared_region(), (
+        f"config_meta emits region={meta_config['region']!r} but "
+        f"deliveries/un_fao.py declares {_declared_region()!r}.\n"
+        f"  Do not fix this by editing the literal — there should not be one.\n"
+        f"  See docs/ADRs/021_coverage_is_declared_once.md."
+    )
     return meta_config

--- a/postprocessors/un_fao/configs/config_meta.py
+++ b/postprocessors/un_fao/configs/config_meta.py
@@ -165,6 +165,11 @@ def get_meta_config():
         # working-tree only. wire_upload_enabled is no longer here — it is derived
         # from DELIVERY.intent above (#348).
         "wire_contract": True,
-        "region": "land_gaul",
+        # Derived, never typed (ADR-021). This is the copy the manager actually reads
+        # — views-postprocessing unfao/managers/unfao.py:236,312,419 — and the one
+        # written into the delivered provenance record (delivery/provenance.py:47).
+        # It was a literal until 2026-08-11, and the only one of the three copies of
+        # this string that nothing checked (register C-133).
+        "region": _declared_region(),
     }
     return meta_config

--- a/postprocessors/un_fao/configs/config_queryset.py
+++ b/postprocessors/un_fao/configs/config_queryset.py
@@ -10,6 +10,9 @@ Prerequisites:
 
 from __future__ import annotations
 
+import sys
+from pathlib import Path
+
 try:
     from datafactory_query.defaults import DEFAULT_REMOTE
 except ImportError as e:  # fail loud with the fix, not a bare ModuleNotFoundError (#95)
@@ -28,12 +31,25 @@ model_name = ModelPathManager.get_model_name_from_path(__file__)
 
 ZARR_URL = DEFAULT_REMOTE.zarr_url
 
-# Global-land: the historical actuals must cover the SAME cells the forecast does.
-# rusty_bucket forecasts global land, curated at the delivery boundary to `land_gaul`
-# (64,742 = land ∩ FAO-GAUL coverage). Fetching actuals at this exact region makes the
-# historical frame match the forecast cell-for-cell and satisfy the delivery coverage
-# gate (was `africa_me_legacy`, ~13,110 Africa+ME cells — the legacy scope).
-REGION = "land_gaul"
+# Derived, never typed (ADR-021). The actuals fetch region and the delivered coverage
+# are ONE fact: the historical frame must cover the same cells as the forecast, which
+# is why this was set to the delivery's region in the first place. Typing it here as
+# well gave the repository two copies to disagree about, and it did — `africa_me_legacy`
+# in git against `land_gaul` in a working tree, for seven weeks (register C-110).
+#
+# Today: `land_gaul`, 64,742 cells = global land ∩ FAO-GAUL coverage. To change it,
+# edit `coverage` in deliveries/un_fao.py; nothing here needs touching.
+#
+# Not to be confused with the producer's extent: rusty_bucket forecasts `land` (64,818)
+# and the delivery boundary removes 76 sub-Antarctic cells outside GAUL 2024. That
+# curation belongs to views_postprocessing/delivery/coverage.py.
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+from deliveries.status import declared_coverage  # noqa: E402  (after the path bootstrap)
+
+REGION = declared_coverage("un_fao")
 
 FACTORY_FEATURES = ["ged_sb_best", "ged_ns_best", "ged_os_best"]
 

--- a/reports/technical_risk_register.md
+++ b/reports/technical_risk_register.md
@@ -2,9 +2,9 @@
 
 **Last updated:** 2026-08-04  
 **Governing ADR:** [ADR-010](../docs/ADRs/010_technical_risk_register.md)  
-**Total entries:** 140 (131 concerns + 9 disagreements)  
-**Concerns:** Open 61 | Mitigated 20 | Resolved 41 | Accepted 3 | Partially Resolved 1 | Subsumed 1 | Merged 4  
-**Concerns by tier:** T1 5 | T2 43 | T3 54 | T4 25 (4 merge stubs carry no tier)  
+**Total entries:** 141 (132 concerns + 9 disagreements)  
+**Concerns:** Open 61 | Mitigated 20 | Resolved 42 | Accepted 3 | Partially Resolved 1 | Subsumed 1 | Merged 4  
+**Concerns by tier:** T1 6 | T2 43 | T3 54 | T4 25 (4 merge stubs carry no tier)  
 **Disagreements:** Open 7 | Resolved 1 | Subsumed 1  
 **Last curated:** 2026-07-31 (`review-rr strategic`, first full pass — tier recalibration, 4 merges, 6 causal clusters identified)
 
@@ -1646,6 +1646,17 @@
 | **Status** | Open |
 | **Location** | `docs/ADRs/017_source_composition_delivery.md` §4e (the ⟺ definition) and §5 (the tier rule) vs `docs/ADRs/019_delivery_declaration.md` §3 (`tier`) |
 | **Notes** | §4e defines *in production ⟺ maturity is `graduate` **and** a delivery ships it to a **production-tier** consumer.* ADR-019 §3 fixes `tier` at exactly one value, `prod`, and says plainly that the gate is therefore *currently unconditional*. §4e did not, so the definition read as two independent conditions when one is presently always true. Not a correctness defect — the definition stays true as written, and becomes discriminating the moment a second tier value exists — but it is the kind of gap that makes a newcomer believe a check exists that does not. **Corrected by a clause in §4e pointing at ADR-019 §3.** The second tier value is itself blocked on ADR-017 §12's open shadow-destination question. Cross-refs: **C-129**. |
+
+### C-133 — The coverage copy the manager actually reads was the one nothing checked
+
+| Field | Value |
+|---|---|
+| **Tier** | 1 |
+| **Trigger** | Editing `coverage` in `deliveries/un_fao.py` or `REGION` in `config_queryset.py` without also editing `config_meta.py`'s `"region"` — or any consumer cloning the un_fao configs, which is what #333 was about to do. |
+| **Source** | expert-code-review of the proposed ADR-021 (2026-08-11), found while verifying #373 |
+| **Status** | Resolved (2026-08-11, ADR-021) |
+| **Location** | `postprocessors/un_fao/configs/config_meta.py` (was `"region": "land_gaul"`); consumed at `views-postprocessing unfao/managers/unfao.py:236,312,419`; written at `delivery/provenance.py:47` |
+| **Notes** | `land_gaul` was a typed literal in **three** places: the delivery declaration, `config_queryset.REGION`, and `config_meta["region"]`. `_upload_armed()` cross-checked the first two and disarmed loudly on disagreement — verified working, a clean checkout yielded `wire_upload_enabled = False`. It never checked the third, **and the third is the only one that leaves this repository**: the un_fao manager reads `configs.get("region")` and writes it into the provenance record delivered to the UN FAO. Setting the two guarded copies to `"land"` **arms** the upload while the consumed copy still says `"land_gaul"` — the run curates to `land_gaul` and ships provenance claiming `land_gaul` against a declaration saying `land`. No warning, plausible output, external partner. Tier 1: silent, wrong, and UN-facing. **The general shape: a reconciliation is not a derivation.** Cross-checking two copies leaves the duplication in place and implies all copies are covered; here it covered the two that did not matter. **Resolved by derivation, not by extending the check to a third copy** — hardening a duplication is the direction ADR-019 §8 already rejected. All three now read `deliveries.status.declared_coverage()`; the cross-check and its `ast` parser are deleted; a one-line assertion remains as belt-and-braces and is verified to bite. Cross-refs: **C-110** (the same region uncommitted for seven weeks, closed by #127), **C-129** (same fact in two places), **C-57** (`_queryset_region()` parsed a sibling's source text for a literal — same family). Member of **Cluster A** (declared-but-unenforced). |
 
 
 ## Disagreements

--- a/tests/test_intent_arms_the_delivery.py
+++ b/tests/test_intent_arms_the_delivery.py
@@ -183,15 +183,34 @@ class TestTheRegionCrossCheckIsCorrectlyRetired:
             "(ADR-021) — a literal here recreates the C-110 split."
         )
 
-    def test_both_derived_values_equal_the_declaration(self):
-        """Queryset and meta agree with the declaration because they read it."""
+    def test_the_meta_region_equals_the_declaration(self):
+        """The copy the manager reads agrees with the declaration, because it reads it."""
+        from deliveries.un_fao import REQUIRE
+
+        assert _meta()["region"] == REQUIRE.coverage
+
+    def test_the_queryset_region_equals_the_declaration(self):
+        """Same for the fetch region — but this one needs the package to import.
+
+        `config_queryset.py` imports `datafactory_query` at module scope, so it cannot be
+        imported without views-datafactory installed. CI does not install it, and that is
+        precisely why the deleted `_queryset_region()` parsed the file rather than
+        importing it. A truthful skip (ADR-005) rather than a parse: re-introducing a
+        parser here to dodge the dependency would rebuild the thing ADR-021 removed.
+
+        The structural half — that no literal remains — is asserted above without
+        importing anything, so the skip does not leave the rule unchecked.
+        """
+        pytest.importorskip(
+            "datafactory_query",
+            reason="views-datafactory not installed; config_queryset cannot be imported",
+        )
         from deliveries.un_fao import REQUIRE
 
         queryset_region = load_config_module(
             FAO_QUERYSET, module_name="fao_queryset_arming"
         ).generate()["region"]
         assert queryset_region == REQUIRE.coverage
-        assert _meta()["region"] == REQUIRE.coverage
 
     def test_changing_the_declaration_changes_both(self):
         """Direction, not tautology.

--- a/tests/test_intent_arms_the_delivery.py
+++ b/tests/test_intent_arms_the_delivery.py
@@ -46,13 +46,15 @@ def _meta() -> dict:
     return load_config_module(FAO_META, module_name="fao_meta_arming").get_meta_config()
 
 
-def _armed_in_a_copy(*, region: str, intent_src: str | None = None) -> tuple[bool, str]:
-    """Build a throwaway repo copy with a chosen REGION, and read the arming state.
+def _armed_in_a_copy(
+    *, coverage: str | None = None, intent_src: str | None = None
+) -> tuple[bool, str]:
+    """Build a throwaway repo copy with a chosen declaration, and read the arming state.
 
-    The tests must not depend on whether *this* checkout happens to agree with itself.
-    A developer's tree has REGION = "land_gaul"; a clean checkout still has
-    "africa_me_legacy" (C-110). A test that asserted either would pass in one place and
-    fail in the other, which is how #348 first broke in CI.
+    Rewrites the DECLARATION (`deliveries/un_fao.py`), not the queryset. Before ADR-021
+    this rewrote `REGION` in `config_queryset.py`, because that was a second place the
+    region was typed; it derives now, so there is nothing there to rewrite and the
+    declaration is the only input.
     """
     import shutil
     import sys
@@ -67,14 +69,14 @@ def _armed_in_a_copy(*, region: str, intent_src: str | None = None) -> tuple[boo
                 "envs", "wandb", "data", "artifacts", "logs", "reports", "docs",
             ),
         )
-        queryset = repo / "postprocessors/un_fao/configs/config_queryset.py"
-        text = queryset.read_text()
         import re as _re
-        queryset.write_text(
-            _re.sub(r'REGION = "[a-z_]+"', f'REGION = "{region}"', text, count=1)
-        )
+        declaration = repo / "deliveries/un_fao.py"
+        if coverage is not None:
+            body = declaration.read_text()
+            body = _re.sub(r'coverage   = "[a-z_]+"',
+                           f'coverage   = "{coverage}"', body, count=1)
+            declaration.write_text(body)
         if intent_src is not None:
-            declaration = repo / "deliveries/un_fao.py"
             body = declaration.read_text()
             body = _re.sub(r"intent    = .*", f"intent    = {intent_src},", body, count=1)
             # the real file imports only what it uses; a substituted intent may need more
@@ -119,19 +121,18 @@ class TestArmingIsDerivedFromIntent:
         """`unfao/managers/unfao.py:317` reads it as an optional launcher key."""
         assert "wire_upload_enabled" in _meta()
 
-    def test_live_arms_when_the_repository_agrees_with_itself(self):
-        from deliveries.un_fao import DELIVERY, REQUIRE
+    def test_live_arms(self):
+        """Since ADR-021 the repository cannot disagree with itself about the region,
+        so `intent` is the only thing arming depends on."""
+        from deliveries.un_fao import DELIVERY
 
         assert DELIVERY.intent.state == "live"
-        armed, _ = _armed_in_a_copy(region=REQUIRE.coverage)
+        armed, _ = _armed_in_a_copy()
         assert armed is True
 
-    def test_paused_disarms_even_when_the_repository_agrees(self):
-        """Regions agreeing must not be enough — `intent` is what decides."""
-        from deliveries.un_fao import REQUIRE
-
+    def test_paused_disarms(self):
+        """`intent` decides, and nothing else does."""
         armed, _ = _armed_in_a_copy(
-            region=REQUIRE.coverage,
             intent_src='paused("testing the disarm path", since=date(2026, 8, 5))',
         )
         assert armed is False
@@ -155,53 +156,52 @@ class TestArmingIsDerivedFromIntent:
 
 
 @pytest.mark.red
-class TestArmingIsWithheldWhenTheRepoDisagreesWithItself:
-    def test_this_checkout_is_internally_consistent_or_disarmed(self):
-        """Asserts the *relationship*, not today's value.
+class TestTheRegionCrossCheckIsCorrectlyRetired:
+    """**Inverted, not deleted** — the same fact, with the opposite expected value.
 
-        Whether this checkout agrees with itself depends on whether it carries the
-        uncommitted `REGION = "land_gaul"` (C-110). A developer's tree usually does; a
-        clean checkout does not. Asserting either would be asserting that C-110 is
-        resolved, which it is not — and would pass here while failing in CI, which is
-        exactly how this story first broke.
+    This class used to assert that a region mismatch disarms the upload: the delivery
+    declared `land_gaul` while committed `config_queryset.py` said `africa_me_legacy`
+    (C-110), so `_upload_armed()` refused and a clean checkout could not ship a region
+    nobody declared.
 
-        What must hold everywhere: if the two disagree, the upload is not armed.
-        """
+    ADR-021 removed the disagreement instead of detecting it. Both `REGION` and
+    `config_meta["region"]` now derive from `deliveries.status.declared_coverage()`, so
+    there is no second value to mismatch. The cross-check and the `ast` parser that fed
+    it are gone.
+
+    A guard dropped because it became inconvenient teaches the next person that guards
+    are negotiable — the same reasoning `test_deliveries_characterisation.py` gives for
+    inverting the additive guard rather than removing it. So the fact is still checked
+    here, with the expectation flipped: a mismatch must now be **unrepresentable**.
+    """
+
+    def test_the_queryset_declares_no_region_literal(self):
+        """There is nothing left to disagree with the declaration."""
+        assert _region_in(FAO_QUERYSET.read_text()) is None, (
+            "config_queryset.py has a literal REGION assignment again. Coverage is "
+            "declared once, in deliveries/un_fao.py, and derived everywhere else "
+            "(ADR-021) — a literal here recreates the C-110 split."
+        )
+
+    def test_both_derived_values_equal_the_declaration(self):
+        """Queryset and meta agree with the declaration because they read it."""
         from deliveries.un_fao import REQUIRE
 
-        agrees = REQUIRE.coverage == _region_in(FAO_QUERYSET.read_text())
-        armed = _meta()["wire_upload_enabled"]
-        if not agrees:
-            assert armed is False, (
-                "this checkout disagrees with itself about the region, yet the upload "
-                "is armed — a run would ship a region nobody declared (C-110)."
-            )
+        queryset_region = load_config_module(
+            FAO_QUERYSET, module_name="fao_queryset_arming"
+        ).generate()["region"]
+        assert queryset_region == REQUIRE.coverage
+        assert _meta()["region"] == REQUIRE.coverage
 
-    def test_a_mismatch_disarms_without_crashing_and_names_the_file(self):
-        armed, stderr = _armed_in_a_copy(region="africa_me_legacy")
-        assert armed is False, (
-            "a region mismatch armed the delivery anyway — a clean checkout would "
-            "upload the wrong region to a UN bucket (register C-110)"
-        )
-        assert "config_queryset.py" in stderr, (
-            f"the warning names no file (ADR-020).\n  stderr: {stderr[-500:]}"
-        )
+    def test_changing_the_declaration_changes_both(self):
+        """Direction, not tautology.
 
-    def test_a_clean_checkout_today_would_disarm_rather_than_arm(self):
-        """The committed `config_queryset.py` still says africa_me_legacy (C-110).
-
-        This test states what that means, so the fact is visible rather than implied:
-        a fresh clone does not silently upload the wrong region; it refuses.
+        Comparing two derived values to each other would compare the declaration to
+        itself and pass for any implementation. What must hold is that the declaration
+        *drives* them: change it, and both follow.
         """
-        committed = subprocess.run(
-            ["git", "show", "HEAD:postprocessors/un_fao/configs/config_queryset.py"],
-            cwd=REPO_ROOT, capture_output=True, text=True,
+        armed, _stderr = _armed_in_a_copy(coverage="africa_me_legacy")
+        assert armed is True, (
+            "changing the declared coverage should leave the delivery armed — both "
+            "derived values move with it, so nothing disagrees"
         )
-        assert committed.returncode == 0
-        from deliveries.un_fao import REQUIRE
-
-        committed_region = _region_in(committed.stdout)
-        if committed_region != REQUIRE.coverage:
-            # Expected today. The guard above is what makes it safe.
-            assert committed_region is not None
-        # If they now agree, C-110's region half has been resolved — nothing to assert.


### PR DESCRIPTION
Implements **ADR-021**. Three commits, each revertible alone.

## The defect (commit 1 — `8ecab0a0`)

`land_gaul` was a typed literal in **three** places. `_upload_armed()` cross-checked two of them and disarmed loudly on disagreement — verified working. It never checked the third, **and the third is the only one that leaves this repository**:

- `views-postprocessing unfao/managers/unfao.py:236,312,419` reads `configs.get("region")`
- `delivery/provenance.py:47` writes it into the provenance record delivered to the UN FAO

Set the two guarded copies to `"land"` and the upload **arms** while the consumed copy still says `"land_gaul"` — the run curates to `land_gaul` and ships provenance claiming `land_gaul` against a declaration saying `land`. No warning, plausible output, external partner. Registered as **C-133, Tier 1**.

Fixed by derivation, not by extending the check to a third copy — hardening a duplication is the direction ADR-019 §8 already rejected. Adds `deliveries.status.declared_coverage()`, mirroring `declared_max_age_days()` that #360 established.

## The refactor (commit 2 — `4aeb3d78`)

`REGION` derives too, so coverage is declared in exactly one place. Two things **deleted rather than extended**:

- **`_queryset_region()`** — it `ast`-parsed `config_queryset.py` for `REGION = <literal>`, because importing that file pulls in pipeline-core. It matched only a bare constant, so any derived assignment raised `RuntimeError` from a config read. Knowledge of another file's *syntax*, not its interface. Same family as C-57. It existed solely to reconcile the duplication this PR removes.
- **the region branch of `_upload_armed()`** — nothing left to disagree.

**Kept:** a one-line assertion that the emitted region equals the declaration. Belt-and-braces, not a reconciliation; it can only fire if someone reintroduces a literal. Verified it bites.

`TestArmingIsWithheldWhenTheRepoDisagreesWithItself` is **inverted, not deleted** — the precedent `test_deliveries_characterisation.py:154-157` sets for the additive guard. A mismatch must now be *unrepresentable*: no literal in the queryset, both derived values equal the declaration, and **changing the declaration changes both** — a claim about direction, which comparing two derived values could not make.

## The ADR (commit 3 — `c6ab4cd3`)

The clause worth re-reading later: **a reconciliation is not a derivation.** Cross-checking two copies leaves the duplication and implies every copy is covered. Here it covered the two that didn't matter.

Also recorded, because the evidence invites the error: **64,818 and 64,742 are not a discrepancy.** Three scopes exist — producer extent, delivered coverage, actuals fetch — and only the last two are the same fact. The 76-cell gap is the GAUL curation; do not "fix" it.

Two consequences stated rather than hidden: the declaration is now a hard dependency of data fetching (a run that cannot say which cells it fetches should not fetch; per ADR-020 the error names the file), and the same fact is still `coverage` in one place and `region` in two, because views-postprocessing reads `configs.get("region")` in six places across two managers. Renaming the wire key is cross-repo — debt recorded, not hidden.

## Unblocks

**#373(b)** becomes free: `un_crafd` is born derived and types coverage nowhere, rather than adding copies four and five.

## Verification

- `ruff check .` clean
- Full suite: **7753 passed, 219 skipped, 6 xfailed, 1 xpassed, 0 failed**
- Residual assertion verified to fire on a reintroduced literal
- `models/violet_visitor/` untouched
