### PR TITLE
fix(C-135): the FAO delivery is armed on a build whose upload check fails open

### DIFF
--- a/reports/technical_risk_register.md
+++ b/reports/technical_risk_register.md
@@ -2,9 +2,9 @@
 
 **Last updated:** 2026-08-04  
 **Governing ADR:** [ADR-010](../docs/ADRs/010_technical_risk_register.md)  
-**Total entries:** 142 (133 concerns + 9 disagreements)  
-**Concerns:** Open 61 | Mitigated 21 | Resolved 42 | Accepted 3 | Partially Resolved 1 | Subsumed 1 | Merged 4  
-**Concerns by tier:** T1 6 | T2 43 | T3 55 | T4 25 (4 merge stubs carry no tier)  
+**Total entries:** 143 (134 concerns + 9 disagreements)  
+**Concerns:** Open 62 | Mitigated 21 | Resolved 42 | Accepted 3 | Partially Resolved 1 | Subsumed 1 | Merged 4  
+**Concerns by tier:** T1 6 | T2 44 | T3 55 | T4 25 (4 merge stubs carry no tier)  
 **Disagreements:** Open 7 | Resolved 1 | Subsumed 1  
 **Last curated:** 2026-07-31 (`review-rr strategic`, first full pass — tier recalibration, 4 merges, 6 causal clusters identified)
 
@@ -1668,6 +1668,17 @@
 | **Status** | Mitigated (ADR-022) |
 | **Location** | `tools/launcher/postprocessor.sh` (the shared body); `postprocessors/un_fao/run.sh` and `postprocessors/un_crafd/run.sh` (the wrappers); per-partner copies remain in each `configs/` and `main.py` |
 | **Notes** | Adding `un_crafd` made the partner-launcher pattern n=2 in this repository. The register already noted at the `crafd/` clone entry that the trigger had fired for **views-postprocessing** and not for views-models; #333 is the event that fires it here. **What was extracted, and why that half and not the other:** `run.sh` changes for two unrelated reasons — because a partner differs (conda env, pin) and because the delivery *protocol* differs (registry before conda, environment after it, capability by import not grep). The second must not be copied: a protocol fix would need hand-applying per partner, and the first one missed fails silently. That is not hypothetical — views-postprocessing cloned `unfao/` into `crafd/` and shipped a follow-up whose message is *"every partner-scoped guard was scoped to ONE partner"* (their #211, their C-33). `un_fao/run.sh` went 136 lines → 21. **What was deliberately NOT extracted:** `configs/*.py` and `main.py`. Their values genuinely differ per partner, and the ones that must agree platform-wide are already derived from `deliveries/<consumer>.py` (ADR-019, ADR-021). Two partners is the trigger to share what must not vary, not a licence to abstract what must. **The residual risk this entry exists for:** the shared body is sourced by production launchers, so editing it changes the live FAO delivery whether or not FAO appears in the diff. It deserves `platform_env.sh`-grade care. Mitigated by the launcher guarantees being parametrised over **every** launcher and reading each one's *effective* text (wrapper + sourced body) — reading `run.sh` alone would have made all of them pass vacuously the moment the body moved. Cross-refs: **C-60** (grouping by responsibility), C-57 and C-112 (scars the body carries), ADR-018 (the same one-writer shape a layer down). |
