### PR TITLE
feat(#146): violet emits 4×4, rusty_bucket takes the roster and declares the gate

### DIFF
--- a/ensembles/rusty_bucket/configs/config_meta.py
+++ b/ensembles/rusty_bucket/configs/config_meta.py
@@ -2,9 +2,29 @@ def get_meta_config():
     meta_config = {
         "name": "rusty_bucket",
         "regression_targets": ["lr_sb_best", "lr_ns_best", "lr_os_best"],
+        # The occurrence/gate channel, so the concat pool carries it (C-132).
+        # views-pipeline-core#422 (in 3.0.1) derives the pooled target list via
+        # `combined_targets` = regression + classification, so the members' `by_*` gate
+        # PFs are pooled alongside the `lr_*` magnitudes. Without this declaration the
+        # pool silently drops occurrence and the ensemble's AP is understated with no
+        # error anywhere.
+        #
+        # All three lines below land together, and the split between them is not
+        # cosmetic. Declaring `classification_targets` with NO classification metric key
+        # is refused at load by `CoreConfigSniffer._check_targets_and_metrics` — the
+        # defect PR #367 shipped. And `AP` belongs under **point**: views-models#372
+        # originally advised the sample key, which passes the sniffer and then fails
+        # `views_evaluation.NativeEvaluator._validate_config`, because METRIC_MEMBERSHIP
+        # puts AP in ("classification", "point"). That would move the failure from config
+        # load to evaluation time — later and quieter (their C-287).
+        #
+        # `Brier_cls_sample` is additionally what all eight constituents declare.
+        "classification_targets": ["by_sb_best", "by_ns_best", "by_os_best"],
         "level": "pgm",
         "aggregation": "concat",
         "regression_sample_metrics": ["CRPS", "QS_sample", "MCR_sample"],
+        "classification_point_metrics": ["AP"],
+        "classification_sample_metrics": ["Brier_cls_sample"],
         "evaluation_profile": "hydranet_ucdp",
         "creator": "Simon",
         "reconciliation": None,

--- a/ensembles/rusty_bucket/configs/config_modelset.py
+++ b/ensembles/rusty_bucket/configs/config_modelset.py
@@ -5,21 +5,33 @@ def get_modelset_config():
     Returns:
     - modelset_config (dict): A dictionary with the key 'models' listing constituent model names.
 
-    Note: these eight ``temporary_*`` constituents are interim stand-ins (clones of
-    the ``heavy_strider`` global-land datafactory baseline). They make a degenerate
-    mixture by design — the job now is to exercise the pooled-draw machinery at the
-    correct global-land shape. They retire when the real ~8 global HydraNets land (#146).
+    The Epic #242 roster, LOCKED in the 05 pre-registration (views-hydranet#246) and
+    pinned in `tests/test_roster_conformance.py`:
+
+        gated_NB     (nb,         soft_gate)           violet_visitor / bright_starship / bold_comet
+        th_gated_NB  (nb,         threshold_gate 0.5)  blazing_meteor / heavy_freighter
+        mixture_NB   (mixture_nb, soft_gate)           pink_pirate / blue_stranger / purple_alien
+
+    These replace the eight `temporary_*` stand-ins — clones of the `heavy_strider`
+    global-land baseline, a degenerate mixture that existed to exercise the pooled-draw
+    machinery at the right shape while the real models were built (#146). They have done
+    that job.
+
+    Every member emits D x K = 4 x 4 = 16 draws, so the pool is 8 x 16 = 128 and each
+    constituent carries equal weight (ADR-015 §2/§3, §6). That uniformity is why this swap
+    could not happen until violet_visitor's sample count was settled: it emitted 8, and
+    the config-time contract correctly refused the mismatch rather than pooling unequally.
     """
     modelset_config = {
         "models": [
-            "temporary_otter",
-            "temporary_robin",
-            "temporary_finch",
-            "temporary_heron",
-            "temporary_lynx",
-            "temporary_bison",
-            "temporary_crane",
-            "temporary_fox",
+            "violet_visitor",
+            "bright_starship",
+            "bold_comet",
+            "blazing_meteor",
+            "heavy_freighter",
+            "pink_pirate",
+            "blue_stranger",
+            "purple_alien",
         ],
     }
     return modelset_config

--- a/models/violet_visitor/configs/config_hyperparameters.py
+++ b/models/violet_visitor/configs/config_hyperparameters.py
@@ -84,7 +84,20 @@ def get_hp_config():
         'sampling_strategy': 'sigmoid',
         'sampling_steepness': 1.0,
 
-        'n_posterior_samples': 8,
+        # D x K = 4 x 4 = 16 produced draws, matching the other seven roster members
+    # (ADR-015 6: the count that matters is the count a model PRODUCES). Was D=8
+    # with no head sampler, i.e. 8 produced -- which is why rusty_bucket could not
+    # be rewired to the roster: it declares expected_samples_per_model: 16 and the
+    # ADR-015 contract refuses a constituent that emits something else.
+    #
+    # Settled 2026-08-11 by maintainer decision (#146, #372 item 2). This model stays
+    # EXPERIMENT_IN_PROGRESS -- its family, composition and seed are still unsettled
+    # and its queryset is not yet migrated -- but the SAMPLE COUNT is no longer part
+    # of the experiment. It is pinned by the ensemble contract
+    # (tests/test_ensemble_configs.py::test_declared_modelset_and_sample_counts_match_reality),
+    # not by the roster foundation pins that this model is exempt from.
+    'n_posterior_samples': 4,
+    'n_head_samples': 4,
         'evaluation_mode': 'stochastic',
         'aggregate_method': 'arithmetic_mean',
         'skip_predictions_delivery': True,

--- a/tests/test_roster_conformance.py
+++ b/tests/test_roster_conformance.py
@@ -35,8 +35,11 @@ from pathlib import Path
 
 import pytest
 
+from tests.conftest import get_regression_targets
+
 REPO_ROOT = Path(__file__).resolve().parent.parent
 MODELS_DIR = REPO_ROOT / "models"
+ENSEMBLES_DIR = REPO_ROOT / "ensembles"
 
 pytestmark = [pytest.mark.green]
 
@@ -334,35 +337,186 @@ class TestModelMeta:
         assert meta["name"] == model_name, f"{model_name} name != directory"
 
 
-# ── the rusty_bucket rewiring is NOT here ─────────────────────────────
-# Swapping the ensemble's 8 `temporary_*` stand-ins for the 8 roster models is S3's
-# delivery unit, and it cannot land while violet_visitor is exempt: rusty_bucket
-# declares `expected_samples_per_model: 16` (ADR-015 §2/§3), the seven pinned members
-# emit D×K = 4×4 = 16, and violet emits 8 (D=8, no head sampler). Rewiring now would
-# fail `test_ensemble_configs.py::test_declared_modelset_and_sample_counts_match_reality`
-# — correctly. The ensemble is rewired in the change that settles violet.
+# ── the rusty_bucket rewiring, landed ──────────────────────────────────
+# Deferred from #369 and done here (#146, #372 item 3). It waited on two things, both
+# now true: violet_visitor emits D×K = 4×4 = 16 like the rest, so the ADR-015 contract
+# holds across all eight; and views-pipeline-core 3.0.1 carries #422, so a declared gate
+# is actually pooled rather than silently dropped.
 #
-# WHEN THAT REWIRING HAPPENS, the gate declaration goes with it, and these are the
-# values (decided 2026-08-11, after views-models#372 proposed a different pair):
-#
-#     "classification_targets":        ["by_sb_best", "by_ns_best", "by_os_best"],
-#     "classification_point_metrics":  ["AP"],
-#     "classification_sample_metrics": ["Brier_cls_sample"],
-#
-# All three lines together. Declaring `classification_targets` without a classification
-# metric key is refused at load by `CoreConfigSniffer._check_targets_and_metrics`, which
-# runs before any side effect — that is the defect views-models#367 shipped, now caught
-# by `tests/test_core_config_sniffer_contract.py`.
-#
-# `AP` belongs under **point**, not sample. views-models#372 proposed
-# `classification_sample_metrics: ["AP"]`; that passes the sniffer and then fails
-# `views_evaluation.NativeEvaluator._validate_config`, because METRIC_MEMBERSHIP puts AP
-# in ("classification", "point"). The pair above was verified against both gates.
-# `Brier_cls_sample` is additionally what all eight roster models already declare.
-#
-# It cannot land before the rewiring, and not only for the sample-count reason above:
-# the eight `temporary_*` stand-ins declare NO classification_targets at all, so the
-# ensemble would be claiming a `by_*` channel its constituents do not produce. The
-# roster models do declare it. Separately, the pool only *respects* a declared gate once
-# views-pipeline-core#422 ships and a release is pinned here (CI pins 3.0.0 exactly), so
-# landing it earlier would be inert rather than wrong.
+# Order matters and gets it wrong LOUDLY, which is the one mercy here: declaring the gate
+# while the members are the `temporary_*` stand-ins — which declare no
+# classification_targets — raises `Model 'X' did not produce a forecast for target
+# 'by_sb_best'` on the PredictionFrame path. A sequencing mistake costs a failed run, not
+# a wrong number.
+
+ENSEMBLE = "rusty_bucket"
+
+
+def _load_modelset(name):
+    return _load(ENSEMBLES_DIR / name / "configs" / "config_modelset.py", "get_modelset_config")
+
+
+def _load_partitions(name, base_dir):
+    return _load(base_dir / name / "configs" / "config_partitions.py", "generate")
+
+
+#: HydraNet/PF concat ensembles that declare no `by_*` gate today, and why they are not
+#: fixed. **This set may only ever SHRINK** — an entry here is an ensemble whose AP is
+#: understated, so adding one means shipping the defect C-132 describes.
+#:
+#: Both are the retired viewser-vs-datafactory parity ensembles. The programme they served
+#: ended when S2 (#365) migrated the trio, so declaring a gate on them would be work on
+#: something scheduled for removal. They are slated to be reduced to README-only
+#: placeholders (the maintainer's decision; #367 proposes deleting them outright). Neither
+#: is scheduled by `monthly_run.sh`, and neither has produced an artifact since 2026-06-03,
+#: so nothing is currently scoring occurrence off them.
+#:
+#: This is recorded rather than filtered silently: the guard found a real pre-existing
+#: defect, and hiding that to make the suite green would be the exact failure the guard
+#: exists to prevent.
+KNOWN_GATELESS = frozenset({"golden_hour", "stellar_horizon"})
+
+
+def test_every_hydranet_pf_ensemble_declares_the_occurrence_gate():
+    """C-132 class guard, fleet-wide rather than just rusty_bucket.
+
+    A `prediction_frame` / `hydranet_ucdp` concat ensemble pools its constituents'
+    per-sample channels, and the occurrence gate rides `classification_targets` (`by_*`).
+    An ensemble that declares `regression_targets` and omits the gate pools the magnitudes
+    only: its AP and Brier are understated with **no error anywhere**, which is the whole
+    of C-132.
+
+    views-pipeline-core#422 makes the pool *respect* a declared gate; it does not
+    synthesise one. So this is the fail-loud that stops a NEW gate-less HydraNet ensemble
+    from reintroducing the defect the framework fix cannot see.
+    """
+    offenders = {}
+    for meta_path in ENSEMBLES_DIR.rglob("configs/config_meta.py"):
+        if meta_path.parent.parent.name in KNOWN_GATELESS:
+            continue
+        name = meta_path.parent.parent.name
+        meta = _load_meta(name, ENSEMBLES_DIR)
+        is_hydranet_pf = (
+            meta.get("prediction_format") == "prediction_frame"
+            or meta.get("evaluation_profile") == "hydranet_ucdp"
+        )
+        reg = meta.get("regression_targets") or []
+        if not (is_hydranet_pf and reg):
+            continue
+        gate = meta.get("classification_targets") or []
+        if len(gate) != len(reg):
+            offenders[name] = {"regression_targets": reg, "classification_targets": gate}
+    assert not offenders, (
+        "these HydraNet/PF concat ensembles do not declare a 1:1 by_* gate channel, so "
+        f"the concat pool silently drops occurrence (C-132): {offenders}. Declare "
+        f"classification_targets in the ensemble config_meta."
+    )
+
+
+class TestRustyBucketEnsemble:
+    """The 8-member concat ensemble — the epic's delivery unit."""
+
+    @pytest.fixture()
+    def ens_meta(self):
+        return _load_meta(ENSEMBLE, ENSEMBLES_DIR)
+
+    def test_members_are_the_roster(self):
+        modelset = _load_modelset(ENSEMBLE)
+        assert modelset["models"] == ROSTER_MODELS, (
+            f"{ENSEMBLE} members {modelset['models']} != roster {ROSTER_MODELS}"
+        )
+
+    def test_no_temporary_stand_ins_remain(self):
+        """The `temporary_*` clones existed to exercise the machinery; they are retired."""
+        leftovers = [m for m in _load_modelset(ENSEMBLE)["models"] if m.startswith("temporary_")]
+        assert not leftovers, f"{ENSEMBLE} still lists stand-ins: {leftovers}"
+
+    def test_aggregation_and_level(self, ens_meta):
+        assert ens_meta["aggregation"] == "concat"
+        assert ens_meta["level"] == "pgm"
+
+    def test_pools_regression_targets(self, ens_meta):
+        assert ens_meta["regression_targets"] == REGRESSION_TARGETS
+        constituent = {
+            tuple(get_regression_targets(MODELS_DIR / m)) for m in _load_modelset(ENSEMBLE)["models"]
+        }
+        assert constituent == {tuple(REGRESSION_TARGETS)}, (
+            f"constituents disagree on regression_targets: {constituent}"
+        )
+
+    def test_pools_the_occurrence_gate_channel(self, ens_meta):
+        assert ens_meta.get("classification_targets") == CLASSIFICATION_TARGETS, (
+            f"{ENSEMBLE} must declare classification_targets={CLASSIFICATION_TARGETS} so the "
+            f"concat pool carries the gate (C-132); got {ens_meta.get('classification_targets')!r}"
+        )
+        assert "targets" not in ens_meta, (
+            f"{ENSEMBLE} carries a retired synthesised `targets` key (#380 upstream) — "
+            f"declare regression_targets / classification_targets instead"
+        )
+
+    def test_the_gate_carries_a_classification_metric_in_the_right_cell(self, ens_meta):
+        """Both keys, and AP under **point** — the pair verified against both gates.
+
+        `classification_targets` with no classification metric key is refused at load by
+        `CoreConfigSniffer._check_targets_and_metrics` (the defect #367 shipped). And AP
+        under `classification_sample_metrics` passes the sniffer and then fails
+        `NativeEvaluator._validate_config`, because METRIC_MEMBERSHIP puts AP in
+        ("classification", "point") — moving the failure later and quieter.
+        """
+        assert ens_meta.get("classification_point_metrics") == ["AP"]
+        assert ens_meta.get("classification_sample_metrics") == ["Brier_cls_sample"]
+
+    def test_every_member_produces_the_declared_count(self):
+        """8 x 16 = 128, equally weighted — the reason the rewiring waited on violet."""
+        from tests.conftest import get_produced_sample_count
+
+        expected = _load(
+            ENSEMBLES_DIR / ENSEMBLE / "configs" / "config_hyperparameters.py", "get_hp_config"
+        )["expected_samples_per_model"]
+        produced = {
+            m: get_produced_sample_count(MODELS_DIR / m)
+            for m in _load_modelset(ENSEMBLE)["models"]
+        }
+        wrong = {m: n for m, n in produced.items() if n != expected}
+        assert not wrong, (
+            f"these constituents do not emit the declared {expected} draws: {wrong}. "
+            f"Unequal counts weight the pooled mixture unequally (ADR-015 §2/§3)."
+        )
+
+    def test_metrics_profile(self, ens_meta):
+        assert ens_meta["regression_sample_metrics"] == ["CRPS", "QS_sample", "MCR_sample"]
+        assert ens_meta["evaluation_profile"] == "hydranet_ucdp"
+
+    def test_uses_prediction_frame_manager(self):
+        main_path = ENSEMBLES_DIR / ENSEMBLE / "main.py"
+        assert main_path.exists(), f"{ENSEMBLE}/main.py is missing"
+        assert "PredictionFrameEnsembleManager" in main_path.read_text()
+
+    def test_partition_boundaries_match_a_member(self):
+        ens_parts = _load_partitions(ENSEMBLE, ENSEMBLES_DIR)
+        member_parts = _load_partitions(ROSTER_MODELS[0], MODELS_DIR)
+        assert ens_parts["calibration"] == member_parts["calibration"]
+        assert ens_parts["validation"] == member_parts["validation"]
+
+
+def test_the_known_gateless_set_only_shrinks():
+    """Both directions are a reviewed edit.
+
+    A new entry means shipping an ensemble whose occurrence is silently understated. A
+    removed entry means the ensemble was fixed or retired — good, and the pin should say
+    so rather than quietly agreeing.
+    """
+    present = {p.parent.parent.name for p in ENSEMBLES_DIR.rglob("configs/config_meta.py")}
+    stale = KNOWN_GATELESS - present
+    assert not stale, (
+        f"{sorted(stale)} no longer exist — remove them from KNOWN_GATELESS so the pin "
+        f"keeps meaning something."
+    )
+    for name in KNOWN_GATELESS:
+        meta = _load_meta(name, ENSEMBLES_DIR)
+        reg = meta.get("regression_targets") or []
+        gate = meta.get("classification_targets") or []
+        assert len(gate) != len(reg), (
+            f"{name} now declares a 1:1 gate channel — good. Remove it from "
+            f"KNOWN_GATELESS so the fleet guard covers it."
+        )


### PR DESCRIPTION
Items **2 and 3** of #372, and the long pole of **#146**.

## violet_visitor: 4×4

`D=8` with no head sampler → `D=4, K=4` = **16 produced**, matching the other seven. Your decision.

**This needs no ADR-015 amendment.** It makes the model *conform* to §2/§3 and §6 rather than changing them — worth saying explicitly, since #372 asked for one if the answer moved the ADR.

The model **stays `EXPERIMENT_IN_PROGRESS`**. Its family (`hurdle_shrinkage` vs the roster's `nb`), composition, seed and queryset migration are all still unsettled; only the sample count leaves the experiment. It is now pinned by the *ensemble contract*, not by the roster foundation pins the model is exempt from — two tests, two concerns.

## rusty_bucket: the roster, and the gate

Eight `temporary_*` stand-ins → the eight roster models, with all three gate lines together, exactly as recorded in this repo's own note (#376):

```python
"classification_targets":        ["by_sb_best", "by_ns_best", "by_os_best"],
"classification_point_metrics":  ["AP"],
"classification_sample_metrics": ["Brier_cls_sample"],
```

Declaring the targets with no classification metric key is refused at load by `CoreConfigSniffer._check_targets_and_metrics` — the defect #367 shipped. And **AP goes under `point`**: pipeline-core originally advised the sample key, which passes the sniffer and then fails `NativeEvaluator._validate_config`.

**Verified by running both, not by reading either:**

```
CoreConfigSniffer.sniff_all('forecasting'): PASS
CoreConfigSniffer.sniff_all('calibration'): PASS
NativeEvaluator._validate_config          : PASS
```

The rewiring could not happen before violet settled: `expected_samples_per_model: 16` and the ADR-015 contract correctly refused a constituent emitting 8. Unequal counts weight the pooled mixture unequally.

Restores the tests held back in #369 now that 3.0.1 carries #422 — membership, no-stand-ins-left, the gate channel, the metric cells, and a check that **every** member produces the declared count.

## The fleet guard found two more

`test_every_hydranet_pf_ensemble_declares_the_occurrence_gate` fires on **`golden_hour`** and **`stellar_horizon`**: `prediction_frame`/`hydranet_ucdp`, three regression targets, **zero** gate channels — the same C-132 defect `rusty_bucket` had.

They are the retired parity ensembles: scheduled by nothing, no artifact since 2026-06-03, and already slated for reduction to README-only placeholders. Recorded in **`KNOWN_GATELESS`**, a set pinned to only ever **shrink**, plus a second test asserting the entries still exist and still lack a gate.

Filtering them silently to make the suite green would be the precise failure the guard exists to prevent.

## Not in this PR

**Item 4 — re-pool and check the numbers.** That is a compute run, not a config change.

On the AP figures: #372 is right that h1 sb 0.316→0.456 etc. are views-hydranet EXP-03, single-source and never independently reproduced. They are the evidence that motivated the fix, not a target. If a re-pool lands elsewhere, that is data.

## Verification

- `ruff check .` clean; full suite **7808 passed, 0 failed**
- Sniffer and evaluator both run against the real combined config
- All eight constituents measured at 16 produced draws
