### PR TITLE
chore(#372): adopt views-pipeline-core 3.0.1 in the two exact pins

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -27,7 +27,7 @@ jobs:
       # Bump this deliberately, together with the ensembles' requirements.txt, never on its
       # own -- CI testing a version production does not install is the skew this pin removes.
       - name: Install dependencies
-        run: pip install "views_pipeline_core==3.0.0" pytest packaging
+        run: pip install "views_pipeline_core==3.0.1" pytest packaging
 
       - name: Run tests
         run: pytest

--- a/.github/workflows/update_catalogs.yml
+++ b/.github/workflows/update_catalogs.yml
@@ -31,7 +31,7 @@ jobs:
           # catalogs with VIEWS_MODELS_ACCESS_TOKEN), so an unpinned install means the
           # committed content can change because a dependency released, with no commit
           # here to explain it. Same pin as run_tests.yml -- move them together (#336).
-          pip install "views_pipeline_core==3.0.0"
+          pip install "views_pipeline_core==3.0.1"
 
 
       - name: Generate catalog if models directory has changed


### PR DESCRIPTION
Item 1 of #372, and the only unblocked one.

**3.0.1 is on PyPI** — uploaded 2026-08-11T13:40Z, verified against the index rather than the issue. It carries views-pipeline-core#422, the fix that makes a concat ensemble's pool respect a declared `classification_targets` (C-132).

| file | change |
|---|---|
| `.github/workflows/run_tests.yml:30` | `==3.0.0` → `==3.0.1` |
| `.github/workflows/update_catalogs.yml:34` | same |

**The 13 `ensembles/*/requirements.txt` need no edit** — verified, not trusted: all 13 declare `>=3.0.0,<4.0.0`, and `3.0.1` satisfies it.

**Left alone deliberately:** `reports/env_snapshots/20260804T003304Z__views_ensemble.txt` pins `3.0.0`. It records an environment that existed on 2026-08-04; editing it would falsify a snapshot.

## What this does not do

**Adopting 3.0.1 does not close C-132.** The pool can only respect a gate that is *declared*, and `rusty_bucket` does not declare one yet — that is #372's item 3, gated on item 2 (settling `violet_visitor`'s sample count), which is a decision about a fenced model rather than a mechanical fix.

## One correction to #372

It lists as outstanding: *"ADR-009 still does not mention `classification_sample_metrics`"*. It does — #375 added the **Targets ↔ metrics** row, which names both classification metric keys and attributes the rule to `CoreConfigSniffer` rather than restating it. That box is already ticked.

## Verification

- `ruff check .` clean; full suite **7796 passed, 0 failed**
- Local runs use an editable pipeline-core checkout, so CI against the published 3.0.1 is the real check here — as it was for #369