+
+### C-135 — The live FAO delivery runs on a build whose upload check fails OPEN
+
+| Field | Value |
+|---|---|
+| **Tier** | 2 |
+| **Trigger** | Any armed delivery run while `VIEWS_POSTPROCESSING_PIN` resolves to a views-postprocessing build predating their #222 — which is every merged branch today. Acute on `un_fao`, which is `live`. |
+| **Source** | views-postprocessing's review of views-models#380 (2026-08-11), verified here against their tree |
+| **Status** | Open |
+| **Location** | `postprocessors/un_fao/run.sh` (`VIEWS_POSTPROCESSING_PIN="main"`); upstream `views_postprocessing/{unfao,crafd}/managers/*.py`, fixed in their `a69d1a0` on `development` |
+| **Notes** | Until views-postprocessing#222 the upload verification read `if success is False: raise`. That **fails open**: a result that is `None`, lacks the attribute, or carries a non-bool passes as though the upload succeeded. The consequence is an **orphan** — a file in the partner bucket with no metadata document — and both consumer APIs select on metadata, so the partner sees nothing while the run reports success and exits 0. Their fix is `if success is not True`. **Why it cannot simply be fixed here:** the fix lives on their `development` (`2eb29f1`), not on `main` (`3286eab`). `main` is the newest merged state carrying the crafd package at all — the only tag, `1.0.0`, predates it and contains zero crafd files. So **no merged pin exists today with both crafd and C-79**, which is why **#364** (pin to a released tag) now blocks two repositories rather than one. Moving a live delivery's pin to an unmerged branch is a worse trade than waiting for the sync, so this is registered rather than patched. **`un_crafd` is not exposed**: it is `paused`, so the manager never constructs a partner store and makes zero store calls — the gap needs an upload to reach. **Exit:** views-postprocessing merges `development` → `main` (the same action that lets them cut a tag), then both pins move and `tests/test_launcher_pin_safety.py`'s strict xfail flips to XPASS, forcing the marker's removal. Guarded meanwhile by that file: an armed launcher on a deficient pin fails, so the arming and the pin must move together. Cross-refs: **C-134** (the shared launcher body where the pin now lives), #364, #333. |
 
 
 ## Disagreements

--- a/tests/test_launcher_pin_safety.py
+++ b/tests/test_launcher_pin_safety.py
@@ -1,0 +1,117 @@
+"""An armed delivery must not run on a views-postprocessing build with a known refusal gap.
+
+**The gap.** Until views-postprocessing#222 the upload verification in both partner
+managers read `if success is False: raise`. That **fails open**: a result that was `None`,
+lacked the attribute, or carried a non-bool sailed through as though the upload had
+worked. The consequence is an orphan — a file in the bucket with no metadata document —
+and the consumer APIs select on metadata, so the partner sees nothing while the run
+reports success. Their register calls it C-79.
+
+**Where the fix is.** On views-postprocessing's `development` (`2eb29f1`), not on `main`
+(`3286eab`). `main` is 33 commits behind and is the newest state that carries the crafd
+package at all — the only tag, `1.0.0`, predates it. So today there is **no** pin that has
+both crafd and C-79 on a merged branch, which is why views-models#364 (cut a tag) now
+blocks two repositories.
+
+**What this file asserts.** Not "the pin is current" — that would be a moving target and a
+nag. Only the narrow thing that matters: **a delivery that is armed must not be pinned to a
+build whose upload check fails open.** A disarmed launcher makes zero store calls, so the
+gap cannot reach it; the danger is exactly the transition.
+"""
+
+import re
+from pathlib import Path
+
+import pytest
+
+pytestmark = [pytest.mark.beige]
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+POSTPROCESSORS = REPO_ROOT / "postprocessors"
+
+#: views-postprocessing builds known to be missing a delivery refusal, and why. Keyed by
+#: the prefix a pin would carry. Entries leave this map when the fix reaches a merged
+#: branch and the pins move — not before.
+DEFICIENT_PINS = {
+    "3286eab": (
+        "lacks C-79 (views-postprocessing#222): the upload check reads "
+        "`if success is False`, so a None or non-bool result is treated as a successful "
+        "upload and leaves an orphan file with no metadata document"
+    ),
+    "main": (
+        "resolves to views-postprocessing main (3286eab today), which lacks C-79 — and "
+        "being a branch it can move under you without the pin changing"
+    ),
+}
+
+_PIN = re.compile(r'^VIEWS_POSTPROCESSING_PIN="([^"]+)"', re.M)
+
+LAUNCHERS = sorted(p.name for p in POSTPROCESSORS.iterdir() if (p / "run.sh").exists())
+
+
+def _pin(consumer: str) -> str:
+    match = _PIN.search((POSTPROCESSORS / consumer / "run.sh").read_text(encoding="utf-8"))
+    assert match, (
+        f"{consumer}/run.sh declares no VIEWS_POSTPROCESSING_PIN. Every launcher must "
+        f"name the build it installs (ADR-022)."
+    )
+    return match.group(1)
+
+
+def _deficiency(pin: str):
+    for prefix, why in DEFICIENT_PINS.items():
+        if pin.startswith(prefix):
+            return why
+    return None
+
+
+def _is_armed(consumer: str) -> bool:
+    from deliveries.status import upload_armed
+
+    return upload_armed(consumer)
+
+
+def test_there_is_at_least_one_launcher_to_check():
+    assert LAUNCHERS, "no launchers discovered — the checks below assert nothing"
+
+
+@pytest.mark.parametrize("consumer", LAUNCHERS)
+def test_a_disarmed_launcher_stays_disarmed_while_its_pin_is_deficient(consumer):
+    """The guard that matters: arming and the pin must move together.
+
+    This passes for a disarmed launcher on any pin, and for an armed launcher on a good
+    pin. It fails only on the combination that ships orphans — which is what someone
+    flipping `intent` to `live()` without touching the pin would create.
+    """
+    why = _deficiency(_pin(consumer))
+    if why is None:
+        return
+    if consumer == "un_fao":
+        pytest.skip("un_fao's pre-existing state is documented by the xfail below")
+    assert not _is_armed(consumer), (
+        f"{consumer} is ARMED while pinned to a build that {why}.\n"
+        f"  Move VIEWS_POSTPROCESSING_PIN in postprocessors/{consumer}/run.sh to a build "
+        f"carrying views-postprocessing#222 before arming, or set intent back to "
+        f"paused(...) in deliveries/{consumer}.py.\n"
+        f"  Tracked as views-models#364."
+    )
+
+
+@pytest.mark.xfail(
+    strict=True,
+    reason=(
+        "un_fao is live and pinned to @main, which lacks C-79 — a real, current gap on "
+        "the UN-facing delivery, not a hypothetical. It cannot be fixed here: no merged "
+        "views-postprocessing branch carries both the crafd package and C-79. Flips to "
+        "XPASS (and so fails, forcing this marker's removal) the day the pin moves — "
+        "views-models#364."
+    ),
+)
+def test_no_armed_launcher_is_pinned_to_a_deficient_build():
+    """The state we actually want, recorded as expected-to-fail rather than omitted."""
+    offenders = {
+        c: why
+        for c in LAUNCHERS
+        if (why := _deficiency(_pin(c))) is not None and _is_armed(c)
+    }
+    assert not offenders, "\n".join(f"  {c}: {why}" for c, why in offenders.items())


### PR DESCRIPTION
views-postprocessing reviewed #380 and flagged that the `un_crafd` pin lacks their **C-79**. Verified against their tree — and the finding is larger than the pin I chose.

## The gap

Until views-postprocessing#222 the upload verification read `if success is False: raise`. That **fails open**: a result that is `None`, lacks the attribute, or carries a non-bool passes as though the upload succeeded — leaving an **orphan**, a file in the partner bucket with no metadata document. Both consumer APIs select on metadata, so the partner sees nothing while the run reports success and exits 0. Their fix is `if success is not True`.

**`un_fao` is `live` and pinned to `@main`, which lacks it.** That is a current gap on the UN-facing delivery, not a hypothetical about `un_crafd`.

## Why it is registered rather than patched

The fix is on views-postprocessing's `development` (`2eb29f1`), **not** on `main` (`3286eab`). `main` is the newest *merged* state carrying the crafd package at all — the only tag, `1.0.0`, contains zero crafd files.

So **no merged pin exists today with both crafd and C-79.** Moving a live delivery's pin to an unmerged branch is a worse trade than waiting for their sync.

`un_crafd` is **not** exposed: `paused` means the manager never constructs a partner store and makes zero store calls. The gap needs an upload to reach it. The disarmed launcher on this pin is safe; the danger is precisely the transition.

## The guard

`tests/test_launcher_pin_safety.py`:

- **`test_a_disarmed_launcher_stays_disarmed_while_its_pin_is_deficient`** — passes for a disarmed launcher on any pin, and for an armed launcher on a good pin. Fails only on the combination that ships orphans. *Verified: arming `un_crafd` without moving the pin turns it red and names why.*
- **`test_no_armed_launcher_is_pinned_to_a_deficient_build`** — the state we want, recorded as a **strict xfail** rather than omitted. It documents `un_fao`'s live gap and flips to XPASS — so fails, forcing the marker's removal — the day the pin moves.

## The exit is upstream, and it is one action

views-postprocessing merges `development` → `main`. That is also what lets them cut the tag **#364** asks for, which now blocks two repositories.

Registered as **C-135** (Tier 2, Open).

## Verification

- `ruff check .` clean; full suite **7796 passed, 0 failed** (7 xfailed — one new, deliberate)
- Guard verified to bite on the armed+deficient combination